### PR TITLE
Allow hooks to be defined for rbenv-install

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -61,6 +61,10 @@ done
 DEFINITION="${ARGUMENTS[0]}"
 [ -n "$DEFINITION" ] || usage 1
 
+for script in $(rbenv-hooks install); do
+  source "$script"
+done
+
 VERSION_NAME="${DEFINITION##*/}"
 PREFIX="${RBENV_ROOT}/versions/${VERSION_NAME}"
 


### PR DESCRIPTION
With this patch people would be able to extend the plugin for rbenv, like I did with https://github.com/fgrehm/rbenv-install-remote

What do you guys think?
