### PR TITLE
Better GCC detection

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -180,7 +180,7 @@ fix_directory_permissions() {
   find "$PREFIX_PATH" -type d -exec chmod go-w {} \;
 }
 
-requires_gcc() {
+require_gcc() {
   local gcc="$(locate_gcc || true)"
   if [ -z "$gcc" ]; then
     { echo

--- a/share/ruby-build/1.8.6-p420
+++ b/share/ruby-build/1.8.6-p420
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "ruby-1.8.6-p420" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.gz"
 install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz" ruby

--- a/share/ruby-build/1.8.7-p249
+++ b/share/ruby-build/1.8.7-p249
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "ruby-1.8.7-p249" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.gz"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby

--- a/share/ruby-build/1.8.7-p334
+++ b/share/ruby-build/1.8.7-p334
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "ruby-1.8.7-p334" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby

--- a/share/ruby-build/1.8.7-p352
+++ b/share/ruby-build/1.8.7-p352
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "ruby-1.8.7-p352" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.gz"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby

--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
-requires_gcc
+require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
 install_package "ruby-1.9.1-p378" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz"
 install_package "rubygems-1.3.5" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.5.tgz" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,4 @@
-requires_gcc
+require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
 install_package "ruby-1.9.2-p290" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz"
 install_package "rubygems-1.8.10" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz" ruby

--- a/share/ruby-build/1.9.3-dev
+++ b/share/ruby-build/1.9.3-dev
@@ -1,4 +1,4 @@
-requires_gcc
+require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
 install_git "ruby-1.9.3-dev" "https://github.com/ruby/ruby.git" "ruby_1_9_3" autoconf standard
 install_package "rubygems-1.8.10" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz" ruby

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,4 @@
-requires_gcc
+require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
 install_package "ruby-1.9.3-preview1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz"
 install_package "rubygems-1.8.10" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.10.tgz" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
 install_package "ruby-1.9.3-rc1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz"

--- a/share/ruby-build/ree-1.8.6-2009.06
+++ b/share/ruby-build/ree-1.8.6-2009.06
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "ruby-enterprise-1.8.6-20090610" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.6-20090610.tar.gz" ree_installer
 install_package "rubygems-1.4.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.4.2.tgz" ruby

--- a/share/ruby-build/ree-1.8.7-2010.02
+++ b/share/ruby-build/ree-1.8.7-2010.02
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "ruby-enterprise-1.8.7-2010.02" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.7-2010.02.tar.gz" ree_installer
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby

--- a/share/ruby-build/ree-1.8.7-2011.03
+++ b/share/ruby-build/ree-1.8.7-2011.03
@@ -1,3 +1,3 @@
-requires_gcc
+require_gcc
 install_package "ruby-enterprise-1.8.7-2011.03" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz" ree_installer
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby


### PR DESCRIPTION
This change clarifies the intent of the `use_gcc42_on_lion` helper and adds support for Xcode 4.2 installations without GCC.
