### PR TITLE
Change server protocol of the ruby-lang.org server in the MRI definitions from HTTP to FTP

### DIFF
--- a/share/ruby-build/1.8.6-p383
+++ b/share/ruby-build/1.8.6-p383
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.6-p383" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.gz#4f49544d4a4d0d34e9d86c41e853db2e"
+install_package "ruby-1.8.6-p383" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.gz#4f49544d4a4d0d34e9d86c41e853db2e"
 install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#e85cfadd025ff6ab689375adbf344bbe" ruby

--- a/share/ruby-build/1.8.6-p420
+++ b/share/ruby-build/1.8.6-p420
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.6-p420" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.gz#ca1eee44f842e93b5098bc5a2bb9a40b"
+install_package "ruby-1.8.6-p420" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.gz#ca1eee44f842e93b5098bc5a2bb9a40b"
 install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#e85cfadd025ff6ab689375adbf344bbe" ruby

--- a/share/ruby-build/1.8.7-p249
+++ b/share/ruby-build/1.8.7-p249
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p249" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.gz#d7db7763cffad279952eb7e9bbfc221c"
+install_package "ruby-1.8.7-p249" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.gz#d7db7763cffad279952eb7e9bbfc221c"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p302
+++ b/share/ruby-build/1.8.7-p302
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p302" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz#f446550dfde0d8162a6ed8d5a38b3ac2"
+install_package "ruby-1.8.7-p302" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz#f446550dfde0d8162a6ed8d5a38b3ac2"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p334
+++ b/share/ruby-build/1.8.7-p334
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p334" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz#aacb6ee5dfe2367682bba56af7f415b8"
+install_package "ruby-1.8.7-p334" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz#aacb6ee5dfe2367682bba56af7f415b8"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p352
+++ b/share/ruby-build/1.8.7-p352
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p352" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.gz#0c33f663a10a540ea65677bb755e57a7"
+install_package "ruby-1.8.7-p352" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.gz#0c33f663a10a540ea65677bb755e57a7"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p357
+++ b/share/ruby-build/1.8.7-p357
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p357" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.gz#b2b8248ff5097cfd629f5b9768d1df82"
+install_package "ruby-1.8.7-p357" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.gz#b2b8248ff5097cfd629f5b9768d1df82"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p358
+++ b/share/ruby-build/1.8.7-p358
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p358" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.gz#26bd55358847459a7752acdbd33a535f"
+install_package "ruby-1.8.7-p358" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.gz#26bd55358847459a7752acdbd33a535f"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p370
+++ b/share/ruby-build/1.8.7-p370
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p370" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.gz#98b00bbd1cdde3116155edb6e555b781"
+install_package "ruby-1.8.7-p370" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.gz#98b00bbd1cdde3116155edb6e555b781"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p371
+++ b/share/ruby-build/1.8.7-p371
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p371" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.gz#653f07bb45f03d0bf3910491288764df"
+install_package "ruby-1.8.7-p371" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.gz#653f07bb45f03d0bf3910491288764df"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.8.7-p374
+++ b/share/ruby-build/1.8.7-p374
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p374" "http://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.gz#b72a0bc5b824398537762e5272bbb8dc"
+install_package "ruby-1.8.7-p374" "ftp://ftp.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.gz#b72a0bc5b824398537762e5272bbb8dc"
 install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby

--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.1-p378" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz#9fc5941bda150ac0a33b299e1e53654c"
+install_package "ruby-1.9.1-p378" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz#9fc5941bda150ac0a33b299e1e53654c"
 install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#e85cfadd025ff6ab689375adbf344bbe" ruby

--- a/share/ruby-build/1.9.1-p430
+++ b/share/ruby-build/1.9.1-p430
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.1-p430" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.gz#093d17e911b1f7306de95422ec332826"
+install_package "ruby-1.9.1-p430" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.gz#093d17e911b1f7306de95422ec332826"
 install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#e85cfadd025ff6ab689375adbf344bbe" ruby

--- a/share/ruby-build/1.9.2-p0
+++ b/share/ruby-build/1.9.2-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.2-p0" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz#755aba44607c580fddc25e7c89260460"
+install_package "ruby-1.9.2-p0" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz#755aba44607c580fddc25e7c89260460"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p180
+++ b/share/ruby-build/1.9.2-p180
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.2-p180" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz#0d6953820c9918820dd916e79f4bfde8"
+install_package "ruby-1.9.2-p180" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz#0d6953820c9918820dd916e79f4bfde8"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.2-p290" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz#604da71839a6ae02b5b5b5e1b792d5eb"
+install_package "ruby-1.9.2-p290" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz#604da71839a6ae02b5b5b5e1b792d5eb"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p318
+++ b/share/ruby-build/1.9.2-p318
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.2-p318" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz#cc7bf1025128e1985882ae243f348802"
+install_package "ruby-1.9.2-p318" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz#cc7bf1025128e1985882ae243f348802"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p320
+++ b/share/ruby-build/1.9.2-p320
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.2-p320" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz#5ef5d9c07af207710bd9c2ad1cef4b42"
+install_package "ruby-1.9.2-p320" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz#5ef5d9c07af207710bd9c2ad1cef4b42"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p0" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz#8e2fef56185cfbaf29d0c8329fc77c05"
+install_package "ruby-1.9.3-p0" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz#8e2fef56185cfbaf29d0c8329fc77c05"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,4 +1,4 @@
 [ -n "$CC" ] || export CC=cc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p125" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz#e3ea86b9d3fc2d3ec867f66969ae3b92"
