### PR TITLE
Dynamically calculate the number of CPUs

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -359,13 +359,21 @@ package_option() {
   eval "$variable=( \"\${value[@]}\" )"
 }
 
+number_cpus() {
+  case "$(uname -s)" in
+  "Linux") echo $(grep -c ^processor /proc/cpuinfo);;
+  "Darwin") echo $(system_profiler | awk '/Number Of CPUs/{print $4}{next;}');;
+  *) echo "2"
+  esac
+}
+
 build_package_standard() {
   local package_name="$1"
 
   if [ "${MAKEOPTS+defined}" ]; then
     MAKE_OPTS="$MAKEOPTS"
   elif [ -z "${MAKE_OPTS+defined}" ]; then
-    MAKE_OPTS="-j 2"
+    MAKE_OPTS="-j $(number_cpus)"
   fi
 
   # Support YAML_CONFIGURE_OPTS, RUBY_CONFIGURE_OPTS, etc.


### PR DESCRIPTION
Instead of passing "-j 2" to make, dynamically calculate the number of
CPUs so we get better compile performance.

Currently works for Mac OS X and Linux and defaults to 2 for anything
else.
