### PR TITLE
Fix `fetch_git` with `--keep`

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -357,9 +357,9 @@ fetch_git() {
       pushd "$RUBY_BUILD_CACHE_PATH" >&4
       local clone_name="$(sanitize "$git_url")"
       if [ -e "${clone_name}" ]; then
-        ( cd "${clone_name}"
+        { cd "${clone_name}"
           git fetch --force "$git_url" "+${git_ref}:${git_ref}"
-        ) >&4 2>&1
+        } >&4 2>&1
       else
         git clone --bare --branch "$git_ref" "$git_url" "${clone_name}" >&4 2>&1
       fi
@@ -369,7 +369,8 @@ fetch_git() {
 
     if [ -e "${package_name}" ]; then
       ( cd "${package_name}"
-        git fetch --force --update-head-ok "$git_url" "+${git_ref}:${git_ref}"
+        git fetch --depth 1 origin "+${git_ref}"
+        git checkout -q -B "$git_ref" "origin/${git_ref}"
       ) >&4 2>&1
     else
       git clone --depth 1 --branch "$git_ref" "$git_url" "${package_name}" >&4 2>&1

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -4,6 +4,11 @@ load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
 
+setup() {
+  export RUBY_BUILD_BUILD_PATH="${TMP}/source"
+  mkdir -p "${RUBY_BUILD_BUILD_PATH}"
+}
+
 @test "failed download displays error message" {
   stub curl false
 
@@ -29,10 +34,12 @@ OUT
 }
 
 @test "updating existing git repository" {
-  stub git "fetch --force --update-head-ok http://example.com/packages/package.git +master:master : true"
+  mkdir -p "${RUBY_BUILD_BUILD_PATH}/package-dev"
+  stub git \
+    "fetch --depth 1 origin +master : true" \
+    "checkout -q -B master origin/master : true"
 
   run_inline_definition <<DEF
-mkdir "\${BUILD_PATH}/package-dev"
 install_git "package-dev" "http://example.com/packages/package.git" master copy
 DEF
   assert_success


### PR DESCRIPTION
Update existing git repo if exists, or clone if not exists.
The destination repo might exist if the `--keep` was supplied for `ruby-build`.
