### PR TITLE
Using mgem when installing mruby.

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -505,7 +505,8 @@ build_package_rbx() {
 build_package_mruby() {
   local package_name="$1"
 
-  { rake
+  { type mgem &>/dev/null && mgem config default > build_config.rb 
+    rake
     mkdir -p "$PREFIX_PATH"
     cp -fR build/host/* "$PREFIX_PATH"
     cd "$PREFIX_PATH/bin"


### PR DESCRIPTION
Using mgem ( https://github.com/mruby/mgem-list ) when installing mruby. 
