### PR TITLE
Update libyaml to version 0.1.6

### DIFF
--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.1-p378" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz#9fc5941bda150ac0a33b299e1e53654c"
 install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#e85cfadd025ff6ab689375adbf344bbe" ruby

--- a/share/ruby-build/1.9.1-p430
+++ b/share/ruby-build/1.9.1-p430
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.1-p430" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.gz#093d17e911b1f7306de95422ec332826"
 install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#e85cfadd025ff6ab689375adbf344bbe" ruby

--- a/share/ruby-build/1.9.2-p0
+++ b/share/ruby-build/1.9.2-p0
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.2-p0" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz#755aba44607c580fddc25e7c89260460"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p180
+++ b/share/ruby-build/1.9.2-p180
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.2-p180" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz#0d6953820c9918820dd916e79f4bfde8"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.2-p290" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz#604da71839a6ae02b5b5b5e1b792d5eb"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p318
+++ b/share/ruby-build/1.9.2-p318
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.2-p318" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz#cc7bf1025128e1985882ae243f348802"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p320
+++ b/share/ruby-build/1.9.2-p320
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.2-p320" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz#5ef5d9c07af207710bd9c2ad1cef4b42"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.2-p326
+++ b/share/ruby-build/1.9.2-p326
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_svn "ruby-1.9.2-p326" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_2" "44353" autoconf standard
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-dev
+++ b/share/ruby-build/1.9.3-dev
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_git "ruby-1.9.3-dev" "https://github.com/ruby/ruby.git" "ruby_1_9_3" autoconf standard

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p0" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz#8e2fef56185cfbaf29d0c8329fc77c05"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,4 +1,4 @@
 [ -n "$CC" ] || export CC=cc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p125" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz#e3ea86b9d3fc2d3ec867f66969ae3b92"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-p194
+++ b/share/ruby-build/1.9.3-p194
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p194" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz#bc0c715c69da4d1d8bd57069c19f6c0e"

--- a/share/ruby-build/1.9.3-p286
+++ b/share/ruby-build/1.9.3-p286
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p286" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz#e2469b55c2a3d0d643097d47fe4984bb"

--- a/share/ruby-build/1.9.3-p327
+++ b/share/ruby-build/1.9.3-p327
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p327" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz#96118e856b502b5d7b3a4398e6c6e98c"

--- a/share/ruby-build/1.9.3-p362
+++ b/share/ruby-build/1.9.3-p362
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p362" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz#1efc2316dc50e97591792d90647fade2"

--- a/share/ruby-build/1.9.3-p374
+++ b/share/ruby-build/1.9.3-p374
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p374" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz#90b6c327abcdf30a954c2d6ae44da2a9"

--- a/share/ruby-build/1.9.3-p385
+++ b/share/ruby-build/1.9.3-p385
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p385" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz#3e0d7f8512400c1a6732327728a56f1d"

--- a/share/ruby-build/1.9.3-p392
+++ b/share/ruby-build/1.9.3-p392
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p392" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz#f689a7b61379f83cbbed3c7077d83859"

--- a/share/ruby-build/1.9.3-p429
+++ b/share/ruby-build/1.9.3-p429
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p429" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz#993c72f7f805a9eb453f90b0b7fe0d2b"

--- a/share/ruby-build/1.9.3-p448
+++ b/share/ruby-build/1.9.3-p448
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p448" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz#a893cff26bcf351b8975ebf2a63b1023"

--- a/share/ruby-build/1.9.3-p484
+++ b/share/ruby-build/1.9.3-p484
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p484" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz#8ac0dee72fe12d75c8b2d0ef5d0c2968"

--- a/share/ruby-build/1.9.3-p545
+++ b/share/ruby-build/1.9.3-p545
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-p545" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz#8e8f6e4d7d0bb54e0edf8d9c4120f40c"

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,4 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-preview1" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz#0f0220be4cc7c51a82c1bd8f6a0969f3"
 install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#178b0ebae78dbb46963c51ad29bb6bd9" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,3 +1,3 @@
 require_gcc
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-1.9.3-rc1" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz#46a2a481536ca0ca0b80ad2b091df68e"

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p0" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.gz#50d307c4dc9297ae59952527be4e755d" standard verify_openssl

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p195" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.gz#0672e5af309ae99d1703d0e96eff8ea5" standard verify_openssl

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p247" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz#c351450a0bed670e0f5ca07da3458a5b" standard verify_openssl

--- a/share/ruby-build/2.0.0-p353
+++ b/share/ruby-build/2.0.0-p353
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p353" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz#78282433fb697dd3613613ff55d734c1" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "ruby-2.0.0-preview1" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.gz#c7d73f3ddb6d25e7733626ddbad04158" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-preview2" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.gz#eaddcbf63dc775708de45c7a81ab54b9" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-rc1" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.gz#7d587dde85e0edf7a2e4f6783e6c0e2e" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-rc2" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.gz#9d5e6f26db7c8c3ddefc81fdb19bd41a" standard verify_openssl

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz#9e6386d53f5200a3e7069107405b93f7" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.0-preview1
+++ b/share/ruby-build/2.1.0-preview1
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-preview1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.gz#9df4f546f6b961895ba58a8afdf857da" standard verify_openssl

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-preview2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.gz#ba2b95d174e156b417a4d580a452eaf5" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-rc1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.gz#a16561f64d78a902fab08693a300df98" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/rbx-2.0.0
+++ b/share/ruby-build/rbx-2.0.0
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.0.0" "http://releases.rubini.us/rubinius-2.0.0.tar.bz2#62e379e044c822b81e7b20a27daf133e" rbx