+install_package "ruby-1.9.3-p125" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz#e3ea86b9d3fc2d3ec867f66969ae3b92"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-p194
+++ b/share/ruby-build/1.9.3-p194
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p194" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz#bc0c715c69da4d1d8bd57069c19f6c0e"
+install_package "ruby-1.9.3-p194" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz#bc0c715c69da4d1d8bd57069c19f6c0e"

--- a/share/ruby-build/1.9.3-p286
+++ b/share/ruby-build/1.9.3-p286
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p286" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz#e2469b55c2a3d0d643097d47fe4984bb"
+install_package "ruby-1.9.3-p286" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz#e2469b55c2a3d0d643097d47fe4984bb"

--- a/share/ruby-build/1.9.3-p327
+++ b/share/ruby-build/1.9.3-p327
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p327" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz#96118e856b502b5d7b3a4398e6c6e98c"
+install_package "ruby-1.9.3-p327" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz#96118e856b502b5d7b3a4398e6c6e98c"

--- a/share/ruby-build/1.9.3-p362
+++ b/share/ruby-build/1.9.3-p362
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p362" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz#1efc2316dc50e97591792d90647fade2"
+install_package "ruby-1.9.3-p362" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz#1efc2316dc50e97591792d90647fade2"

--- a/share/ruby-build/1.9.3-p374
+++ b/share/ruby-build/1.9.3-p374
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p374" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz#90b6c327abcdf30a954c2d6ae44da2a9"
+install_package "ruby-1.9.3-p374" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz#90b6c327abcdf30a954c2d6ae44da2a9"

--- a/share/ruby-build/1.9.3-p385
+++ b/share/ruby-build/1.9.3-p385
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p385" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz#3e0d7f8512400c1a6732327728a56f1d"
+install_package "ruby-1.9.3-p385" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz#3e0d7f8512400c1a6732327728a56f1d"

--- a/share/ruby-build/1.9.3-p392
+++ b/share/ruby-build/1.9.3-p392
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p392" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz#f689a7b61379f83cbbed3c7077d83859"
+install_package "ruby-1.9.3-p392" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz#f689a7b61379f83cbbed3c7077d83859"

--- a/share/ruby-build/1.9.3-p429
+++ b/share/ruby-build/1.9.3-p429
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p429" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz#993c72f7f805a9eb453f90b0b7fe0d2b"
+install_package "ruby-1.9.3-p429" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz#993c72f7f805a9eb453f90b0b7fe0d2b"

--- a/share/ruby-build/1.9.3-p448
+++ b/share/ruby-build/1.9.3-p448
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-p448" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz#a893cff26bcf351b8975ebf2a63b1023"
+install_package "ruby-1.9.3-p448" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz#a893cff26bcf351b8975ebf2a63b1023"

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-preview1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz#0f0220be4cc7c51a82c1bd8f6a0969f3"
+install_package "ruby-1.9.3-preview1" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz#0f0220be4cc7c51a82c1bd8f6a0969f3"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,3 +1,3 @@
 require_gcc
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-rc1" "http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz#46a2a481536ca0ca0b80ad2b091df68e"
+install_package "ruby-1.9.3-rc1" "ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz#46a2a481536ca0ca0b80ad2b091df68e"

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p0" "http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.gz#50d307c4dc9297ae59952527be4e755d" standard verify_openssl
+install_package "ruby-2.0.0-p0" "ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.gz#50d307c4dc9297ae59952527be4e755d" standard verify_openssl

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p195" "http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.gz#0672e5af309ae99d1703d0e96eff8ea5" standard verify_openssl
+install_package "ruby-2.0.0-p195" "ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.gz#0672e5af309ae99d1703d0e96eff8ea5" standard verify_openssl

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p247" "http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz#c351450a0bed670e0f5ca07da3458a5b" standard verify_openssl
+install_package "ruby-2.0.0-p247" "ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz#c351450a0bed670e0f5ca07da3458a5b" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-2.0.0-preview1" "http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.gz#c7d73f3ddb6d25e7733626ddbad04158" standard verify_openssl
+install_package "ruby-2.0.0-preview1" "ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.gz#c7d73f3ddb6d25e7733626ddbad04158" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-preview2" "http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.gz#eaddcbf63dc775708de45c7a81ab54b9" standard verify_openssl
+install_package "ruby-2.0.0-preview2" "ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.gz#eaddcbf63dc775708de45c7a81ab54b9" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc1" "http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.gz#7d587dde85e0edf7a2e4f6783e6c0e2e" standard verify_openssl
+install_package "ruby-2.0.0-rc1" "ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.gz#7d587dde85e0edf7a2e4f6783e6c0e2e" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc2" "http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.gz#9d5e6f26db7c8c3ddefc81fdb19bd41a" standard verify_openssl
+install_package "ruby-2.0.0-rc2" "ftp://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.gz#9d5e6f26db7c8c3ddefc81fdb19bd41a" standard verify_openssl


### PR DESCRIPTION
It seems that the ftp.ruby-lang.org server no longer accepts HTTP connections, which prevents us from installing any version of Ruby MRI using the default ruby-build definitions. This PR fixes the issue.
