### PR TITLE
cache git clone directory

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -288,7 +288,7 @@ fetch_git() {
   if type git &>/dev/null; then
     if [ -n "$RUBY_BUILD_CACHE_PATH" ]; then
       pushd "$RUBY_BUILD_CACHE_PATH" >&4
-      local clone_name=$(echo $git_url | sed "s/[^a-z0-9.]/_/g; s/__*/_/g")
+      local clone_name=$(echo $git_url | sed "s/[^A-Za-z0-9.-]/_/g; s/__*/_/g")
       if [ -e "${clone_name}" ]; then
         { cd "${clone_name}"
           git fetch --force "$git_url" "+${git_ref}:${git_ref}" 
@@ -296,7 +296,7 @@ fetch_git() {
       else
         git clone --bare --branch "$git_ref" "$git_url" "${clone_name}" >&4 2>&1
       fi
-      git_url="file://$RUBY_BUILD_CACHE_PATH/${clone_name}"
+      git_url="$RUBY_BUILD_CACHE_PATH/${clone_name}"
       popd >&4
     fi
 


### PR DESCRIPTION
if RUBY_BUILD_CACHE_PATH is set, create and maintain a local bare git
repository in this location.  The name of the git repository is based
on the git URL, so it will be shared between branches.
