### PR TITLE
RUBY_BUILD_MIRROR_URL defaults to https://...

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1026,7 +1026,7 @@ else
 fi
 
 if [ -z "$RUBY_BUILD_MIRROR_URL" ]; then
-  RUBY_BUILD_MIRROR_URL="http://dqw8nmjcqpjn7.cloudfront.net"
+  RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
 else
   RUBY_BUILD_MIRROR_URL="${RUBY_BUILD_MIRROR_URL%/}"
 fi


### PR DESCRIPTION
Because encryption and authenticity are now cool :smiley_cat: 
