### PR TITLE
Specify compression formats in definition files

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -97,7 +97,15 @@ file_is_not_empty() {
 }
 
 install_package() {
-  install_package_using "tarball" 1 "$@"
+  local nargs
+
+  if [ "$#" -eq 3 ]; then
+    nargs=1
+  else
+    nargs=2
+  fi
+
+  install_package_using "tarball" "$nargs" "$@"
 }
 
 install_git() {
@@ -224,6 +232,7 @@ http_get_wget() {
 fetch_tarball() {
   local package_name="$1"
   local package_url="$2"
+  local format
   local mirror_url
   local checksum
 
@@ -236,7 +245,13 @@ fetch_tarball() {
     fi
   fi
 
-  local package_filename="${package_name}.tar.gz"
+  if [ -n "$3" ]; then
+    format="$3"
+  else
+    format="tar.gz"
+  fi
+
+  local package_filename="${package_name}.${format}"
   symlink_tarball_from_cache "$package_filename" "$checksum" || {
     echo "Downloading ${package_filename}..." >&2
     { http head "$mirror_url" &&
@@ -245,7 +260,7 @@ fetch_tarball() {
     download_tarball "$package_url" "$package_filename" "$checksum"
   }
 
-  { if tar xzvf "$package_filename"; then
+  { if extract "$package_filename"; then
       if [ -z "$KEEP_BUILD_PATH" ]; then
         rm -f "$package_filename"
       else
@@ -253,6 +268,21 @@ fetch_tarball() {
       fi
     fi
   } >&4 2>&1
+}
+
+extract() {
+  local filename="$1"
+  [ -n "$filename" ] || return 1
+
+  case "$filename" in
+    *.tar.gz)
+      tar xzvf "$filename";;
+    *.tar.bz2)
+      tar xjvf "$filename";;
+    *)
+      echo "unrecognized file extension: $filename" >&2;
+      return 1;;
+  esac
 }
 
 symlink_tarball_from_cache() {

--- a/share/ruby-build/topaz-dev
+++ b/share/ruby-build/topaz-dev
@@ -1,1 +1,1 @@
-install_package topaz "http://topazruby.com/builds/$(topaz_architecture)/latest/" topaz
+install_package topaz "http://topazruby.com/builds/$(topaz_architecture)/latest/" "tar.bz2" topaz


### PR DESCRIPTION
This is another method for fixing issues like #344 (where the downloaded
file is tar.bz2 but we're invoking `tar xzvf`).

Instead of relying on tar to do the compression format detection (as I
have in the other PR), this commit adds an extra optional argument to
install_package for specifying the filename extension. If omitted,
'tar.gz' is assumed. Currently only .tar.gz and .tar.bz2 are supported,
but it would be easy to add more -- see the new `extract` function.

I prefer this solution because it will work with GNU tar before version
1.15. I'm not sure if bsdtar implementations do the compression format
detection that newer GNU ones do, and if they have, how long they've
been doing so...

I also prefer it because downloaded tarballs are now given the correct
file extension (assuming the file definition is correct). So if
topaz-dev is downloaded but fails to install, manually debugging is
slightly less confusing.

Hopefully a more robust approach than #355 to solving #344.
