### PR TITLE
Support for the patch that gets MRI 1.8.7 to build on Fedora 16+.

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -138,7 +138,11 @@ build_package() {
   echo "Installing ${package_name}..." >&2
 
   for command in $commands; do
-    "build_package_${command}"
+    if [ "${command:0:1}" = "+" ]; then
+      build_package_patch "${command:1}"
+    else
+      "build_package_${command}"
+    fi
   done
 }
 
@@ -211,6 +215,16 @@ build_package_jruby() {
   ln -fs jruby ruby
   install_jruby_launcher
   remove_windows_files
+}
+
+build_package_patch() {
+  local patch_url=$1
+
+  echo "Downloading ${patch_url}..." >&2
+  { fetch_url "$patch_url" > _rbenv.patch
+    patch -p1 < _rbenv.patch
+    rm _rbenv.patch
+  } >&4 2>&1
 }
 
 install_jruby_launcher() {

--- a/share/ruby-build/1.8.7-p370
+++ b/share/ruby-build/1.8.7-p370
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p370" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.gz"
+install_package "ruby-1.8.7-p370" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.gz" "+http://bugs.ruby-lang.org/attachments/download/1931/stdout-rouge-fix.patch" standard
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz" ruby


### PR DESCRIPTION
I couldn't use ruby-build to get MRI 1.8.7 on my Fedora system, and I wanted it so I could test my gems on 1.8.7, so I read up on it and made it work.

I tried to keep the bash clean and simple, but I'm open to any feedback on making the diff better. I hope you'll consider merging this, so rbenv install 1.8.7 "just works" for Fedora users too.

Bug question on StackOverflow: http://stackoverflow.com/questions/6134456/error-while-installing-ruby-1-8-7-on-fedora-15/6321482#6321482
Bug with patch on the MRI bug tracker: http://bugs.ruby-lang.org/issues/5108
