### PR TITLE
Fix the has_broken_mac_openssl function for the pre-release version of OS X

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -608,7 +608,7 @@ verify_gcc() {
 
 has_broken_mac_openssl() {
   [ "$(uname -s)" = "Darwin" ] &&
-  [ "$(openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8r 8 Feb 2011" ] &&
+  [[ "$(openssl version 2>/dev/null || true)" =~ 'OpenSSL 0\.9\.8' ]] &&
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]]
 }
 


### PR DESCRIPTION
Hi sstephenson,

Since there is an updated version of openssl bundled with OS X 10.8.4 (12E52), the has_broken_mac_openssl does not work properly as before.

I've made a modification to treat all the 0.9.8 series as broken libraries.
Please have take a look and see if it could be merged to the official version.

Thank you!
