### PR TITLE
Add Ruby Enterprise 1.8.7 2011.03

### DIFF
--- a/versions/ree-1.8.7-2011.03
+++ b/versions/ree-1.8.7-2011.03
@@ -1,10 +1,10 @@
 build_package_ree_installer() {
-  local options="--auto $PREFIX_PATH"
+  local options=""
   if [[ "Darwin" = "$(uname)" ]]; then
-    options="$options --no-tcmalloc"
+    options="--no-tcmalloc"
   fi
 
-  { ./installer $options
+  { ./installer --auto "$PREFIX_PATH" $options
   } >$LOG_PATH 2>&1
 }
 


### PR DESCRIPTION
Slight issue, ree doesn't compile under Lion with the new LLVM gcc default. Need to switch back to the classic.

```
$ export CC=/usr/bin/gcc-4.2
```
