### PR TITLE
show definitions in proper sort order - by version number

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -822,7 +822,7 @@ list_definitions() {
   { for definition in "${RUBY_BUILD_ROOT}/share/ruby-build/"*; do
       echo "${definition##*/}"
     done
-  } | sort
+  } | sort --version-sort
 }
 
 


### PR DESCRIPTION
Previously, jruby versions would show as follows:

jruby-1.7.1
jruby-1.7.10
jruby-1.7.2
jruby-1.7.3

After this change, they show as:

jruby-1.7.7
jruby-1.7.8
jruby-1.7.9
jruby-1.7.10

I'm not sure if the version on Mac OS X supports this flag. It works on Ubuntu 13.10
