### PR TITLE
Change 'sed -E' to functionally equivalent and more widely known 'sed -r...

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -558,7 +558,7 @@ fix_rbx_gem_binstubs() {
     for file in "$gemdir"/*; do
       binstub="${bindir}/${file##*/}"
       rm -f "$binstub"
-      sed -E "s:^#\!.+:#\!${bindir}/ruby:" < "$file" > "$binstub"
+      sed -r "s:^#\!.+:#\!${bindir}/ruby:" < "$file" > "$binstub"
       chmod +x "$binstub"
     done
     rm -rf "$gemdir"


### PR DESCRIPTION
...', per http://blog.dmitryleskov.com/small-hacks/mysterious-gnu-sed-option-e/.  E.g., sed 4.1.5 was installed on my RHEL5.3 box and didn't understand -E
