### PR TITLE
Add JRuby 1.7.0.preview2

### DIFF
--- a/share/ruby-build/jruby-1.7.0-preview2
+++ b/share/ruby-build/jruby-1.7.0-preview2
@@ -1,0 +1,1 @@
+install_package "jruby-1.7.0.preview2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview2/jruby-bin-1.7.0.preview2.tar.gz" jruby


### PR DESCRIPTION
Closes #191.

As far as I can tell, the jruby-1.7.0-preview1 tarball is still available, so I didn't remove it.

```
wget http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-bin-1.7.0.preview1.tar.gz
```
