### PR TITLE
Allow passing custom options to ruby-build when calling rbenv-install

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -28,9 +28,5 @@ esac
 VERSION_NAME="${DEFINITION##*/}"
 PREFIX="${RBENV_ROOT}/versions/${VERSION_NAME}"
 
-if [ -z "${RUBY_BUILD_OPTS+defined}" ]; then
-  RUBY_BUILD_OPTS=""
-fi
-
 ruby-build $RUBY_BUILD_OPTS "$DEFINITION" "$PREFIX"
 rbenv rehash


### PR DESCRIPTION
In the same manner as issue #89, rbenv-install may look for RUBY_BUILD_OPTS to forward to ruby-build. While this did not fix any particular issue for me, it's proven to be useful when enabling verbose mode for ruby-build, for example.
