### PR TITLE
Fix #517

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -912,7 +912,7 @@ done
 DEFINITION_PATH="${ARGUMENTS[0]}"
 if [ -z "$DEFINITION_PATH" ]; then
   usage
-elif [ ! -e "$DEFINITION_PATH" ]; then
+elif [ ! -f "$DEFINITION_PATH" ]; then
   BUILTIN_DEFINITION_PATH="${RUBY_BUILD_ROOT}/share/ruby-build/${DEFINITION_PATH}"
   if [ -e "$BUILTIN_DEFINITION_PATH" ]; then
     DEFINITION_PATH="$BUILTIN_DEFINITION_PATH"


### PR DESCRIPTION
Better to use -f than -e to check for a user-specified definition file.
With -e, if the user accidentally types the name of a directory (or, far
less likely, a device file) with the same name as the Ruby they're
trying to install, they end up with ruby-build doing absolutely nothing
at best, or an error message that could be pretty confusing at worst.
