### PR TITLE
Make the downloading message print the actual file name, not just the package name plus .tar.gz.

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -262,7 +262,8 @@ fetch_tarball() {
   fi
 
   if ! reuse_existing_tarball "$package_filename" "$checksum"; then
-    echo "Downloading ${package_filename}..." >&2
+    local tarball_filename=$(basename $package_url)
+    echo "Downloading ${tarball_filename}..." >&2
     http head "$mirror_url" &&
     download_tarball "$mirror_url" "$package_filename" "$checksum" ||
     download_tarball "$package_url" "$package_filename" "$checksum"


### PR DESCRIPTION
Currently the 'Downloading...' message prints the package name plus .tar.gz, assuming this is always the same as the URL being downloaded. This isn't the case for JRuby, so this fixes the message to use the name of the file from the actual URL.
