### PR TITLE
Patch 1.9.3-rc1 to enable ruby-debug

### DIFF
--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,2 +1,9 @@
+build_package_symbols_patch() {
+  { echo "applying symbol visibility fix" >&2
+    git apply <( curl https://github.com/ruby/ruby/pull/47.diff )
+  } >&4 2>&1
+}
+
+use_gcc42_on_lion
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
-install_package "ruby-1.9.3-rc1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz"
+install_package "ruby-1.9.3-rc1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz" symbols_patch standard


### PR DESCRIPTION
Ruby 1.9.3 has [a known bug](https://github.com/ruby/ruby/pull/47) that disables ruby-debug19 from compiling against it.

This patches the build process. I don't know if the same patch is needed for 1.9.3-dev
