### PR TITLE
Add definition for ree-1.8.7-2012.02

### DIFF
--- a/share/ruby-build/ree-1.8.7-2012.02
+++ b/share/ruby-build/ree-1.8.7-2012.02
@@ -1,0 +1,2 @@
+require_gcc
+install_package "ruby-enterprise-1.8.7-2012.02" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.02.tar.gz" ree_installer


### PR DESCRIPTION
REE 1.8.7-2012.02 includes rubygems 1.8.15.

Here's the annoucement: http://blog.phusion.nl/2012/02/21/ruby-enterprise-edition-1-8-7-2012-02-released-end-of-life-imminent/

I don't know if that means we could kill the `require_gcc` line as well.
