### PR TITLE
Restore -O3 default when we build with clang

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -730,8 +730,12 @@ fi
 
 # Work around warnings building Ruby 2.0 on Clang 2.x:
 # pass -Wno-error=shorten-64-to-32 if the compiler accepts it.
+#
+# When we set CFLAGS, Ruby won't apply its default flags, though. Since clang
+# builds 1.9.x and 2.x only, where -O3 is default, we can safely set that flag.
+# Ensure it's the first flag since later flags take precedence.
 if "${CC:-cc}" -x c /dev/null -E -Wno-error=shorten-64-to-32 &>/dev/null; then
-  RUBY_CFLAGS="$RUBY_CFLAGS -Wno-error=shorten-64-to-32"
+  RUBY_CFLAGS="-O3 -Wno-error=shorten-64-to-32 $RUBY_CFLAGS"
 fi
 
 if [ -z "$MAKE" ]; then


### PR DESCRIPTION
When we set the `-Wno-error=shorten-64-to-32` cflags, Ruby says "oh, someone set cflags, I won't set any" and we lose its default `-O3`. That kills 1.9.3 and 2.0.0 perf.

Since clang can only build 1.9/2.0, we can safely assume that if we're adding the `-Wno-error` flag, we should also provide `-O3` (`-O2` is default for 1.8).

We set `-O3` first since later `-O` options take precedence, so you can override with `RUBY_CFLAGS="-Os" ...`
