### PR TITLE
Could you add this definition to ruby-build ? Thanks!

### DIFF
--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,0 +1,3 @@
+install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
+install_package "ruby-1.9.1-p378" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz"
+install_package "rubygems-1.3.5" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.5.tgz" ruby


### PR DESCRIPTION
Added definition for Ruby 1.9.1-p378 (rubygems 1.3.5) - The standard debian versions for Ubuntu Lucid 10.04.

We use standard Ubuntu 10.04 Debian packages on production, and would like to be able to use ruby-build (and rbenv) to make it easier to match that on our development machines.

Thanks!
- Jake
