### PR TITLE
Update 2.1.0-preview2

### DIFF
--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-preview1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.gz#ba2b95d174e156b417a4d580a452eaf5" standard verify_openssl
+install_package "ruby-2.1.0-preview2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.gz#ba2b95d174e156b417a4d580a452eaf5" standard verify_openssl


### PR DESCRIPTION
A minor typo prevents ruby 2.1.0 preview2 from being installed.
