### PR TITLE
remove prereleases for released versions

### DIFF
--- a/share/ruby-build/1.9.3-dev
+++ b/share/ruby-build/1.9.3-dev
@@ -1,2 +1,0 @@
-install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
-install_svn "ruby-1.9.3-dev" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_3" "HEAD" autoconf standard

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,0 @@
-require_gcc
-install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
-install_package "ruby-1.9.3-preview1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,3 +1,0 @@
-require_gcc
-install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz"
-install_package "ruby-1.9.3-rc1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz"

--- a/share/ruby-build/jruby-1.7.0-preview1
+++ b/share/ruby-build/jruby-1.7.0-preview1
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.preview1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-bin-1.7.0.preview1.tar.gz" jruby

--- a/share/ruby-build/jruby-1.7.0-preview2
+++ b/share/ruby-build/jruby-1.7.0-preview2
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.preview2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview2/jruby-bin-1.7.0.preview2.tar.gz" jruby

--- a/share/ruby-build/jruby-1.7.0-rc1
+++ b/share/ruby-build/jruby-1.7.0-rc1
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.RC1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.RC1/jruby-bin-1.7.0.RC1.tar.gz" jruby

--- a/share/ruby-build/jruby-1.7.0-rc2
+++ b/share/ruby-build/jruby-1.7.0-rc2
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.RC2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.RC2/jruby-bin-1.7.0.RC2.tar.gz" jruby


### PR DESCRIPTION
Once a version is released, do we really need to keep definitions for the prereleases of that version?
