### PR TITLE
remove PREFIX dir after failed rbenv install

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -78,5 +78,9 @@ if [ -z "${RUBY_BUILD_CACHE_PATH}" ] && [ -d "${RBENV_ROOT}/cache" ]; then
   export RUBY_BUILD_CACHE_PATH="${RBENV_ROOT}/cache"
 fi
 
-ruby-build $KEEP $VERBOSE "$DEFINITION" "$PREFIX"
-rbenv rehash
+if ruby-build $KEEP $VERBOSE "$DEFINITION" "$PREFIX"; then
+  rbenv rehash
+else
+  rm -rf "$PREFIX"
+  exit 1
+fi


### PR DESCRIPTION
When REE installation fails, it still manages to create a directory in
"versions/", fooling rbenv into thinking there is now a version available
there. This cleans up after the fact.

References sstephenson/rbenv#297
