### PR TITLE
Fix install file mode for files in share/

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,4 +17,4 @@ SHARE_PATH="${PREFIX}/share/ruby-build"
 mkdir -p "$BIN_PATH" "$SHARE_PATH"
 
 install -p bin/* "$BIN_PATH"
-install -p share/ruby-build/* "$SHARE_PATH"
+install -p -m 0644 share/ruby-build/* "$SHARE_PATH"


### PR DESCRIPTION
install(1) defaults to file mode 0755 which is inappropriate for Ruby definitions
