### PR TITLE
Override RBENV_VERSION only if it has not been set

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -146,7 +146,9 @@ fi
 # REE installer requires an existing Ruby installation to run. An
 # unsatisfied local .ruby-version file can cause the installer to
 # fail.)
-export RBENV_VERSION="$(rbenv global 2>/dev/null || true)"
+if [ -z "${RBENV_VERSION}" ]; then
+  export RBENV_VERSION="$(rbenv global 2>/dev/null || true)"
+fi
 
 
 # Execute `before_install` hooks.


### PR DESCRIPTION
Please don't override `RBENV_VERSION` with global version if it has been set.
I'd like to override the Ruby version which will be used during build via environment variable.
