### PR TITLE
Allow overriding of options passed to Make

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -127,9 +127,11 @@ build_package() {
 
 build_package_standard() {
   local package_name="$1"
-
+  if [ -z "${MAKE_OPTS+defined}" ]; then
+    MAKE_OPTS="-j 2"
+  fi
   { ./configure --prefix="$PREFIX_PATH" $CONFIGURE_OPTS
-    make -j 2
+    make $MAKE_OPTS
     make install
   } >&4 2>&1
 }


### PR DESCRIPTION
I ran into issues building Rubies on Ubuntu Lucid Lynx, finding that the -j 2 parameter passed to Make was the culprit. This commit modifies build_package_standard to look for a MAKE_OPTS environment variable to override the build options. This make it possible (1) to test different parameters to make, and (2) work around errors building on some platforms (like Ubuntu Lucid). This should also address issue #88
