### PR TITLE
Remove old definitions of preview or rc versions of Ruby and JRuby

### DIFF
--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,0 @@
-require_gcc
-install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-preview1" "http://www.dnsbalance.ring.gr.jp/pub/lang/ruby/1.9/ruby-1.9.3-preview1.tar.gz#0f0220be4cc7c51a82c1bd8f6a0969f3"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,3 +1,0 @@
-require_gcc
-install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-1.9.3-rc1" "http://www.dnsbalance.ring.gr.jp/pub/lang/ruby/1.9/ruby-1.9.3-rc1.tar.gz#46a2a481536ca0ca0b80ad2b091df68e"

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,0 @@
-install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "yaml-0.1.4" "http://pyyaml.org/download/libyaml/yaml-0.1.4.tar.gz#36c852831d02cf90508c29852361d01b"
-install_package "ruby-2.0.0-preview1" "http://www.dnsbalance.ring.gr.jp/pub/lang/ruby/2.0/ruby-2.0.0-preview1.tar.gz#c7d73f3ddb6d25e7733626ddbad04158" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,2 +1,0 @@
-install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-preview2" "http://www.dnsbalance.ring.gr.jp/pub/lang/ruby/2.0/ruby-2.0.0-preview2.tar.gz#eaddcbf63dc775708de45c7a81ab54b9" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,2 +1,0 @@
-install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc1" "http://www.dnsbalance.ring.gr.jp/pub/lang/ruby/2.0/ruby-2.0.0-rc1.tar.gz#7d587dde85e0edf7a2e4f6783e6c0e2e" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,2 +1,0 @@
-install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc2" "http://www.dnsbalance.ring.gr.jp/pub/lang/ruby/2.0/ruby-2.0.0-rc2.tar.gz#9d5e6f26db7c8c3ddefc81fdb19bd41a" standard verify_openssl

--- a/share/ruby-build/jruby-1.7.0-preview1
+++ b/share/ruby-build/jruby-1.7.0-preview1
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.preview1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-bin-1.7.0.preview1.tar.gz#7b9e5e1cd0d818d0199086d948f948b4" jruby

--- a/share/ruby-build/jruby-1.7.0-preview2
+++ b/share/ruby-build/jruby-1.7.0-preview2
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.preview2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview2/jruby-bin-1.7.0.preview2.tar.gz#e8f1623759590aadbf49e4cc53f1cb61" jruby

--- a/share/ruby-build/jruby-1.7.0-rc1
+++ b/share/ruby-build/jruby-1.7.0-rc1
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.RC1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.RC1/jruby-bin-1.7.0.RC1.tar.gz#bdddcee3d126cddd9a85b5a066a7e25e" jruby

--- a/share/ruby-build/jruby-1.7.0-rc2
+++ b/share/ruby-build/jruby-1.7.0-rc2
@@ -1,1 +1,0 @@
-install_package "jruby-1.7.0.RC2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.RC2/jruby-bin-1.7.0.RC2.tar.gz#ffe2dd61711f4574fed344af151e5de5" jruby


### PR DESCRIPTION
I think it is pointless to have old definitions of preview and rc versions having several stable releases or patch levels. If don't agree with that, cancel this pull request freely.
