### PR TITLE
Ruby 2.1.2 is released!

### DIFF
--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#de62b43dfcd858e66a74bee1c834e959" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.1.2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz#a5b5c83565f8bd954ee522bd287d2ca1" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.1.2 is released. this version includes readline-6.3 build fixes.

https://www.ruby-lang.org/en/news/2014/05/09/ruby-2-1-2-is-released/

ref. https://github.com/sstephenson/ruby-build/issues/550 https://github.com/sstephenson/ruby-build/issues/528 https://github.com/sstephenson/ruby-build/issues/526
