### PR TITLE
Add definition for JRuby 1.6.5.1

### DIFF
--- a/share/ruby-build/jruby-1.6.5.1
+++ b/share/ruby-build/jruby-1.6.5.1
@@ -1,0 +1,1 @@
+install_package "jruby-1.6.5.1" "http://jruby.org.s3.amazonaws.com/downloads/1.6.5.1/jruby-bin-1.6.5.1.tar.gz" jruby


### PR DESCRIPTION
This commit adds a definition for the JRuby security update released this week. Tested with OpenJDK 1.7 preview on Lion.
