### PR TITLE
Remove -q option from curl invocation to read curlrc

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -247,11 +247,11 @@ http() {
 }
 
 http_head_curl() {
-  curl -qsILf "$1" >&4 2>&1
+  curl -sILf "$1" >&4 2>&1
 }
 
 http_get_curl() {
-  curl -q -o "${2:--}" -sSLf "$1"
+  curl -o "${2:--}" -sSLf "$1"
 }
 
 http_head_wget() {


### PR DESCRIPTION
See curl(1)

```
-q If used as the first parameter on the command line, the curlrc
   config file will not be read and used. See the -K, --config for
   details on the default config file search path.
```
