### PR TITLE
Ruby 2.1.2 should also install YAML 0.1.6

### DIFF
--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,3 @@
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#5fe00cda18ca5daeb43762b80c38e06e" --if needs_yaml
 install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#de62b43dfcd858e66a74bee1c834e959" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz#a5b5c83565f8bd954ee522bd287d2ca1" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.1.2 is missing a statement to install YAML 0.1.6 if it still
needs to be installed. As it's an important security update, it should
do what previous versions of Ruby are doing.

Signed-off-by: David Celis me@davidcel.is
