### PR TITLE
Add option to not install existing versions

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -6,16 +6,16 @@
 #        rbenv install [-f] [-kvp] <definition-file>
 #        rbenv install -l|--list
 #
-#   -l/--list        List all available versions
-#   -f/--force       Install even if the version appears to be installed already
+#   -l/--list          List all available versions
+#   -f/--force         Install even if the version appears to be installed already
 #   -s/--skip-existing Skip if the version appears to be installed already
 #
 #   ruby-build options:
 #
-#   -k/--keep        Keep source tree in $RBENV_BUILD_ROOT after installation
-#                    (defaults to $RBENV_ROOT/sources)
-#   -v/--verbose     Verbose mode: print compilation status to stdout
-#   -p/--patch       Apply a patch from stdin before building
+#   -k/--keep          Keep source tree in $RBENV_BUILD_ROOT after installation
+#                      (defaults to $RBENV_ROOT/sources)
+#   -v/--verbose       Verbose mode: print compilation status to stdout
+#   -p/--patch         Apply a patch from stdin before building
 #
 # For detailed information on installing Ruby versions with
 # ruby-build, including a list of environment variables for adjusting


### PR DESCRIPTION
The -f option allows for forcing installation of versions that already
exist in the environment. If that option isn't used, then an interactive
prompt is created which causes problems for non-interactive execution of
the command. One could use -f for non-interactive executions, but it
causes a significant slowdown in runtime if you don't want to reinstall
that version.

This change allows for a -n option to not install versions that already
exist, while still exiting with a happy status code (for cases where
scripts may be kicking off the rbenv install command where `set -e` has
been run).

This command stemmed from using rbenv in our CI setup. We wanted to install the ruby version, of each app but each run failed if we already had the ruby version installed. We wound up with a lengthy `if-else` stanza to try installing the version and ignore errors if they matched the pattern for an already installed version or properly breaking the build if there were installation errors. I realized this was a simpler answer.

If there is another, better, existing solution, I'm all ears. I couldn't figure one out. :\
