### PR TITLE
Add JRuby 1.7.9 to rbenv

### DIFF
--- a/share/ruby-build/jruby-1.7.9
+++ b/share/ruby-build/jruby-1.7.9
@@ -1,0 +1,1 @@
+install_package "jruby-1.7.9" "http://jruby.org.s3.amazonaws.com/downloads/1.7.9/jruby-bin-1.7.9.tar.gz#b2e44f1f44837c07068ee453a89f4b55" jruby


### PR DESCRIPTION
JRuby 1.7.9 is out as of Friday, December 6 - adds support.
