### PR TITLE
Auto-discovery of build definitions from rbenv plugins

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -162,6 +162,15 @@ if [ -z "${RUBY_BUILD_CACHE_PATH}" ] && [ -d "${RBENV_ROOT}/cache" ]; then
   export RUBY_BUILD_CACHE_PATH="${RBENV_ROOT}/cache"
 fi
 
+# Add `share/ruby-build/` directory from each rbenv plugin to the list of
+# paths where build definitions are looked up.
+shopt -s nullglob
+for plugin_path in "$RBENV_ROOT"/plugins/*/share/ruby-build; do
+  RUBY_BUILD_DEFINITIONS="${RUBY_BUILD_DEFINITIONS}:${plugin_path}"
+done
+export RUBY_BUILD_DEFINITIONS
+shopt -u nullglob
+
 # Default RBENV_VERSION to the globally-specified Ruby version. (The
 # REE installer requires an existing Ruby installation to run. An
 # unsatisfied local .ruby-version file can cause the installer to

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -73,3 +73,23 @@ OUT
 
   unstub ruby-build
 }
+
+@test "no build definitions from plugins" {
+  assert [ ! -e "${RBENV_ROOT}/plugins" ]
+  stub_ruby_build 'echo $RUBY_BUILD_DEFINITIONS'
+
+  run rbenv-install 2.1.2
+  assert_success ""
+}
+
+@test "some build definitions from plugins" {
+  mkdir -p "${RBENV_ROOT}/plugins/foo/share/ruby-build"
+  mkdir -p "${RBENV_ROOT}/plugins/bar/share/ruby-build"
+  stub_ruby_build "echo \$RUBY_BUILD_DEFINITIONS | tr ':' $'\\n'"
+
+  run rbenv-install 2.1.2
+  assert_success <<OUT
+${RBENV_ROOT}/plugins/bar/share/ruby-build
+${RBENV_ROOT}/plugins/foo/share/ruby-build
+OUT
+}


### PR DESCRIPTION
The `share/ruby-build/` directory from each rbenv plugin, if it exists, is added to RUBY_BUILD_DEFINITIONS automatically during `rbenv install`.

@sstephenson: I first started adding this functionality to rbenv itself, but I figured I could just as well add it here and keep rbenv blissfully unaware of ruby-build and its concerns. Thoughts?

Continuation of #613, #608 /cc @parkr @thomasjo 
