### PR TITLE
show downloading progress when --verbose is on

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -227,7 +227,7 @@ http_head_curl() {
 }
 
 http_get_curl() {
-  curl -q -o "${2:--}" -sSLf "$1"
+  curl -q -o "${2:--}" -SLf "$1"
 }
 
 http_head_wget() {
@@ -235,7 +235,7 @@ http_head_wget() {
 }
 
 http_get_wget() {
-  wget -nv -O "${2:--}" "$1"
+  wget -v -O "${2:--}" "$1"
 }
 
 fetch_tarball() {


### PR DESCRIPTION
this PR enable the downloading progress for curl and wget, so we can get clear about the progress while downloading the ruby source like this:

```
Downloading ruby-2.1.0.tar.gz...
/tmp/ruby-build.20140327132203.5768 ~
-> http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 14.3M    0 99345    0     0    703      0  5:57:25  0:02:21  5:55:04   174
```

(oh shit, 174 bytes per second)

I don't know if the quiet policy is by design or not, unluckily the network in china is really sucks on downloading ruby :( , maybe a progress could make us life better on sucks network?
