### PR TITLE
OpenSSL library updated to 1.0.1h

### DIFF
--- a/share/ruby-build/2.0.0-dev
+++ b/share/ruby-build/2.0.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_0_0" autoconf standard verify_openssl

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p0" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.gz#aff85ba5ceb70303cb7fb616f5db8b95ec47a8820116198d1c866cc4fff151ed" standard verify_openssl

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p195" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.gz#a2fe8d44eac3c27d191ca2d0ee2d871f9aed873c74491b2a8df229bfdc4e5a93" standard verify_openssl

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p247" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz#3e71042872c77726409460e8647a2f304083a15ae0defe90d8000a69917e20d3" standard verify_openssl

--- a/share/ruby-build/2.0.0-p353
+++ b/share/ruby-build/2.0.0-p353
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p353" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz#465afc77d201b5815bb7ce3660a1f5a131f4429a3fa483c126ce66923e4726cc" standard verify_openssl

--- a/share/ruby-build/2.0.0-p451
+++ b/share/ruby-build/2.0.0-p451
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p451" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz#e6d6900eb4084053058349cfdbf63ad1414b6a8d75d58b47ed81010a9947e73b" standard verify_openssl

--- a/share/ruby-build/2.0.0-p481
+++ b/share/ruby-build/2.0.0-p481
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p481" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz#00dd3d72435eb77f2bd94537c1738e5219ca42b6d68df3d4f20c183f4bd12d0f" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-2.0.0-preview1" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.gz#94b585560c05cb40fadd03e675bd3beb8271c2e976b45644cc765bf854cfd80c" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-preview2" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.gz#03d15c7c643f737906c7736820bf4d6f3a71aa8f1dce343284240fee5665f970" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-rc1" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.gz#f9ca3e5b539ccf6bca6875d448a1aec34e73f7c173af180e58500c6f47096916" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-rc2" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.gz#87072ab3e6d393d47f7402682364e4f24efe1c518969795cc01fcdeeb0e646f3" standard verify_openssl

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz#3538ec1f6af96ed9deb04e0965274528162726cc9ba3625dcf23648df872d09d" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.0-dev
+++ b/share/ruby-build/2.1.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_1" ldflags_dirs autoconf standard verify_openssl

--- a/share/ruby-build/2.1.0-preview1
+++ b/share/ruby-build/2.1.0-preview1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-preview1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.gz#747472fb33bcc529f1000e5320605a7e166a095d3805520b989e73b33c05b046" standard verify_openssl

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-preview2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.gz#a9b1dbc16090ddff8f6c6adbc1fd0473bcae8c69143cecabe65d55f95f6dbbfb" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-rc1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.gz#1b467f13be6d3b3648a4de76b34b748781fe4f504a19c08ffa348c75dd62635e" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz#c843df31ae88ed49f5393142b02b9a9f5a6557453805fd489a76fbafeae88941" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz#f22a6447811a81f3c808d1c2a5ce3b5f5f0955c68c9a749182feb425589e6635" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0-dev
+++ b/share/ruby-build/2.2.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.1g" "https://www.openssl.org/source/openssl-1.0.1g.tar.gz#53cb818c3b90e507a8348f4f5eaedb05d8bfe5358aabb508b7263cc670c3e028" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
Previous versions of the library contain a vulnerability CVE-2014-0224.

http://ccsinjection.lepidum.co.jp/
