### PR TITLE
2.0.0-p451 should use libyaml-0.1.6 too

### DIFF
--- a/share/ruby-build/2.0.0-p451
+++ b/share/ruby-build/2.0.0-p451
@@ -1,2 +1,3 @@
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1e" "https://www.openssl.org/source/openssl-1.0.1e.tar.gz#66bf6f10f060d561929de96f9dfe5b8c" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p451" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz#9227787a9636551f1749ee8394b5ffe5" standard verify_openssl


### PR DESCRIPTION
It appears that 2.0.0-p451 missed out on the yaml 0.1.6 change, #534 .. or is there a reason it wasn't needed?
