### PR TITLE
Version sorting that works on OS X (presumably)

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -845,7 +845,7 @@ list_definitions() {
   { for definition in "${RUBY_BUILD_ROOT}/share/ruby-build/"*; do
       echo "${definition##*/}"
     done
-  } | sort --version-sort
+  } | sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n
 }
 
 


### PR DESCRIPTION
Further to #492, this version doesn't use flags for sort that the OSX version doesn't support. 

There is one corner case: jruby-9000 isn't show together with the other jruby versions, but otherwise version sorting works.

Based on: http://stackoverflow.com/a/4495368
