### PR TITLE
Split build_package_standard into smaller functions

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -142,19 +142,38 @@ build_package() {
   done
 }
 
-build_package_standard() {
-  local package_name="$1"
+build_package_configure() {
+  { ./configure --prefix="$PREFIX_PATH" $CONFIGURE_OPTS
+  } >&4 2>&1
+}
 
+build_package_make() {
   if [ "${MAKEOPTS+defined}" ]; then
     MAKE_OPTS="$MAKEOPTS"
   elif [ -z "${MAKE_OPTS+defined}" ]; then
     MAKE_OPTS="-j 2"
   fi
 
-  { ./configure --prefix="$PREFIX_PATH" $CONFIGURE_OPTS
-    make $MAKE_OPTS
-    make install
+  { make $MAKE_OPTS
   } >&4 2>&1
+}
+
+build_package_install() {
+  { make install
+  } >&4 2>&1
+}
+
+build_package_standard() {
+  local package_name="$1"
+
+  echo "Configuring ${package_name}..." >&2
+  build_package_configure
+
+  echo "Building ${package_name}..." >&2
+  build_package_make
+
+  echo "Installing ${package_name}..." >&2
+  build_package_make_install
 }
 
 build_package_autoconf() {


### PR DESCRIPTION
While trying to work around a build issue with ruby-1.8.7-p358 on Fedora 17, I needed to inject some custom commands before running `make`. I didn't want to override the entire `build_package_standard` function, as it might change in the future. So I broke the function down into smaller functions, that I could selectively override.
