### PR TITLE
Some ruby-build definitions expect the target (parent) directory to exist

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -167,6 +167,7 @@ remove_windows_files() {
 }
 
 build_package_copy() {
+  mkdir -p "$PREFIX_PATH"
   cp -R . "$PREFIX_PATH"
 }
 


### PR DESCRIPTION
Some ruby-build definitions expect the target (parent) directory to exist, which sometimes isn't there with a fresh rbenv install, so use mkdir as part of the rbenv-install script.

See: https://gist.github.com/b9adc50e729e94fccb28
