### PR TITLE
Prefer ggrep for grep invocations that use GNU extensions.

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -44,7 +44,7 @@ usage() {
 
 definitions() {
   local query="$1"
-  ruby-build --definitions | grep -F "$query" || true
+  ruby-build --definitions | $(type -p ggrep grep | head -1) -F "$query" || true
 }
 
 indent() {

--- a/script/mirror
+++ b/script/mirror
@@ -43,7 +43,7 @@ potentially_new_packages() {
 }
 
 extract_urls() {
-  grep -hoe 'http[^"]\+#[^"]\+' "$@" | sort | uniq
+  $(type -p ggrep grep | head -1) -hoe 'http[^"]\+#[^"]\+' "$@" | sort | uniq
 }
 
 update() {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -115,7 +115,7 @@ assert_output() {
 
 assert_output_contains() {
   local expected="$1"
-  echo "$output" | grep -F "$expected" >/dev/null || {
+  echo "$output" | $(type -p ggrep grep | head -1) -F "$expected" >/dev/null || {
     { echo "expected output to contain $expected"
       echo "actual: $output"
     } | flunk


### PR DESCRIPTION
This allows ruby-build to work on Solaris 11.1.
