### PR TITLE
Simple, optional tarball cache support

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -74,5 +74,9 @@ if [ -n "${RBENV_BUILD_ROOT}" ]; then
   KEEP="-k"
 fi
 
+if [ -z "${CACHE_PATH}" ] && [ -d "${RBENV_ROOT}/cache" ]; then
+  export CACHE_PATH="${RBENV_ROOT}/cache"
+fi
+
 ruby-build $KEEP $VERBOSE "$DEFINITION" "$PREFIX"
 rbenv rehash

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -143,8 +143,11 @@ fetch_tarball() {
   local package_url="$2"
 
   echo "Downloading ${package_url}..." >&2
-  { fetch_url "$package_url" > "${package_name}.tar.gz"
-    tar xzvf "${package_name}.tar.gz"
+  { if [ ! -e "${CACHE_PATH}${package_name}.tar.gz" ]; then
+      fetch_url "$package_url" > "${package_name}.tar.gz"
+      [ -n "${CACHE_PATH}" ] && mv "${package_name}.tar.gz" "${CACHE_PATH}${package_name}.tar.gz"
+    fi
+    tar xzvf "${CACHE_PATH}${package_name}.tar.gz"
   } >&4 2>&1
 }
 
@@ -460,6 +463,10 @@ if [ -z "$TMPDIR" ]; then
   TMP="/tmp"
 else
   TMP="${TMPDIR%/}"
+fi
+
+if [ -n "$CACHE_PATH" ]; then
+  CACHE_PATH="${CACHE_PATH%/}/"
 fi
 
 SEED="$(date "+%Y%m%d%H%M%S").$$"


### PR DESCRIPTION
# Rationale

Both in development and in production, some usage patterns of ruby-build
are slowed down by the download phase. In scenarios such as
troubleshooting failing builds or with provisioning situations (chef,
vagrant...) the repeated download is unnerving, bandwidth wasting and
simply against etiquette towards tarball hosters.

It also happens that some source sites happen to be down and in such
cases it is helpful to be able to sideload sources to rbenv.
# Behavior

By default nothing changes.

If the variable `CACHE_PATH` is set, then ruby-build will use that
directory to store a successful download, and will check before
downloading if the tarball is already there, in which case downloading
is skipped.

The file is first downloaded as before in the tmp subdirectory and only
moved afterwards, thus ensuring consistency.

There is no default cache path and the optional variable is to be set by
hand, ensuring people know what they're doing when using ruby-build.

Additionnally, rbenv-install will helpfully set `CACHE_PATH` if and only
if a `RBENV_ROOT/cache` directory exists. Again, the directory has to be
created manually.

The `CACHE_PATH` variable internally ends with a slash to mutualize
non-cached cases. Still, consistency is ensured whether or not a slash
is provided externally.
# Notes

I'm not quite sure `CACHE_PATH` is a good name, maybe
`RUBY_BUILD_CACHE_PATH` is better and less conflicting.
