### PR TITLE
Fix Java 7 detection

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -583,7 +583,7 @@ fix_rbx_irb() {
 }
 
 require_java7() {
-  local version="$(java -version 2>/dev/null | head -1)"
+  local version="$(java -version 2>&1 | head -1)"
   if [[ $version != *1.[789]* ]]; then
     colorize 1 "ERROR" >&3
     echo ": Java 7 required. Please install a 1.7-compatible JRE." >&3

--- a/test/build.bats
+++ b/test/build.bats
@@ -438,7 +438,7 @@ OUT
 @test "JRuby Java is outdated" {
   cached_tarball "jruby-9000.dev" bin/jruby
 
-  stub java '-version : echo java version "1.6.0_21"'
+  stub java '-version : echo java version "1.6.0_21" >&2'
 
   run_inline_definition <<DEF
 require_java7
@@ -452,7 +452,7 @@ OUT
 @test "JRuby Java 7 up-to-date" {
   cached_tarball "jruby-9000.dev" bin/jruby
 
-  stub java '-version : echo java version "1.7.0_21"'
+  stub java '-version : echo java version "1.7.0_21" >&2'
 
   run_inline_definition <<DEF
 require_java7


### PR DESCRIPTION
For legacy reasons, Java directs `-version` output to stderr rather than stdout.

The current implementation of `require_java7` (quite reasonably!) expects the version to be on stdout, resulting in failed checks when a valid JRE 7 installation exists. 

This pull request redirects stderr to stdout for parsing and modifies the test stubs to behave identically to Java.
