### PR TITLE
Keep downloaded tarball sometimes

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -241,8 +241,13 @@ fetch_tarball() {
     download_tarball "$package_url" "$package_filename" "$checksum"
   }
 
-  { tar xzvf "$package_filename"
-    rm -f "$package_filename"
+  { if tar xzvf "$package_filename"; then
+      if [ -z "$KEEP_BUILD_PATH" ]; then
+        rm -f "$package_filename"
+      else
+        true
+      fi
+    fi
   } >&4 2>&1
 }
 


### PR DESCRIPTION
In slow Internet environment, downloading a source tarball takes a lot of time. It is painful to re-download the tarball.
Therefore, do not delete the tarball if `tar xf` fails or user uses `-k/--keep` to keep the source.
Additionally, use `--continue` option of `curl` and `wget` to resume download if previous download is interrupted.
