### PR TITLE
doc note on curl dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ versions of Ruby on UNIX-like systems.
 
 ### Installing ruby-build
 
+ruby-build depends on curl to download binaries. This ships with OSX. If you are using ubuntu install it with `apt-get install curl`.
+
     $ git clone git://github.com/sstephenson/ruby-build.git
     $ cd ruby-build
     $ ./install.sh


### PR DESCRIPTION
added a note on curl dependency to the documentation. I kept forgetting when setting up new ubuntu 10.04 servers which don't have curl installed by default.
