### PR TITLE
Added uninstall script

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -9,20 +9,19 @@ fi
 BIN_PATH="${PREFIX}/bin"
 SHARE_PATH="${PREFIX}/share/ruby-build"
 
-if [ -d "${BIN_PATH}" ]; then
-    for file in bin/*; do
-        rm "${BIN_PATH}/${file}"
-    done
-else
-    echo "${BIN_PATH} does not exist, are you sure you installed ruby-build standalone, and not as an rbenv plugin (rbenv/plugins/ruby-build)?"
-fi
-
 if [ -d "${SHARE_PATH}" ]; then
-    for file in share/ruby-build/*; do
-        rm "${SHARE_PATH}/${file}" 
-    done
+    if [ -d "${BIN_PATH}" ]; then
+        for file in bin/*; do
+            rm "${BIN_PATH}/${file}"
+        done
+        for file in share/ruby-build/*; do
+            rm "${SHARE_PATH}/${file}" 
+        done
+        echo "Uninstalled standalone ruby-build from ${BIN_PATH} and ${SHARE_PATH}."
+    else
+        echo "${BIN_PATH} does not exist, uninstall aborted."
+    fi
 else
-    echo "${SHARE_PATH} does not exist, are you sure you installed ruby-build standalone, and not as an rbenv plugin (rbenv/plugins/ruby-build)?"
+    echo "${SHARE_PATH} does not exist, uninstall aborted.  ${SHARE_PATH} is automatically created when you run the ruby-build standalone install.sh script.  Are you sure you installed ruby-build standalone, and not as an rbenv plugin (rbenv/plugins/ruby-build)?"
 fi
 
-echo "Uninstalled ruby-build"


### PR DESCRIPTION
I'm reinstalling ruby-build as an rbenv plugin, and realized there is no way to easily uninstall ruby-build if you did the standalone install.  However, the install.sh script is simple enough, so I just reversed it to make an uninstall.sh script.

However, haven't tested yet it because I apparently didn't install ruby-build as a standalone project after all.  But figure I'd submit this pull request for you to take a look at anyway.  Will try it out in a VM a little later.
