### PR TITLE
Use HTTPS by default

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1011,7 +1011,7 @@ else
 fi
 
 if [ -z "$RUBY_BUILD_MIRROR_URL" ]; then
-  RUBY_BUILD_MIRROR_URL="http://dqw8nmjcqpjn7.cloudfront.net"
+  RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
 else
   RUBY_BUILD_MIRROR_URL="${RUBY_BUILD_MIRROR_URL%/}"
 fi


### PR DESCRIPTION
One character change - use HTTPS by default when fetching from default ruby mirror.
