### PR TITLE
Disable insecure SSL protocols

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -802,7 +802,7 @@ build_package_mac_openssl() {
   OPENSSL_CONFIGURE="${OPENSSL_CONFIGURE:-./config}"
 
   # Compile a shared lib with zlib dynamically linked, no kerberos.
-  package_option openssl configure --openssldir="$OPENSSLDIR" zlib-dynamic no-krb5 shared
+  package_option openssl configure --openssldir="$OPENSSLDIR" zlib-dynamic no-ssl2 no-ssl3 no-krb5 shared
 
   # Default MAKE_OPTS are -j 2 which can confuse the build. Thankfully, make
   # gives precedence to the last -j option, so we can override that.


### PR DESCRIPTION
SSLv2 and v3 have serious protocol flaws. They should be disabled by default. This is also what most distributions do and is recommended by the OpenSSL wiki: http://wiki.openssl.org/index.php/Compilation_and_Installation#Configure_Options
