### PR TITLE
If package cannot be downloaded display error and stop

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -280,6 +280,11 @@ download_tarball() {
     verify_checksum "$package_filename" "$checksum"
   } >&4 2>&1 || return 1
 
+  if [ ! -e "${package_filename}" ]; then
+    echo "error: unable to download ${package_filename}" >&2
+    exit 1
+  fi
+
   if [ -n "$RUBY_BUILD_CACHE_PATH" ]; then
     local cached_package_filename="${RUBY_BUILD_CACHE_PATH}/$package_filename"
     { mv "$package_filename" "$cached_package_filename"


### PR DESCRIPTION
Right now if a package download fails the script doesn't notice, continues and throws unhelpful errors.

With this addition if download is unsuccessful, we reports an error and exit.
