### PR TITLE
Strip single quote from LDFLAGS and CPPFLAGS

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -835,8 +835,8 @@ if [ -n "$VERBOSE" ]; then
   trap "kill $TAIL_PID" SIGINT SIGTERM EXIT
 fi
 
-export LDFLAGS="-L'${PREFIX_PATH}/lib' ${LDFLAGS}"
-export CPPFLAGS="-I'${PREFIX_PATH}/include' ${CPPFLAGS}"
+export LDFLAGS="-L${PREFIX_PATH}/lib ${LDFLAGS}"
+export CPPFLAGS="-I${PREFIX_PATH}/include ${CPPFLAGS}"
 
 unset RUBYOPT
 unset RUBYLIB


### PR DESCRIPTION
To building 2.1.0-dev with ruby-build master happened build failure. It seems that LDFLAGS and CPPFLAGS contains wrong variables such as single quote.

PS: ruby-trunk checked these variables and stopped build process by https://github.com/ruby/ruby/commit/3636f8c0f56ddf15e26e28e7a38e748588fad976
