### PR TITLE
Upgrades rubygems for 1.9.1: 1.3.5 -> 1.3.7

### DIFF
--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
 install_package "ruby-1.9.1-p378" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz#9fc5941bda150ac0a33b299e1e53654c"
-install_package "rubygems-1.3.5" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.5.tgz#6e317335898e73beab15623cdd5f8cff" ruby
+install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#e85cfadd025ff6ab689375adbf344bbe" ruby


### PR DESCRIPTION
This upgrades RubyGems so that bundler can be installed on Ruby 1.9.1.

The bundler gem is dependent on RubyGems >= 1.3.6. Otherwise you get this:

```
$ gem install bundler
ERROR:  Error installing bundler:
    bundler requires RubyGems version >= 1.3.6
```
