### PR TITLE
Solaris doesn't come with readlink so use greadlink if available instead.

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -3,6 +3,10 @@
 set -E
 exec 3<&2 # preserve original stderr at fd 3
 
+resolve_link() {
+  $(type -p greadlink readlink | head -1) $1
+}
+
 abs_dirname() {
   local cwd="$(pwd)"
   local path="$1"
@@ -10,7 +14,7 @@ abs_dirname() {
   while [ -n "$path" ]; do
     cd "${path%/*}"
     local name="${path##*/}"
-    path="$(readlink "$name" || true)"
+    path="$(resolve_link "$name" || true)"
   done
 
   pwd


### PR DESCRIPTION
Solaris doesn't come with readlink so use greadlink if available instead.

Taken from Ryan Tomayko's "GNU is killing Solaris", c.f. http://tomayko.com/writings/gnu-is-killing-solaris
