### PR TITLE
script for updating ruby versions by executing rbenv update-versions

### DIFF
--- a/bin/rbenv-update-versions
+++ b/bin/rbenv-update-versions
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Summary: Updates the ruby versions by pulling them from remote
+#
+# Updates all ruby versions, by cding to the rbenv/plugins directory
+# and doing a git pull origin master
+
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+SCRIPT=$(readlink -f $0)
+SCRIPTPATH=`dirname $SCRIPT`
+
+cd $SCRIPTPATH && git pull origin master
+
+rbenv rehash


### PR DESCRIPTION
Added a way to update all versions by just typing `rbenv update-versions` from anywhere in the terminal without setting an rbenv path.

_After trying to add this script to rbenv where it was misplaced because it uses the plugin, I try to add this little script in the Plugin itself._

PR try for the rbenv respo: https://github.com/sstephenson/rbenv/pull/406
