### PR TITLE
Don't set the Rubinius gems directory to the prefix

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -428,7 +428,7 @@ build_package_ree_installer() {
 build_package_rbx() {
   local package_name="$1"
 
-  { ./configure --prefix="$PREFIX_PATH" --gemsdir="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS
+  { ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS
     rake install
   } >&4 2>&1
 }


### PR DESCRIPTION
This causes tricky issues with Bundler. Bundler assumes that the
configure gem path _only_ contains gems. When using this configuration
option, this is not the case.

What happens is that Bundler then removes the path for the Ruby stdlib
from the load path, because it is located inside what is configured as
the gems directory. This then breaks for example Rails applications when
using ruby-build to build Rubinius.

Also see: https://github.com/rubinius/rubinius/issues/2544
