### PR TITLE
link the latest log to /tmp/ruby-build.latest.log

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1007,6 +1007,8 @@ unset RUBYLIB
 
 trap build_failed ERR
 mkdir -p "$BUILD_PATH"
+ln -nsf "$BUILD_PATH" "${TMP}/ruby-build.latest"
+ln -nsf "$LOG_PATH" "${TMP}/ruby-build.latest.log"
 source "$DEFINITION_PATH"
 [ -z "${KEEP_BUILD_PATH}" ] && rm -fr "$BUILD_PATH"
 trap - ERR


### PR DESCRIPTION
currently the logs and tmp files would be stored at path like `"${TMP}/ruby-build.${SEED}.log"`, which is not easy for human eye to find out the current log file.

this pr soft link the latest log file to TMP/ruby-build.latest.log, and link the tmp directory to TMP/ruby-build.latest/
