### PR TITLE
REE and SSLv2

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -145,9 +145,18 @@ build_package_ruby() {
 
 build_package_ree_installer() {
   local options=""
-  if [[ "Darwin" = "$(uname)" ]]; then
-    options="--no-tcmalloc"
-  fi
+
+  case "$(uname)" in
+    Darwin)
+      options="--no-tcmalloc"
+      ;;
+
+    Linux)
+      # http://digitaldisorder.posterous.com/ruby-rvm-and-debian-sid-problems
+      cat "${RUBY_BUILD_ROOT}/share/patches/disable_sslv2.patch" |\
+        patch source/ext/openssl/ossl_ssl.c
+      ;;
+  esac
 
   # Work around install_useful_libraries crash with --dont-install-useful-gems
   mkdir -p "$PREFIX_PATH/lib/ruby/gems/1.8/gems"

--- a/share/patches/disable_sslv2.patch
+++ b/share/patches/disable_sslv2.patch
@@ -1,0 +1,15 @@
+--- source/ext/openssl/ossl_ssl.c.orig	2011-10-26 12:50:55.025190711 -0200
++++ source/ext/openssl/ossl_ssl.c	2011-10-26 12:51:16.349296460 -0200
+@@ -101,9 +101,9 @@
+     OSSL_SSL_METHOD_ENTRY(TLSv1),
+     OSSL_SSL_METHOD_ENTRY(TLSv1_server),
+     OSSL_SSL_METHOD_ENTRY(TLSv1_client),
+-    OSSL_SSL_METHOD_ENTRY(SSLv2),
+-    OSSL_SSL_METHOD_ENTRY(SSLv2_server),
+-    OSSL_SSL_METHOD_ENTRY(SSLv2_client),
++    // OSSL_SSL_METHOD_ENTRY(SSLv2),
++    // OSSL_SSL_METHOD_ENTRY(SSLv2_server),
++    // OSSL_SSL_METHOD_ENTRY(SSLv2_client),
+     OSSL_SSL_METHOD_ENTRY(SSLv3),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_server),
+     OSSL_SSL_METHOD_ENTRY(SSLv3_client),


### PR DESCRIPTION
Latest GNU/Linux distros have SSLv2 disabled by default. This patch adds a simple workaround commenting the offending lines in source/ext/openssl/ossl_ssl.c.
