### PR TITLE
Read ruby-build revision from git if available

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -892,7 +892,13 @@ apply_ruby_patch() {
 }
 
 version() {
-  echo "ruby-build ${RUBY_BUILD_VERSION}"
+  local git_revision
+  # Read the revision from git if the remote points to "ruby-build" repository
+  if GIT_DIR="$RUBY_BUILD_INSTALL_PREFIX/.git" git remote -v 2>/dev/null | grep -q /ruby-build; then
+    git_revision="$(GIT_DIR="$RUBY_BUILD_INSTALL_PREFIX/.git" git describe --tags HEAD 2>/dev/null || true)"
+    git_revision="${git_revision#v}"
+  fi
+  echo "ruby-build ${git_revision:-$RUBY_BUILD_VERSION}"
 }
 
 usage() {
@@ -919,12 +925,10 @@ unset VERBOSE
 unset KEEP_BUILD_PATH
 unset HAS_PATCH
 
-if [ -z "$RUBY_BUILD_ROOT" ]; then
-  RUBY_BUILD_ROOT="$(abs_dirname "$0")/.."
-fi
+RUBY_BUILD_INSTALL_PREFIX="$(abs_dirname "$0")/.."
 
 OLDIFS="$IFS"
-IFS=: RUBY_BUILD_DEFINITIONS=($RUBY_BUILD_DEFINITIONS ${RUBY_BUILD_ROOT}/share/ruby-build)
+IFS=: RUBY_BUILD_DEFINITIONS=($RUBY_BUILD_DEFINITIONS ${RUBY_BUILD_ROOT:-$RUBY_BUILD_INSTALL_PREFIX}/share/ruby-build)
 IFS="$OLDIFS"
 
 parse_options "$@"

--- a/test/version.bats
+++ b/test/version.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+bats_bin="${BATS_TEST_DIRNAME}/../bin/ruby-build"
+static_version="$(grep VERSION "$bats_bin" | head -1 | cut -d'"' -f 2)"
+
+@test "ruby-build static version" {
+  stub git 'echo "ASPLODE" >&2; exit 1'
+  run ruby-build --version
+  assert_success "ruby-build ${static_version}"
+  unstub git
+}
+
+@test "ruby-build git version" {
+  stub git \
+    'remote -v : echo origin https://github.com/sstephenson/ruby-build.git' \
+    "describe --tags HEAD : echo v1984-12-gSHA"
+  run ruby-build --version
+  assert_success "ruby-build 1984-12-gSHA"
+  unstub git
+}
+
+@test "git describe fails" {
+  stub git \
+    'remote -v : echo origin https://github.com/sstephenson/ruby-build.git' \
+    "describe --tags HEAD : echo ASPLODE >&2; exit 1"
+  run ruby-build --version
+  assert_success "ruby-build ${static_version}"
+  unstub git
+}
+
+@test "git remote doesn't match" {
+  stub git \
+    'remote -v : echo origin https://github.com/Homebrew/homebrew.git' \
+    "describe --tags HEAD : echo v1984-12-gSHA"
+  run ruby-build --version
+  assert_success "ruby-build ${static_version}"
+}


### PR DESCRIPTION
For people who are riding the edge version by pulling from master, this provides a more detailed version number that, when pasted to us, tells us exactly what git revision they're on.
