### PR TITLE
OS X: Fixes check for OpenSSL version

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -714,7 +714,7 @@ use_homebrew_readline() {
 
 has_broken_mac_openssl() {
   [ "$(uname -s)" = "Darwin" ] &&
-  [[ "$(openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ]] &&
+  [[ "$(/usr/bin/openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ]] &&
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]] &&
   ! use_homebrew_openssl
 }


### PR DESCRIPTION
We only care about Apple's OpenSSL when checking the version.  Any other
OpenSSL that happens to be in the PATH doesn't matter.

In my case, I had another copy of the `openssl` command in my path (1.0.1)
and I had keg-only homebrew openssl.

I expected it to pick up the homebrew version but didn't because of the
newer openssl in the path.

The ruby build then failed with the annoying "Ignore OpenSSL broken by Apple."
message
