### PR TITLE
Make build output and log more useful

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -71,10 +71,21 @@ colorize() {
   fi
 }
 
+os_information() {
+  if type -p lsb_release >/dev/null; then
+    lsb_release -sir | xargs echo
+  elif type -p sw_vers >/dev/null; then
+    echo "OS X $(sw_vers -productVersion)"
+  else
+    local os="$(cat /etc/{centos,redhat,fedora,system}-release /etc/debian_version 2>/dev/null | head -1)"
+    echo "${os:-$(uname -sr)}"
+  fi
+}
+
 build_failed() {
   { echo
     colorize 1 "BUILD FAILED"
-    echo " ($(version))"
+    echo " ($(os_information) using $(version))"
     echo
 
     if ! rmdir "${BUILD_PATH}" 2>/dev/null; then


### PR DESCRIPTION
- Print OS and ruby-build version on build failure.
- Highlight path to full log so people can't miss it.
- Print Ruby configure options when openssl extention fails to compile.
- Don't log files as they're extracted from tarballs. It only pollutes the log and is not useful info.

![screen shot 2014-09-06 at 2 38 30 am](https://cloud.githubusercontent.com/assets/887/4174799/b034cbc6-35a9-11e4-9a1d-2b63ff3967d8.png)

![screen shot 2014-09-06 at 2 32 05 am](https://cloud.githubusercontent.com/assets/887/4174798/b033d1a8-35a9-11e4-9349-87ec63b77967.png)
