### PR TITLE
fix exit status of install with verbose

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -701,7 +701,8 @@ fi
 exec 4<> "$LOG_PATH" # open the log file at fd 4
 if [ -n "$VERBOSE" ]; then
   tail -f "$LOG_PATH" &
-  trap "kill 0" SIGINT SIGTERM EXIT
+  TAIL_PID=$!
+  trap "kill $TAIL_PID" SIGINT SIGTERM EXIT
 fi
 
 export LDFLAGS="-L'${PREFIX_PATH}/lib' ${LDFLAGS}"


### PR DESCRIPTION
This will fix exit status of `rbenv install -v <version>`.
