### PR TITLE
Added rbenv-remove command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ ruby-build provides an `rbenv-install` command that shortens this to:
 
     $ rbenv install 1.9.2-p290
 
+### Removing Ruby
+
+To remove a Ruby version, ruby-build provides a `rbenv-remove` command. 
+You can use this function with rbenv command.
+
+    $ rbenv remove 1.9.2-p290
+
+rbenv-remove simply removes `$HOME/.rbenv/versions/[specified version]/`
+recursively.
+
 ### Version History
 
 #### 20120216

--- a/bin/rbenv-remove
+++ b/bin/rbenv-remove
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+usage() {
+  { echo "usage: rbenv remove VERSION"
+    echo
+    echo "Available versions:"
+    rbenv versions 
+    echo
+  } >&2
+}
+
+if [ -z "$RBENV_ROOT" ]; then
+  RBENV_ROOT="${HOME}/.rbenv"
+fi
+
+VERSION_NAME="$1"
+case "$VERSION_NAME" in
+"" | -* )
+ usage
+ exit 1
+  ;;
+esac
+
+PREFIX="${RBENV_ROOT}/versions/${VERSION_NAME}"
+
+if [ ! -d $PREFIX ]; then
+  echo "$VERSION_NAME is not installed." >&2
+  usage
+  exit 1;
+fi
+
+echo "This will execute rm -rf ${PREFIX}."
+echo -n "Are you sure want to uninstall ${VERSION_NAME}? [y/N]:"; read answer
+case "$answer" in
+y | Y | yes | YES | Yes )
+  rm -rf "$PREFIX" && rbenv rehash && exit 0 || exit 1
+  ;;
+* )
+  echo "skipped."
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
I wrote a rbenv-remove function for removing a existing ruby version. This simply executes rm -rf  $HOME/.rbenv/versions/[version]/ .
