### PR TITLE
Support REE 1.8.6

### DIFF
--- a/share/ruby-build/ree-1.8.6-20090610
+++ b/share/ruby-build/ree-1.8.6-20090610
@@ -1,0 +1,16 @@
+build_package_ree_installer() {
+  local options=""
+  if [[ "Darwin" = "$(uname)" ]]; then
+    options="--no-tcmalloc"
+  fi
+
+  # Work around install_useful_libraries crash with --dont-install-useful-gems
+  mkdir -p "$PREFIX_PATH/lib/ruby/gems/1.8/gems"
+
+  { ./installer --auto "$PREFIX_PATH" --dont-install-useful-gems $options
+  } >&4 2>&1
+}
+
+use_gcc42_on_lion
+install_package "ruby-enterprise-1.8.6-20090610" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.6-20090610.tar.gz" ree_installer
+install_package "rubygems-1.4.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.4.2.tgz" ruby


### PR DESCRIPTION
I wrote a definition for the final version of REE 1.8.6 (20090610).  Unfortunately some of us are still using it in the wild.  I thought it would be a common-enough version to merit inclusion.  (Probably installed more places than MRI 1.8.6 these days.)

There are just two significant differences from REE 1.8.7:
- Downgrade Rubygems to the most recent compatible version (1.4.2)
- Create a directory that REE's insane installer expects, but doesn't get created with --dont-install-useful-gems (otherwise the installer crashes)

Hopefully this is helpful :)
