### PR TITLE
build_package_mruby() doesn't force copying files

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -438,7 +438,7 @@ build_package_mruby() {
 
   { rake
     mkdir -p "$PREFIX_PATH"
-    cp -R build/host/* "$PREFIX_PATH"
+    cp -fR build/host/* "$PREFIX_PATH"
     cd "$PREFIX_PATH/bin"
     ln -fs mruby ruby
     ln -fs mirb irb


### PR DESCRIPTION
When running rbenv `install -f mruby-dev`, the `cp` command doesn't use the force flag. This causes an issue when using a custom build configuration (via MRUBY_CONFIG environment variable) and installing mrbgems from Github, as the pack files in the git repositories are read-only.

Here's the offending line:
https://github.com/sstephenson/ruby-build/blob/master/bin/ruby-build#L441

Adding `-f` to the `cp` command fixed the issue for me.