--- a/share/ruby-build/rbx-2.0.0-dev
+++ b/share/ruby-build/rbx-2.0.0-dev
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_git "rubinius-2.0.0-dev" "https://github.com/rubinius/rubinius.git" "master" rbx

--- a/share/ruby-build/rbx-2.0.0-rc1
+++ b/share/ruby-build/rbx-2.0.0-rc1
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-release-2.0.0-rc1" "https://nodeload.github.com/rubinius/rubinius/tar.gz/release-2.0.0-rc1#d9726d9eb34c861b9f6596bf478a3116" rbx

--- a/share/ruby-build/rbx-2.1.0
+++ b/share/ruby-build/rbx-2.1.0
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.1.0" "http://releases.rubini.us/rubinius-2.1.0.tar.bz2#908053f38fd840c75a93aab7487c20a5" rbx

--- a/share/ruby-build/rbx-2.1.1
+++ b/share/ruby-build/rbx-2.1.1
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.1.1" "http://releases.rubini.us/rubinius-2.1.1.tar.bz2#6b4df0caec5ea88373e113f97a3b4c72" rbx

--- a/share/ruby-build/rbx-2.2.0
+++ b/share/ruby-build/rbx-2.2.0
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.2.0" "http://releases.rubini.us/rubinius-2.2.0.tar.bz2#f1fbc6f3baf1da5ad86b3858f30f3349" rbx

--- a/share/ruby-build/rbx-2.2.1
+++ b/share/ruby-build/rbx-2.2.1
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.2.1" "http://releases.rubini.us/rubinius-2.2.1.tar.bz2#83c4d61d5fdb070d11babd867852277b" rbx

--- a/share/ruby-build/rbx-2.2.2
+++ b/share/ruby-build/rbx-2.2.2
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.2.2" "http://releases.rubini.us/rubinius-2.2.2.tar.bz2#ac70d629ea43525d91e81f4ccf135299" rbx

--- a/share/ruby-build/rbx-2.2.3
+++ b/share/ruby-build/rbx-2.2.3
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.2.3" "http://releases.rubini.us/rubinius-2.2.3.tar.bz2#d9978cf1a4e8f0310db63e49834f9837" rbx

--- a/share/ruby-build/rbx-2.2.4
+++ b/share/ruby-build/rbx-2.2.4
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.2.4" "http://releases.rubini.us/rubinius-2.2.4.tar.bz2#c10699da85a8eb5861a37b29077213bd" rbx

--- a/share/ruby-build/rbx-2.2.5
+++ b/share/ruby-build/rbx-2.2.5
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.2.5" "http://releases.rubini.us/rubinius-2.2.5.tar.bz2" rbx

--- a/share/ruby-build/rbx-2.2.6
+++ b/share/ruby-build/rbx-2.2.6
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz#24f6093c1e840ca5df2eb09291a1dbf1" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "rubinius-2.2.6" "http://releases.rubini.us/rubinius-2.2.6.tar.bz2" rbx

--- a/test/build.bats
+++ b/test/build.bats
@@ -56,7 +56,7 @@ assert_build_log() {
 }
 
 @test "yaml is installed for ruby" {
-  cached_tarball "yaml-0.1.5"
+  cached_tarball "yaml-0.1.6"
   cached_tarball "ruby-2.0.0"
 
   stub brew false
@@ -69,7 +69,7 @@ assert_build_log() {
   unstub make
 
   assert_build_log <<OUT
-yaml-0.1.5: --prefix=$INSTALL_ROOT
+yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
 make install
 ruby-2.0.0: --prefix=$INSTALL_ROOT
@@ -79,7 +79,7 @@ OUT
 }
 
 @test "apply ruby patch before building" {
-  cached_tarball "yaml-0.1.5"
+  cached_tarball "yaml-0.1.6"
   cached_tarball "ruby-2.0.0"
 
   stub brew false
@@ -94,7 +94,7 @@ OUT
   unstub patch
 
   assert_build_log <<OUT
-yaml-0.1.5: --prefix=$INSTALL_ROOT
+yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
 make install
 patch -p0 -i -

--- a/test/fixtures/definitions/needs-yaml
+++ b/test/fixtures/definitions/needs-yaml
@@ -1,2 +1,2 @@
-install_package "yaml-0.1.5" "http://pyyaml.org/download/libyaml/yaml-0.1.5.tar.gz" --if needs_yaml
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" --if needs_yaml
 install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"


### PR DESCRIPTION
This is required to close the following security problem:

http://www.ocert.org/advisories/ocert-2014-003.html
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-2525

I've run the bats tests, and got full marks on them. Please let me know if I can do anything to help expedite this PR or the subsequent release!
