### PR TITLE
List Rubies in natural version sort order.

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -871,7 +871,7 @@ list_definitions() {
       echo "${definition##*/}"
     done
   } | sed -e "h" -e 's/[+-]/./g' -e "G" -e 's/\n/	/' |
-      sort -t "." -k "1,1" -k "2,2n" -k "3,3n" -k "4,4n" -k "5,5n" |
+      LC_ALL=C sort -t "." -k "1,1" -k "2,2n" -k "3,3n" -k "4,4n"  |
       cut -f 2
 }
 


### PR DESCRIPTION
Show Rubies listed by `ruby-build --definitions` in a nice sort order by Ruby names then versions. This commit uses a combination of `sed`, `sort` and `cut` to achieve the desired result since GNU `ls` and `sort` natural version number sorting options aren't portable.

First normalize each Ruby (by converting dashes and plusses to periods) followed by a tab then the original Ruby version:

``` shell
sed -e "h" -e 's/[+-]/./g' -e "G" -e 's/\n/ /'
```

For example, `jruby-9000+graal-dev` becomes `jruby.9000.graal.dev\tjruby-9000+graal-dev`.

Then dictionary sort the first column and numerically sort the next four columns:

``` shell
sort -t "." -k "1,1" -k "2,2n" -k "3,3n" -k "4,4n" -k "5,5n"
```

For most non-MRI Rubies, this results in the Ruby name being dictionary sorted and the MAJOR, MINOR, TINY, plus one more column being numerically sorted. Additional numeric sort columns could be added but aren't needed at present. For all existing ruby-build Ruby versions this sort order is correct.

Once natural version number sorted, cut to the original Ruby versions column with a `cut -f 2`.

Closes #512.

One caveat is that with ruby-build's special case dropping the CRuby `ruby-` prefix (see #543), a future MRI version 10.0+ could be missorted. I'm assuming 1.X will be long dead before a 10.0+ comes around but now we've had a JRuby 9000 so who knows.

See chruby [#278](https://github.com/postmodern/chruby/pull/278) and [#277](https://github.com/postmodern/chruby/pull/277) for more discussion of related numeric sorting of Ruby versions with sed.
