### PR TITLE
`rbenv install` completion includes definitions from plugins

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -24,13 +24,22 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
+if [ -z "$RBENV_ROOT" ]; then
+  RBENV_ROOT="${HOME}/.rbenv"
+fi
+
+# Add `share/ruby-build/` directory from each rbenv plugin to the list of
+# paths where build definitions are looked up.
+shopt -s nullglob
+for plugin_path in "$RBENV_ROOT"/plugins/*/share/ruby-build; do
+  RUBY_BUILD_DEFINITIONS="${RUBY_BUILD_DEFINITIONS}:${plugin_path}"
+done
+export RUBY_BUILD_DEFINITIONS
+shopt -u nullglob
+
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
   exec ruby-build --definitions
-fi
-
-if [ -z "$RBENV_ROOT" ]; then
-  RBENV_ROOT="${HOME}/.rbenv"
 fi
 
 # Load shared library functions
@@ -50,15 +59,6 @@ definitions() {
 indent() {
   sed 's/^/  /'
 }
-
-# Add `share/ruby-build/` directory from each rbenv plugin to the list of
-# paths where build definitions are looked up.
-shopt -s nullglob
-for plugin_path in "$RBENV_ROOT"/plugins/*/share/ruby-build; do
-  RUBY_BUILD_DEFINITIONS="${RUBY_BUILD_DEFINITIONS}:${plugin_path}"
-done
-export RUBY_BUILD_DEFINITIONS
-shopt -u nullglob
 
 unset FORCE
 unset SKIP_EXISTING

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -110,3 +110,17 @@ Available versions:
   ${RBENV_ROOT}/plugins/foo/share/ruby-build
 OUT
 }
+
+@test "completion results include build definitions from plugins" {
+  mkdir -p "${RBENV_ROOT}/plugins/foo/share/ruby-build"
+  mkdir -p "${RBENV_ROOT}/plugins/bar/share/ruby-build"
+  stub ruby-build "--definitions : echo \$RUBY_BUILD_DEFINITIONS | tr ':' $'\\n'"
+
+  run rbenv-install --complete
+  assert_success
+  assert_output <<OUT
+
+${RBENV_ROOT}/plugins/bar/share/ruby-build
+${RBENV_ROOT}/plugins/foo/share/ruby-build
+OUT
+}


### PR DESCRIPTION
Before, `ruby-build --definitions` was invoked sooner than RUBY_BUILD_DEFINITIONS was built up with paths from rbenv plugins.

References #614; similar #627

/cc @parkr :blush: 
