### PR TITLE
Add definition for heroku-patched 1.8.7-p375

### DIFF
--- a/share/ruby-build/heroku-1.8.7-p375
+++ b/share/ruby-build/heroku-1.8.7-p375
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1_8_7_375" "https://github.com/heroku/ruby/archive/v1_8_7_375.tar.gz#c4a92e56b636f0d8eca6f09de3f4ca17" autoconf auto_tcltk standard
+install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#0c95a9869914ba1a45bf71d3b8048420" ruby


### PR DESCRIPTION
This build is an unofficial backport of the patch for
"Heap Overflow in Floating Point Parsing (CVE-2013-4164)"
to Ruby 1.8.7-p374.

The definition is called `heroku-1.8.7-p375`.

The defnition refers to a tarball of this tag:
https://github.com/heroku/ruby/releases/tag/v1_8_7_375
