### PR TITLE
Configure patch options via environment variables

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -796,9 +796,19 @@ isolated_gem_install() {
 }
 
 apply_ruby_patch() {
+  local package_name="$1"
+
+  # Support RUBY_PATCH_OPTS, etc.
+  local package_var_name="$(capitalize "${package_name%%-*}")"
+  local PACKAGE_PATCH_OPTS="${package_var_name}_PATCH_OPTS"
+
+  if [ -z "${PATCH_OPTS+defined}" ] && [ -z "${!PACKAGE_PATCH_OPTS+defined}" ]; then
+    local PATCH_OPTS="-p0"
+  fi
+
   case "$1" in
   ruby-* | jruby-* | rubinius-* )
-    patch -p0 -i "${2:--}"
+    ${PATCH:-patch} $PATCH_OPTS ${!PACKAGE_PATCH_OPTS} -i "${2:--}"
     ;;
   esac
 }


### PR DESCRIPTION
I would like to configure the options for `patch` during `ruby-build`. For example, I need `-p1` as patch option to apply changeset from git repository.

```
git diff HEAD^ | env RUBY_PATCH_OPTS="-p1" rbenv install -p -v 2.1.0
```
