### PR TITLE
Support extra definitions paths via RUBY_BUILD_DEFINITIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ You can set certain environment variables to control the build process.
   their original source URLs instead of using a mirror.
 * `RUBY_BUILD_ROOT` overrides the default location from where build definitions
   in `share/ruby-build/` are looked up.
+* `RUBY_BUILD_DEFINITIONS` can be a list of colon-separated paths that get
+  additionally searched when looking up build definitions.
 * `CC` sets the path to the C compiler.
 * `RUBY_CFLAGS` lets you pass additional options to the default `CFLAGS`. Use
   this to override, for instance, the `-O3` option.

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -907,12 +907,10 @@ usage() {
 }
 
 list_definitions() {
-  shopt -s nullglob
-  { for definition in "${RUBY_BUILD_ROOT}/share/ruby-build/"*; do
-      echo "${definition##*/}"
+  { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
+      [ -d "$DEFINITION_DIR" ] && ls "$DEFINITION_DIR"
     done
   } | sort
-  shopt -u nullglob
 }
 
 
@@ -924,6 +922,10 @@ unset HAS_PATCH
 if [ -z "$RUBY_BUILD_ROOT" ]; then
   RUBY_BUILD_ROOT="$(abs_dirname "$0")/.."
 fi
+
+OLDIFS="$IFS"
+IFS=: RUBY_BUILD_DEFINITIONS=($RUBY_BUILD_DEFINITIONS ${RUBY_BUILD_ROOT}/share/ruby-build)
+IFS="$OLDIFS"
 
 parse_options "$@"
 
@@ -964,10 +966,14 @@ DEFINITION_PATH="${ARGUMENTS[0]}"
 if [ -z "$DEFINITION_PATH" ]; then
   usage
 elif [ ! -f "$DEFINITION_PATH" ]; then
-  BUILTIN_DEFINITION_PATH="${RUBY_BUILD_ROOT}/share/ruby-build/${DEFINITION_PATH}"
-  if [ -e "$BUILTIN_DEFINITION_PATH" ]; then
-    DEFINITION_PATH="$BUILTIN_DEFINITION_PATH"
-  else
+  for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
+    if [ -f "${DEFINITION_DIR}/${DEFINITION_PATH}" ]; then
+      DEFINITION_PATH="${DEFINITION_DIR}/${DEFINITION_PATH}"
+      break
+    fi
+  done
+
+  if [ ! -f "$DEFINITION_PATH" ]; then
     echo "ruby-build: definition not found: ${DEFINITION_PATH}" >&2
     exit 2
   fi

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -26,6 +26,39 @@ NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
   assert_success "1.9.3-test"
 }
 
+@test "one path via RUBY_BUILD_DEFINITIONS" {
+  export RUBY_BUILD_DEFINITIONS="${TMP}/definitions"
+  mkdir -p "$RUBY_BUILD_DEFINITIONS"
+  touch "${RUBY_BUILD_DEFINITIONS}/1.9.3-test"
+  run ruby-build --definitions
+  assert_success
+  assert_output_contains "1.9.3-test"
+  assert [ "${#lines[*]}" -eq "$((NUM_DEFINITIONS + 1))" ]
+}
+
+@test "multiple paths via RUBY_BUILD_DEFINITIONS" {
+  export RUBY_BUILD_DEFINITIONS="${TMP}/definitions:${TMP}/other"
+  mkdir -p "${TMP}/definitions"
+  touch "${TMP}/definitions/1.9.3-test"
+  mkdir -p "${TMP}/other"
+  touch "${TMP}/other/2.1.2-test"
+  run ruby-build --definitions
+  assert_success
+  assert_output_contains "1.9.3-test"
+  assert_output_contains "2.1.2-test"
+  assert [ "${#lines[*]}" -eq "$((NUM_DEFINITIONS + 2))" ]
+}
+
+@test "installing definition from RUBY_BUILD_DEFINITIONS by priority" {
+  export RUBY_BUILD_DEFINITIONS="${TMP}/definitions:${TMP}/other"
+  mkdir -p "${TMP}/definitions"
+  echo true > "${TMP}/definitions/1.9.3-test"
+  mkdir -p "${TMP}/other"
+  echo false > "${TMP}/other/1.9.3-test"
+  run bin/ruby-build "1.9.3-test" "${TMP}/install"
+  assert_success ""
+}
+
 @test "installing nonexistent definition" {
   run ruby-build "nonexistent" "${TMP}/install"
   assert [ "$status" -eq 2 ]


### PR DESCRIPTION
/cc @parkr

Fixes #608, alt. to #609
