### PR TITLE
Allow gem flags to be set through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ process.
 * `RUBY_CONFIGURE_OPTS` and `RUBY_MAKE_OPTS` allow you to specify
   configure and make options for buildling MRI. These variables will
   be passed to Ruby only, not any dependent packages (e.g. libyaml).
+* `RUBY_BUILD_GEM_FLAGS` lets you specify additional options for when invoking the `gem` command.
+* `RUBY_BUILD_GEM_INSTALL_FLAGS` lets you specify additional options them `gem install` subcommand.
 
 ### Checksum verification
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -483,7 +483,7 @@ build_package_jruby() {
 
 install_jruby_launcher() {
   cd "${PREFIX_PATH}/bin"
-  { ./ruby gem install jruby-launcher
+  { ./ruby gem ${RUBY_BUILD_GEM_FLAGS} install ${RUBY_BUILD_GEM_INSTALL_FLAGS} jruby-launcher
   } >&4 2>&1
 }
 


### PR DESCRIPTION
When building jruby, ruby-build automatically installs the jruby-launcher gem.

The problem is that I would like to specify that it should install it from a source I specify, rather than from rubygems.org. However, since I won't have access to the `gem` command until after jruby is installed, it is currently impossible for me to do that.

I have added two environment variables to allow users to inject command line parameters to `gem`, making this possible.

This may not be a need many people have but it is not an invasive change.

Thanks!
Mike
