### PR TITLE
Don't install newer versions of rubygems by default in JRuby.

### DIFF
--- a/share/ruby-build/jruby-1.6.3
+++ b/share/ruby-build/jruby-1.6.3
@@ -1,2 +1,1 @@
 install_package "jruby-1.6.3" "http://jruby.org.s3.amazonaws.com/downloads/1.6.3/jruby-bin-1.6.3.tar.gz" jruby
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby

--- a/share/ruby-build/jruby-1.6.4
+++ b/share/ruby-build/jruby-1.6.4
@@ -1,2 +1,1 @@
 install_package "jruby-1.6.4" "http://jruby.org.s3.amazonaws.com/downloads/1.6.4/jruby-bin-1.6.4.tar.gz" jruby
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby

--- a/share/ruby-build/jruby-1.7.0-dev
+++ b/share/ruby-build/jruby-1.7.0-dev
@@ -1,2 +1,1 @@
 install_package "jruby-1.7.0.dev" "http://ci.jruby.org/snapshots/jruby-bin-1.7.0.dev.tar.gz" jruby
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby


### PR DESCRIPTION
The default rubygems included in JRuby is the recommended (it's patched by JRuby team), I asked to JRuby team [about it some weeks ago](https://twitter.com/#!/hiro_asari/status/128886275590725633) just to be sure.

The users will still the option of install newer versions of rubygems that might or not work. (See #91 for a non-working case)
