### PR TITLE
set --with-gcc=gcc-4.2 on lion + xcode 4.1

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -151,6 +151,7 @@ use_gcc42_on_lion() {
   if [ "$(uname -s)" = "Darwin" ]; then
     if [ "$(expr "$(sw_vers -productVersion | cut -f 2 -d .)" \>= 7 || true)" -eq 1 ]; then
       export CC=/usr/bin/gcc-4.2
+      CONFIGURE_OPTS="--with-gcc=$CC $CONFIGURE_OPTS"
     fi
   fi
 }


### PR DESCRIPTION
The CC export works, but may as well follow the recommendation in https://github.com/ruby/ruby/commit/9151ed22b360ba3d2bde3b51969a682f9a4a3096

(Could replace the CC export, even)
