### PR TITLE
Add dynamic make tool detection

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -2,6 +2,8 @@
 
 RUBY_BUILD_VERSION="20130104"
 
+MAKE="`which gmake || which make`"
+
 set -E
 exec 3<&2 # preserve original stderr at fd 3
 
@@ -319,8 +321,8 @@ build_package_standard() {
   fi
 
   { ./configure --prefix="$PREFIX_PATH" $CONFIGURE_OPTS
-    make $MAKE_OPTS
-    make install
+    $MAKE $MAKE_OPTS
+    $MAKE install
   } >&4 2>&1
 }
 


### PR DESCRIPTION
On FreeBSD the GNU make binary is called 'gmake'. The native
BSD make cannot be used due to syntax incompatibilities.
