### PR TITLE
Added definition for 1.8.7-p374-cheerful0 [fixes CVE-2013-4164], closes ...

### DIFF
--- a/share/ruby-build/1.8.7-p374-cheerful0
+++ b/share/ruby-build/1.8.7-p374-cheerful0
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1_8_7_374_cheerful0" "https://github.com/cheerful/ruby/archive/v1_8_7_374_cheerful0.tar.gz#0648a1341603c868d28146468db5f0c7" autoconf auto_tcltk standard
+install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby


### PR DESCRIPTION
...#456.

This build is an unofficial backport of the patch for
"Heap Overflow in Floating Point Parsing (CVE-2013-4164)"
to Ruby 1.8.7-p374.

This patch was provided by Makandra and is based on the offical
patches for Ruby 1.9 and Ruby 2:
http://makandracards.com/railslts/19977-backported-fix-for-heap-overflow-in-floating-point-parsing-cve-2013-4164

To indicate the unofficial nature of this version, "cheerful0"
was added to the version string, and the version date was updated:

```
$ ruby -v
ruby 1.8.7 (2013-11-25 patchlevel cheerful0 374) [i686-darwin13.0.0]
```
