### PR TITLE
Fix TMPDIR noexec check to explicitly exit with a zero exit status on success

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1027,7 +1027,10 @@ fi
 tmp_executable="${TMP}/ruby-build-test.$$"
 noexec=""
 if mkdir -p "$TMP" && touch "$tmp_executable" 2>/dev/null; then
-  cat > "$tmp_executable" <<<"#!$BASH"
+  cat > "$tmp_executable" <<-EOF
+	#!${BASH}
+	exit 0
+	EOF
   chmod +x "$tmp_executable"
 else
   echo "ruby-build: TMPDIR=$TMP is set to a non-accessible location" >&2


### PR DESCRIPTION
The TMPDIR check implemented in a4556a73 incorrectly reports that
TMPDIR cannot hold executables on 4.3.11(1) on Ubuntu 14.04.1 LTS.
This is because a script containing no commands returns a non-zero
exit code.  Contrast the following:

  bash 3.2.53(1) on OS X 10.9.5:

```
$ bash -c '' && echo SUCCESS
SUCCESS
```

  bash 4.3.11(1) on Ubuntu 14.04.1 LTS:

```
$ bash -c '' || echo FAIL
FAIL
```

This patch modifies the test script to explicitly call `exit 0` to
ensure that a successful exit code is returned if the script executes
successfully.
