### PR TITLE
Add Ruby 1.8.7-p371

### DIFF
--- a/share/ruby-build/1.8.7-p371
+++ b/share/ruby-build/1.8.7-p371
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p371" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.gz#653f07bb45f03d0bf3910491288764df"
+install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby


### PR DESCRIPTION
Add Ruby 1.8.7-p371 which fixes CVE-2012-4466 in Ruby 1.8.7-p370: http://www.ruby-forum.com/topic/4406661
