### PR TITLE
Correct the JRuby 9000 snapshot directory name.

### DIFF
--- a/share/ruby-build/jruby-9000-dev
+++ b/share/ruby-build/jruby-9000-dev
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9000.dev" "http://ci.jruby.org/snapshots/master/jruby-dist-9000.dev-bin.tar.gz" jruby
+install_package "jruby-9000.dev-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-dist-9000.dev-bin.tar.gz" jruby


### PR DESCRIPTION
The name of the JRuby 9000 snapshot build directory has changed - this updates ruby-build to know about that. cc @mkristian
