### PR TITLE
Allow define RUBY_CONFIGURE_OPTS on rbx configure

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -428,7 +428,7 @@ build_package_ree_installer() {
 build_package_rbx() {
   local package_name="$1"
 
-  { ./configure --prefix="$PREFIX_PATH" --gemsdir="$PREFIX_PATH"
+  { ./configure --prefix="$PREFIX_PATH" --gemsdir="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS
     rake install
   } >&4 2>&1
 }


### PR DESCRIPTION
The configure of rbx can take a RUBY_CONFIGURE_OPTS. You can by example
use the `--skip-prebuilt` OPTS
