### PR TITLE
Add definition for ree-1.8.7-2012-01

### DIFF
--- a/share/ruby-build/ree-1.8.7-2012.01
+++ b/share/ruby-build/ree-1.8.7-2012.01
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-enterprise-1.8.7-2012.01" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.01.tar.gz" ree_installer
+install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby


### PR DESCRIPTION
There is a 2012-01 release of Ruby Enterprise on [their download page](http://www.rubyenterpriseedition.com/download.html). Though I'm not sure if it's official yet.

What's the best way to test this without mucking up my brew installed version?
