### PR TITLE
Adding rehash command info for running rbenv-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ ruby-build provides an `rbenv-install` command that shortens this to:
 
     $ rbenv install 1.9.2-p290
 
-Once installed for [rbenv](https://github.com/sstephenson/rbenv) 
-you have to rebuild the shim binaries. You should do this any time 
-you install a new Ruby binary (for example, when installing a new 
-Ruby version, or when installing a gem that provides a binary).
+Once installed you have to rebuild the shim binaries. You should do 
+this any time you install a new Ruby binary (for example, when 
+installing a new Ruby version, or when installing a gem that provides 
+a binary).
 
     $ rbenv rehash
 


### PR DESCRIPTION
Copied over the paragraph from the rbenv README about running the `rbenv rehash` command whenever installing a new Ruby.
