### PR TITLE
This fixes issue #239 related to building Ruby on FreeBSD systems

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -315,10 +315,13 @@ build_package_standard() {
   if [ "${MAKEOPTS+defined}" ]; then
     MAKE_OPTS="$MAKEOPTS"
   elif [ -z "${MAKE_OPTS+defined}" ]; then
-    if [[ "FreeBSD" = "$(uname)" ]]; then
-      MAKE_OPTS="-B -j 2" # '-j 2' only builds on FreeBSD with the -B argument
-    else
+    make --version       &>/dev/null ; PROBE_GCC_MAKE=$?
+    make -V MAKE_VERSION &>/dev/null ; PROBE_BSD_MAKE=$?
+
+    if [ $PROBE_GCC_MAKE -eq 0 ]; then
       MAKE_OPTS="-j 2"
+    elif [ $PROBE_BSD_MAKE -eq 0 ]; then
+      MAKE_OPTS="-B -j 2" # '-j 2' only builds on BSD make with the -B argument
     fi
   fi
 


### PR DESCRIPTION
This relates to issue #239 that caused Ruby-build to fail when building Ruby on FreeBSD systems. 

I tracked down the error, and it was caused by running make with the `make -j 2`-parameter.  

Why it failed I don't know, but it would seem that using `-j` is disabling backwards compatibility, from the make man-page:

> -B:
>             Try to be backwards compatible by executing a single shell per
>            command and by executing the commands to make the sources of a
>            dependency line in sequence.  This is turned on by default unless
>            -j is used.
> 
> -j max_jobs
>             Specify the maximum number of jobs that make may have running at
>             any one time.  Turns compatibility mode off, unless the -B flag
>             is also specified.

Before my change, running `rbenv install 1.9.3-p327` ran `make -j 2` would cause the compiling to fail:

```
installing default wait_for_single_fd libraries
compiling wait_for_single_fd.c
linking shared-object -test-/wait_for_single_fd/wait_for_single_fd.so
make: don't know how to make ../../.ext/common/bigdecimal. Stop
*** [ext/bigdecimal/all] Error code 2
1 error
*** [build-ext] Error code 2
```

After my change, the build would complete with `make -B -j 2`. 

I don't know if my solution is the "prettiest", but maybe we should consider just adding the -B argument on other non-freebsd systems as well.

Thoughts about this? 
