### PR TITLE
Added an environment variable to set build arch

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -210,6 +210,13 @@ list_definitions() {
   } | sort
 }
 
+set_architecture() {
+  echo Setting build architecture to $1
+  export CONFIGURE_OPTS="--with-arch=$1 ${CONFIGURE_OPTS}"
+  export CFLAGS="-arch $1 ${CFLAGS}"
+  export LDFLAGS="-arch $1 ${LDFLAGS}"
+}
+
 
 
 unset VERBOSE
@@ -274,6 +281,10 @@ exec 4<> "$LOG_PATH" # open the log file at fd 4
 if [ -n "$VERBOSE" ]; then
   tail -f "$LOG_PATH" &
   trap "kill 0" SIGINT SIGTERM EXIT
+fi
+
+if [ -n "${RUBY_BUILD_ARCH}" ]; then
+  set_architecture "${RUBY_BUILD_ARCH}"
 fi
 
 export LDFLAGS="-L'${PREFIX_PATH}/lib' ${LDFLAGS}"


### PR DESCRIPTION
This pull request is the result of me struggling to get a 32 bit ruby installed on 64 bit lion so that the oracle gem will work [1] 

You can now do the following:
RUBY_BUILD_ARCH=i386 /usr/local/bin/ruby-build 1.9.2-p290 ~/.rbenv/versions/1.9.2-i386

If you do not want to accept this pull request, then please document somewhere the command to build a 32 bit ruby on Lion:
CONFIGURE_OPTS="--with-arch=i386" CFLAGS="-arch i386" LDFLAGS="-arch i386" /usr/local/bin/ruby-build 1.9.2-p290 ~/.rbenv/versions/1.9.2-i386

[1] http://rubyforge.org/forum/forum.php?thread_id=49548&forum_id=1078
