### PR TITLE
Changed references of p327 to p286

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Or, if you would like to install the latest development release:
 To install a Ruby version for use with rbenv, run `rbenv install` with
 the exact name of the version you want to install. For example,
 
-    rbenv install 1.9.3-p327
+    rbenv install 1.9.3-p286
 
 Ruby versions will be installed into a directory of the same name
 under `~/.rbenv/versions`.
@@ -84,7 +84,7 @@ Run the `ruby-build` command with the exact name of the version you
 want to install and the full path where you want to install it. For
 example,
 
-    ruby-build 1.9.3-p327 ~/local/ruby-1.9.3-p327
+    ruby-build 1.9.3-p286 ~/local/ruby-1.9.3-p286
 
 To see a list of all available Ruby versions, run `ruby-build
 --definitions`.


### PR DESCRIPTION
Not sure why there's a reference in the install instructions to 1.9.3-p327, a non-existent (as far as I can tell) version. I know rbenv isn't written for those who simply copy and paste their way through app development, but putting in a seemingly broken value without warning that it's a placeholder seems unnecessary. When p327 didn't work, I tried the version of Ruby that I have now (1.9.3-p258) and got the same error. At that point, I didn't know if rbenv + ruby-build is limited to very specific versions or if either rbenv and/or ruby-build wasn't properly installed on my machine.
