### PR TITLE
Show specific upgrade instructions based on environment

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -195,17 +195,25 @@ ruby-build $KEEP $VERBOSE $HAS_PATCH "$DEFINITION" "$PREFIX" || STATUS="$?"
 # Display a more helpful message if the definition wasn't found.
 if [ "$STATUS" == "2" ]; then
   { candidates="$(definitions "$DEFINITION")"
+    here="$(dirname "${0%/*}")"
     if [ -n "$candidates" ]; then
       echo
       echo "The following versions contain \`$DEFINITION' in the name:"
       echo "$candidates" | indent
     fi
     echo
-    echo "You can list all available versions with \`rbenv install --list'."
+    echo "See all available versions with \`rbenv install --list'."
     echo
-    echo "If the version you're looking for is not present, first try upgrading"
-    echo "ruby-build. If it's still missing, open a request on the ruby-build"
-    echo "issue tracker: https://github.com/sstephenson/ruby-build/issues"
+    echo -n "If the version you need is missing, try upgrading ruby-build"
+    if [ "$here" != "${here#$(brew --prefix 2>/dev/null)}" ]; then
+      printf ":\n\n"
+      echo "  brew update && brew upgrade ruby-build"
+    elif [ -d "${here}/.git" ]; then
+      printf ":\n\n"
+      echo "  cd ${here} && git pull"
+    else
+      printf ".\n"
+    fi
   } >&2
 fi
 

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -52,6 +52,7 @@ OUT
 }
 
 @test "nonexistent version" {
+  stub brew false
   stub_ruby_build 'echo ERROR >&2 && exit 2' \
     "--definitions : echo 1.8.7 1.9.3-p0 1.9.3-p194 2.1.2 | tr ' ' $'\\n'"
 
@@ -64,13 +65,34 @@ The following versions contain \`1.9.3' in the name:
   1.9.3-p0
   1.9.3-p194
 
-You can list all available versions with \`rbenv install --list'.
+See all available versions with \`rbenv install --list'.
 
-If the version you're looking for is not present, first try upgrading
-ruby-build. If it's still missing, open a request on the ruby-build
-issue tracker: https://github.com/sstephenson/ruby-build/issues
+If the version you need is missing, try upgrading ruby-build:
+
+  cd ${BATS_TEST_DIRNAME}/.. && git pull
 OUT
 
+  unstub ruby-build
+}
+
+@test "Homebrew upgrade instructions" {
+  stub brew "--prefix : echo '${BATS_TEST_DIRNAME%/*}'"
+  stub_ruby_build 'echo ERROR >&2 && exit 2' \
+    "--definitions : true"
+
+  run rbenv-install 1.9.3
+  assert_failure
+  assert_output <<OUT
+ERROR
+
+See all available versions with \`rbenv install --list'.
+
+If the version you need is missing, try upgrading ruby-build:
+
+  brew update && brew upgrade ruby-build
+OUT
+
+  unstub brew
   unstub ruby-build
 }
 


### PR DESCRIPTION
Because ruby-build is both a Homebrew formula and an rbenv plugin, some people end up with both installed. In these cases, executing `rbenv install` vs. `ruby-build` might not use the same install. Users end up being unsure where `rbenv install` is coming from and upgrading it from the wrong location.
- https://github.com/sstephenson/ruby-build/issues/588#issuecomment-48026552
- https://github.com/sstephenson/ruby-build/issues/569#issuecomment-42778989
- https://github.com/sstephenson/ruby-build/pull/480
- https://github.com/sstephenson/ruby-build/issues/366#issue-15051163
- https://github.com/sstephenson/ruby-build/issues/362#issuecomment-19513846
- https://github.com/sstephenson/ruby-build/issues/254#issuecomment-16306018

This detect whether ruby-build is contained in Homebrew or git and shows upgrade instructions accordingly. Example:

```
See all available versions with `rbenv install --list'.

If the version you need is missing, try upgrading ruby-build:

  brew update && brew upgrade ruby-build
```

How does everyone feel about this?
