### PR TITLE
Sort Ruby versions when listing available definitions

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -936,9 +936,13 @@ list_definitions() {
   { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
       [ -d "$DEFINITION_DIR" ] && ls "$DEFINITION_DIR"
     done
-  } | sort
+  } | sort_versions
 }
 
+sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
 
 
 unset VERBOSE

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -64,3 +64,33 @@ NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
   assert [ "$status" -eq 2 ]
   assert_output "ruby-build: definition not found: nonexistent"
 }
+
+@test "sorting Ruby versions" {
+  export RUBY_BUILD_ROOT="$TMP"
+  mkdir -p "${RUBY_BUILD_ROOT}/share/ruby-build"
+  expected="1.9.3-dev
+1.9.3-preview1
+1.9.3-rc1
+1.9.3-p0
+1.9.3-p125
+2.1.0-dev
+2.1.0-rc1
+2.1.0
+2.1.1
+2.2.0-dev
+jruby-1.6.5
+jruby-1.6.5.1
+jruby-1.7.0-preview1
+jruby-1.7.0-rc1
+jruby-1.7.0
+jruby-1.7.1
+jruby-1.7.9
+jruby-1.7.10
+jruby-9000-dev
+jruby-9000"
+  for ver in "$expected"; do
+    touch "${RUBY_BUILD_ROOT}/share/ruby-build/$ver"
+  done
+  run ruby-build --definitions
+  assert_success "$expected"
+}


### PR DESCRIPTION
Stable releases should now be sorted as a higher version than preview releases or RCs. For instance:
- 1.9.3-preview < 1.9.3-rc1 < 1.9.3-p0
- 2.1.0-dev < 2.1.0-rc1 < 2.1.0
- jruby-1.7.0-preview1 < jruby-1.7.0-rc1 < jruby-1.7.0

Credit for the basis of this code goes to @mpapis and https://github.com/postmodern/chruby/pull/277#issuecomment-48812444

Closes #628, closes #512, #492

/cc @havenwood @nirvdrum
