### PR TITLE
Provides Ruby 1.8.7-p374 with a patch for recent security vulnerability

### DIFF
--- a/share/ruby-build/1.8.7-p374-fix-overflow-point-parsing
+++ b/share/ruby-build/1.8.7-p374-fix-overflow-point-parsing
@@ -1,0 +1,8 @@
+build_package_patch_ruby_fix_overflow_point_parsing() {
+  wget 'https://railslts.com/files/ruby-1_8_7p374-fix-overflow-point-parsing-cve-2013-4164.patch'
+  patch -p1 < ruby-1_8_7p374-fix-overflow-point-parsing-cve-2013-4164.patch
+}
+
+require_gcc
+install_package "ruby-1.8.7-p374" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.gz#b72a0bc5b824398537762e5272bbb8dc" patch_ruby_fix_overflow_point_parsing auto_tcltk standard
+install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby


### PR DESCRIPTION
- Fixes "Heap Overflow in Floating Point Parsing (CVE-2013-4164)" in Ruby 1.8.7-p374
- Patch can be found here: https://railslts.com/files/ruby-1_8_7p374-fix-overflow-point-parsing-cve-2013-4164.patch
- Install: rbenv install 1.8.7-p374-fix-overflow-point-parsing
- Use [decide whether you might want global/shell]: rbenv local 1.8.7-p374-fix-overflow-point-parsing

You can test the patch by running `10.times { ("1."+"1"*300000).to_f }` within an irb.
