### PR TITLE
Added uninstall script, simple reversal of the install script

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,12 +13,16 @@ if [ -d "${BIN_PATH}" ]
     for file in bin/*; do
         rm "${BIN_PATH}/${file}"
     done
+then
+    echo "${BIN_PATH} does not exist, are you sure you installed ruby-build standalone, and not as an rbenv plugin (rbenv/plugins/ruby-build)?"
 fi
 
 if [ -d "${SHARE_PATH}" ]
     for file in share/ruby-build/*; do
         rm "${SHARE_PATH}/${file}" 
     done
+then
+    echo "${SHARE_PATH} does not exist, are you sure you installed ruby-build standalone, and not as an rbenv plugin (rbenv/plugins/ruby-build)?"
 fi
 
 echo "Uninstalled ruby-build"


### PR DESCRIPTION
I'm reinstalling ruby-build as an rbenv plugin, and realized there is no way to easily uninstall ruby-build if you did the standalone install.  However, the install.sh script is simple enough, so I just reversed it to make an uninstall.sh script.

However, I haven't been able to test it because I apparently didn't install ruby-build as a standalone project after all.  But figure I'd submit this pull request for you to take a look at anyway.
