### PR TITLE
Old JRuby 1.7.0 package URL returns a 404

### DIFF
--- a/share/ruby-build/jruby-1.7.0-preview1
+++ b/share/ruby-build/jruby-1.7.0-preview1
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.0.preview1" "http://ci.jruby.org/snapshots/1.7.x/jruby-bin-1.7.0.preview1.tar.gz" jruby
+install_package "jruby-1.7.0.preview1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-bin-1.7.0.preview1.tar.gz" jruby


### PR DESCRIPTION
I guess preview 2 is right around the corner according to the CI directory, but it isn't on the homepage yet.

```
$ curl -I http://ci.jruby.org/snapshots/1.7.x/jruby-bin-1.7.0.preview1.tar.gz
HTTP/1.1 404 Not Found
Server: nginx/0.7.65
Date: Thu, 19 Jul 2012 07:54:00 GMT
Content-Type: text/html
Content-Length: 947
Connection: keep-alive
```
