### PR TITLE
Use the latest rubygems on ree ruby version ( 1.8.10 )

### DIFF
--- a/share/ruby-build/ree-1.8.7-2011.03
+++ b/share/ruby-build/ree-1.8.7-2011.03
@@ -1,3 +1,3 @@
 use_gcc42_on_lion
 install_package "ruby-enterprise-1.8.7-2011.03" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby
+install_package "rubygems-1.8.10" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz" ruby


### PR DESCRIPTION
the latest version of rubygems is not 1.8.10 and it's compatible to ree.
