### PR TITLE
Added definition for JRuby 1.6.7.

### DIFF
--- a/share/ruby-build/jruby-1.6.7
+++ b/share/ruby-build/jruby-1.6.7
@@ -1,0 +1,1 @@
+install_package "jruby-1.6.7" "http://jruby.org.s3.amazonaws.com/downloads/1.6.7/jruby-bin-1.6.7.tar.gz" jruby


### PR DESCRIPTION
Got bit by a 1.6.6 issue with `popen` so I created a definition to test 1.6.7.  Thanks for making it so easy to install multiple versions of Ruby!
