### PR TITLE
Add rbx-2.2.10

### DIFF
--- a/share/ruby-build/rbx-2.2.10
+++ b/share/ruby-build/rbx-2.2.10
@@ -1,0 +1,2 @@
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "rubinius-2.2.10" "http://releases.rubini.us/rubinius-2.2.10.tar.bz2#2a3e6b71f27073b8d83b9592b05523af70bc147ddcd0673bffae55b4167c9d81" rbx


### PR DESCRIPTION
Adds rbx 2.2.10 which was released on the rubini.us website.
