### PR TITLE
updated jruby-1.7.0.preview1 url

### DIFF
--- a/share/ruby-build/jruby-1.7.0-preview1
+++ b/share/ruby-build/jruby-1.7.0-preview1
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.0.preview1" "http://ci.jruby.org/snapshots/1.7.x/jruby-bin-1.7.0.preview1.tar.gz" jruby
+install_package "jruby-1.7.0.preview1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-bin-1.7.0.preview1.tar.gz" jruby


### PR DESCRIPTION
The existing URL is returning 404.  Looks like they're using Amazon S3 now.  Updated the link accordingly.
