### PR TITLE
Fix build failure when clang installed and not used

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -662,11 +662,10 @@ else
   TMP="${TMPDIR%/}"
 fi
 
-# Work around warnings building Ruby 2.0 on Clang 2.x
-if type clang &>/dev/null; then
-  if "${CC:-clang}" -x c /dev/null -E -Wno-error=shorten-64-to-32 &>/dev/null; then
-    RUBY_CFLAGS="$RUBY_CFLAGS -Wno-error=shorten-64-to-32"
-  fi
+# Work around warnings building Ruby 2.0 on Clang 2.x:
+# pass -Wno-error=shorten-64-to-32 if the compiler accepts it.
+if "${CC:-cc}" -x c /dev/null -E -Wno-error=shorten-64-to-32 &>/dev/null; then
+  RUBY_CFLAGS="$RUBY_CFLAGS -Wno-error=shorten-64-to-32"
 fi
 
 if [ -z "$MAKE" ]; then


### PR DESCRIPTION
This better targets the shorten-64-to-32 workaround, to fix #325.

The previous version of this logic was causing us to pass the flag when
- clang is on the PATH, and
- $CC, or 'clang' if CC unset, accepts the flag.

But this is totally wrong if we have clang installed, haven't set $CC, and are going to end up using gcc. We end up passing the flag to gcc, which rejects it.

The real fix is to put this in the autoconf goo in MRI upstream -- the only correct way to decide whether to pass this flag is after we know exactly what compiler we're using and can test if that compiler accepts the flag.  But we can do better than before by approximating autoconf's choice of compiler as $CC if set, 'cc' otherwise (which will typically be a symlink to gcc or clang or another.)
