### PR TITLE
Update jruby-1.7.0-preview1 to jruby-1.7.0-preview2.dev

### DIFF
--- a/share/ruby-build/jruby-1.7.0-preview1
+++ b/share/ruby-build/jruby-1.7.0-preview1
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.preview1" "http://ci.jruby.org/snapshots/1.7.x/jruby-bin-1.7.0.preview1.tar.gz" jruby

--- a/share/ruby-build/jruby-1.7.0-preview2.dev
+++ b/share/ruby-build/jruby-1.7.0-preview2.dev
@@ -1,0 +1,1 @@
+install_package "jruby-1.7.0.preview2.dev" "http://ci.jruby.org/snapshots/1.7.x/jruby-bin-1.7.0.preview2.dev.tar.gz" jruby


### PR DESCRIPTION
It seems that  jruby-1.7.0-preview1 tarball is deleted.
