### PR TITLE
use Homebrew openssl if available

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -609,7 +609,17 @@ verify_gcc() {
 has_broken_mac_openssl() {
   [ "$(uname -s)" = "Darwin" ] &&
   [[ "$(openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ]] &&
-  [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]]
+  [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]] &&
+  ! use_homebrew_openssl
+}
+
+use_homebrew_openssl() {
+  local ssldir="$(brew --prefix openssl 2>/dev/null || true)"
+  if [ -d "$ssldir" ]; then
+    package_option ruby configure --with-openssl-dir="$ssldir"
+  else
+    return 1
+  fi
 }
 
 build_package_mac_openssl() {


### PR DESCRIPTION
The only smell in this new code is that the function `has_broken_mac_openssl()` now has a chance to mutate the environment. I'm OK with this since it was an elegant way to fix the problem and avoid having to change code in Ruby 2.0.0-\* formulas.

Fixes #343, references #367
