### PR TITLE
Update JRruby shebangs after a `ruby-build install jruby ...`

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -517,7 +517,7 @@ install_jruby_launcher() {
 fix_jruby_shebangs() {
   for file in "${PREFIX_PATH}/bin"/*; do
     if [ "$(head -c 20 "$file")" = "#!/usr/bin/env jruby" ]; then
-      sed -i -E "s:^#\!/usr/bin/env jruby:#\!${PREFIX_PATH}/bin/jruby:" "$file"
+      sed -i -E "1s:.+:#\!${PREFIX_PATH}/bin/jruby:" "$file"
     fi
   done
 }


### PR DESCRIPTION
The default shebang of a the scripts in a JRuby installation is `#!/usr/bin/env jruby`. On a rbenv managed JRuby, this will execute a rbenv managed shim. In a situation, where a JRuby tool like `gem` is executed from within of a running rbenv by a rbenv plugin, (e.g. rbenv-gemset) this can trigger another rbenv run to resolve the shim. This can lead to an endless loop of rbenv calls.
- After JRuby installation, check JRuby bin directory for files with
  standard jruby shebang
- Replace all standard `!/usr/bin/env jruby` shebangs with a shebang
  pointing directly to the JRuby binary

Fixes sstephenson/ruby-build#471
