### PR TITLE
upload all ruby-build files to s3

### DIFF
--- a/bin/upload-to-mirror
+++ b/bin/upload-to-mirror
@@ -134,9 +134,8 @@ for def in $(ruby_definitions); do
   package_url="${def%%#*}"
 
   mirror_url="http://${S3_BUCKET}/${checksum}"
-  # echo $mirror_url
+
   { http head "$mirror_url"
   } ||
   mirror "$package_url" "$checksum"
-  # echo $package_url
 done


### PR DESCRIPTION
in response to sstephenson/ruby-build#392

This is a script that allows anyone to upload all the checksum'ed ruby-build binary files to an S3 mirror. I used the script personally to recover from the ftp.ruby-lang.org outage, but it could also be used to maintain the official mirrors.

Known problems with this release:
1. Current version always downloads all the files and uploads anything with MD5 matches.
2. I have not attained nearly the level of bashfu as the maintainers of this project, but I'm happy to learn. I'm sure this is ghastly and needs the guts ripped out.
3. I pasted over code from ruby-build. Lots of it. I'd like to just include all of the functions available in ruby-build, but don't know how?
4. There's some cargoculting in that same cut & paste mess. Again, I'd be happy to learn a few bash tricks from my elders.
5. I used s3cmd instead of curl to push the files up to S3. Doing AWS signatures in bash made me want to put a fork in my eye. Using s3cmd made me want to bang my thumb with a hammer. Lesser of two evils chosen here.

feedback requested from @sferik who thought this might be a good idea.
