### PR TITLE
Added support to platforms where bash is not in /bin directory 

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -E
 exec 3<&2 # preserve original stderr at fd 3


### PR DESCRIPTION
Changed ruby-build to use /usr/bin/env to support platforms where bash is not in /bin/
