### PR TITLE
Add FreeBSD support to num_cpu_cores() function

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -104,7 +104,7 @@ file_is_not_empty() {
 
 num_cpu_cores() {
   local num=""
-  if [ "Darwin" = "$(uname -s)" ]; then
+  if [ "Darwin" = "$(uname -s)" -o "FreeBSD" = "$(uname -s)" ]; then
     num="$(sysctl -n hw.ncpu 2>/dev/null || true)"
   elif [ -r /proc/cpuinfo ]; then
     num="$(grep ^processor /proc/cpuinfo | wc -l)"

--- a/test/build.bats
+++ b/test/build.bats
@@ -221,6 +221,30 @@ make install
 OUT
 }
 
+@test "number of CPU cores is detected on FreeBSD" {
+  cached_tarball "ruby-2.0.0"
+
+  stub uname '-s : echo FreeBSD'
+  stub sysctl '-n hw.ncpu : echo 4'
+  stub_make_install
+
+  export -n MAKE_OPTS
+  run_inline_definition <<DEF
+install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub sysctl
+  unstub make
+
+  assert_build_log <<OUT
+ruby-2.0.0: --prefix=$INSTALL_ROOT
+make -j 4
+make install
+OUT
+}
+
 @test "number of CPU cores is detected on Mac" {
   cached_tarball "ruby-2.0.0"
 


### PR DESCRIPTION
Hello!

Currently num_cpu_cores() function assumes that build environment is either MacOS (Darwin) or Linux. This commit adds support for FreeBSD, which has the same hw.ncpu sysctl as Darwin.
