### PR TITLE
Improved mirror support

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -233,7 +233,7 @@ fetch_tarball() {
 
     if [[ ! "${package_name}" =~ ^(openssl|yaml|rubygems).* ]] &&
       [ -n "$RUBY_BUILD_MIRROR_URL" ]; then
-      mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
+      mirror_url="${RUBY_BUILD_MIRROR_URL}#$checksum"
     fi
   fi
 


### PR DESCRIPTION
- Don't overwrite install URLs for yaml, openssl or rubygems with `RUBY_BUILD_MIRROR_URL`
- Use anchor for mirror checksum to match non-mirror URIs

example:

```
$ RUBY_BUILD_MIRROR_URL="http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz" \
  rbenv install 1.9.3-p448

Downloading yaml-0.1.4.tar.gz...
-> http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz
Installing yaml-0.1.4...
Installed yaml-0.1.4 to /Users/matt/.rbenv/versions/1.9.3-p448

Downloading ruby-1.9.3-p448.tar.gz...
-> http://www.mirrorservice.org/sites/ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz#a893cff26bcf351b8975ebf2a63b1023
Installing ruby-1.9.3-p448...
Installed ruby-1.9.3-p448 to /Users/matt/.rbenv/versions/1.9.3-p448
```
