### PR TITLE
REE should use the do not install helpful gems option

### DIFF
--- a/share/ruby-build/ree-1.8.7-2011.03
+++ b/share/ruby-build/ree-1.8.7-2011.03
@@ -4,7 +4,7 @@ build_package_ree_installer() {
     options="--no-tcmalloc"
   fi
 
-  { ./installer --auto "$PREFIX_PATH" $options
+  { ./installer --auto "$PREFIX_PATH" --dont-install-useful-gems $options
   } >&4 2>&1
 }
 


### PR DESCRIPTION
no need to start with a bunch of cruft we may not even be wanting to use, let users install their gems themselves
