### PR TITLE
Fix Rubinius gem binstubs path

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -431,6 +431,7 @@ build_package_rbx() {
   { bundle
     ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS
     rake install
+    fix_rbx_gem_binstubs "$PREFIX_PATH"
   } >&4 2>&1
 }
 
@@ -514,6 +515,20 @@ after_install_package() {
 fix_directory_permissions() {
   # Ensure installed directories are not world-writable to avoid Bundler warnings
   find "$PREFIX_PATH" -type d \( -perm -020 -o -perm -002 \) -exec chmod go-w {} \;
+}
+
+fix_rbx_gem_binstubs() {
+  local prefix="$1"
+  local gemdir="${prefix}/gems/bin"
+  local bindir="${prefix}/bin"
+  # Symlink Rubinius' `gems/bin/` into `bin/`
+  if [ -d "$gemdir" ]; then
+    for file in "$gemdir"/*; do
+      [ -x "$file" ] && mv "$file" "$bindir"
+    done
+    rm -rf "$gemdir"
+    ln -s ../bin "$gemdir"
+  fi
 }
 
 require_gcc() {


### PR DESCRIPTION
Rubinius 2 insists that it installs RubyGems binstubs into `PREFIX/gems/bin` instead of `PREFIX/bin`.

This creates complexity for rbenv rehash and exec processes, so we symlink `gems/bin` into `bin` and have RubyGems create binstubs at a location that is consistent with other Ruby implementations.

@sstephenson Right now this is done unconditionally. Should we only be doing this when ruby-build is invoked through rbenv-install? I'm wondering whether this might be unwanted by people who use ruby-build for non rbenv-related purposes.

See sstephenson/rbenv#178, sstephenson/rbenv#461
