### PR TITLE
Add link to suggested build environment to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Or, if you would like to install the latest development release:
 
 ## Usage
 
+Before you begin, you should ensure that your build environment has the proper
+system dependencies for compiling the wanted Ruby version (see our [recommendations](https://github.com/sstephenson/ruby-build/wiki#suggested-build-environment)).
+
 ### Using `rbenv install` with rbenv
 
 To install a Ruby version for use with rbenv, run `rbenv install` with the


### PR DESCRIPTION
I've added a link to the suggested build environment Wiki page subsection into the Usage section of the README. I believe this information about build environment dependencies necessary for usage should be prominently mentioned in the install process documentation up front to avoid unnecessary errors and confusion.
