### PR TITLE
Populate custom definitions before executing code for `--list`

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -51,11 +51,24 @@ indent() {
   sed 's/^/  /'
 }
 
+populate_custom_definitions() {
+  # Add `share/ruby-build/` directory from each rbenv plugin to the list of
+  # paths where build definitions are looked up.
+  shopt -s nullglob
+  for plugin_path in "$RBENV_ROOT"/plugins/*/share/ruby-build; do
+    RUBY_BUILD_DEFINITIONS="${RUBY_BUILD_DEFINITIONS}:${plugin_path}"
+  done
+  export RUBY_BUILD_DEFINITIONS
+  shopt -u nullglob
+}
+
 unset FORCE
 unset SKIP_EXISTING
 unset KEEP
 unset VERBOSE
 unset HAS_PATCH
+
+populate_custom_definitions
 
 parse_options "$@"
 for option in "${OPTIONS[@]}"; do
@@ -161,15 +174,6 @@ fi
 if [ -z "${RUBY_BUILD_CACHE_PATH}" ] && [ -d "${RBENV_ROOT}/cache" ]; then
   export RUBY_BUILD_CACHE_PATH="${RBENV_ROOT}/cache"
 fi
-
-# Add `share/ruby-build/` directory from each rbenv plugin to the list of
-# paths where build definitions are looked up.
-shopt -s nullglob
-for plugin_path in "$RBENV_ROOT"/plugins/*/share/ruby-build; do
-  RUBY_BUILD_DEFINITIONS="${RUBY_BUILD_DEFINITIONS}:${plugin_path}"
-done
-export RUBY_BUILD_DEFINITIONS
-shopt -u nullglob
 
 # Default RBENV_VERSION to the globally-specified Ruby version. (The
 # REE installer requires an existing Ruby installation to run. An


### PR DESCRIPTION
One bug with `rbenv install` and custom definition paths (https://github.com/sstephenson/ruby-build/pull/614, https://github.com/sstephenson/ruby-build/pull/613) is its use with the `--list` switch.

The code that I have moved in this mock PR ensures that the `RUBY_BUILD_DEFINITIONS` list of paths is properly populated before calling the `definitions` function in `--list`.

I'm sure there's a more style-conformant solution, but this gets the job done.

/cc @mislav 
