### PR TITLE
Run sed without the -E flag in fix_jruby_shebangs. (GNU sed version 4.1.5 on CentOS 5.8 does not support the -E flag)

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -519,7 +519,7 @@ install_jruby_launcher() {
 fix_jruby_shebangs() {
   for file in "${PREFIX_PATH}/bin"/*; do
     if [ "$(head -c 20 "$file")" = "#!/usr/bin/env jruby" ]; then
-      sed -i.bak -E "1s:.+:#\!${PREFIX_PATH}/bin/jruby:" "$file"
+      sed -i.bak "1 s:.*:#\!${PREFIX_PATH}\/bin\/jruby:" "$file"
       rm "$file".bak
     fi
   done


### PR DESCRIPTION
JRuby installations with ruby-build on CentOS 5.8 are failing for me with the recent fix_jruby_shebangs changes to ruby-build. GNU sed version 4.1.5 on CentOS 5.8 does not support the -E flag:

$ sed -E
sed: invalid option -- E

sed can be run without the -E flag in fix_jruby_shebangs so it works with GNU sed version 4.1.5 on CentOS 5.8.
