### PR TITLE
Removed rubygems install from recipe share/ruby-build/rbx-2.0.0-dev

### DIFF
--- a/share/ruby-build/rbx-2.0.0-dev
+++ b/share/ruby-build/rbx-2.0.0-dev
@@ -1,2 +1,1 @@
 install_git "rubinius-2.0.0-dev" "https://github.com/rubinius/rubinius.git" "master" rbx
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz" ruby


### PR DESCRIPTION
Removed installing a separate rubygems version for Rubinius. We bundle the most recent version of rubygems known to work with Rubinius.
