### PR TITLE
tar can automatically detect archive type from 1.15 version (2004-12-20)

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -245,7 +245,7 @@ fetch_tarball() {
     download_tarball "$package_url" "$package_filename" "$checksum"
   }
 
-  { if tar xzvf "$package_filename"; then
+  { if tar xvf "$package_filename"; then
       if [ -z "$KEEP_BUILD_PATH" ]; then
         rm -f "$package_filename"
       else


### PR DESCRIPTION
This fixes installing of rbx-2.0.0 for me.
