### PR TITLE
When available, patch defaults to latest stable

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -127,6 +127,11 @@ for script in "${scripts[@]}"; do source "$script"; done
 # Set VERSION_NAME from $DEFINITION, if it is not already set. Then
 # compute the installation prefix.
 [ -n "$VERSION_NAME" ] || VERSION_NAME="${DEFINITION##*/}"
+
+# If VERSION_NAME does not contain the patch, assume the latest stable
+PATCHED_VERSION_NAME=`definitions | egrep "${VERSION_NAME}-p[0-9]+" | sort | tail -n 1`
+[ -z "$PATCHED_VERSION_NAME" ] || VERSION_NAME="$PATCHED_VERSION_NAME"
+
 PREFIX="${RBENV_ROOT}/versions/${VERSION_NAME}"
 
 [ -d "${PREFIX}" ] && PREFIX_EXISTS=1


### PR DESCRIPTION
This is just a small enhancement to enable the user to only state the required version, using the latest stable patch by default.

For example, `rbenv install 1.9.3` has the same effect as `rbenv install 1.9.3-p545`.

Works on OS X Mavericks. Did not create any bats test for this as I did not find a tests file for CLI details (therefore, assumed it would not be required).
