### PR TITLE
Add rbx-2.0.0pre that pulls latest from Github

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -40,7 +40,7 @@ install_package() {
 
   cd "$TEMP_PATH"
   download_package "$package_name" "$package_url"
-  extract_package "$package_name"
+  extract_package "$package_name" $*
   cd "$package_name"
   build_package "$package_name" $*
   after_install_package "$package_name"
@@ -60,9 +60,17 @@ download_package() {
 
 extract_package() {
   local package_name="$1"
+  local extras="$*"
 
-  { tar xzvf "${package_name}.tar.gz"
-  } >&4 2>&1
+  if [ "${extras: -6}" == "github" ]; then
+    { mkdir "${package_name}"
+      echo "Unpacking Github tarball"
+      tar xzvf "${package_name}.tar.gz" -C "${package_name}"
+    } >&4 2>&1
+  else
+    { tar xzvf "${package_name}.tar.gz"
+    } >&4 2>&1
+  fi
 }
 
 build_package() {

--- a/share/ruby-build/rbx-2.0.0pre
+++ b/share/ruby-build/rbx-2.0.0pre
@@ -1,0 +1,10 @@
+build_package_rbx-2.0.0pre_github() {
+  local package_name="$1"
+
+  { cd rubinius-rubinius-*
+    ./configure --prefix="$PREFIX_PATH" --gemsdir="$PREFIX_PATH"
+    rake install
+  } >&4 2>&1
+}
+
+install_package "rubinius-2.0.0.pre" "https://nodeload.github.com/rubinius/rubinius/tarball/2.0.0pre" rbx-2.0.0pre_github


### PR DESCRIPTION
The tricky thing about pulling down a tarball from Github is the commit hash is part of the directory name.

curling https://nodeload.github.com/rubinius/rubinius/tarball/2.0.0pre yields rubinius-rubinius-abc123.tar.gz but install_package will rename this to rubinius-2.0.0pre. I had to change extract_archive just a little to recognize a definition from Github, which you can see [here](https://github.com/jc00ke/ruby-build/pull/new/54135eb1a24bba1b125cd30aa3cb0d61ff3ecd1b#L0R65). Maybe there's a better way to detect this, but this method works on all of the definitions.
