### PR TITLE
Use HTTPS URLs to fetch JRuby distfiles.

### DIFF
--- a/share/ruby-build/jruby-1.5.6
+++ b/share/ruby-build/jruby-1.5.6
@@ -1,1 +1,1 @@
-install_package "jruby-1.5.6" "http://jruby.org.s3.amazonaws.com/downloads/1.5.6/jruby-bin-1.5.6.tar.gz#545148197f98a4483276cdef5cedda0542a518d68d771c122f310195d8925089" jruby
+install_package "jruby-1.5.6" "https://s3.amazonaws.com/jruby-org/downloads/1.5.6/jruby-bin-1.5.6.tar.gz#545148197f98a4483276cdef5cedda0542a518d68d771c122f310195d8925089" jruby

--- a/share/ruby-build/jruby-1.6.3
+++ b/share/ruby-build/jruby-1.6.3
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.3" "http://jruby.org.s3.amazonaws.com/downloads/1.6.3/jruby-bin-1.6.3.tar.gz#9432fe3951782393d9755493585865190d7802e0bd162ff599e9c374605840ca" jruby
+install_package "jruby-1.6.3" "https://s3.amazonaws.com/jruby-org/downloads/1.6.3/jruby-bin-1.6.3.tar.gz#9432fe3951782393d9755493585865190d7802e0bd162ff599e9c374605840ca" jruby

--- a/share/ruby-build/jruby-1.6.4
+++ b/share/ruby-build/jruby-1.6.4
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.4" "http://jruby.org.s3.amazonaws.com/downloads/1.6.4/jruby-bin-1.6.4.tar.gz#64fb1a850f3982d88166d68a3f830afbc81d14c1a20884a8076da010daa66e8a" jruby
+install_package "jruby-1.6.4" "https://s3.amazonaws.com/jruby-org/downloads/1.6.4/jruby-bin-1.6.4.tar.gz#64fb1a850f3982d88166d68a3f830afbc81d14c1a20884a8076da010daa66e8a" jruby

--- a/share/ruby-build/jruby-1.6.5
+++ b/share/ruby-build/jruby-1.6.5
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.5" "http://jruby.org.s3.amazonaws.com/downloads/1.6.5/jruby-bin-1.6.5.tar.gz#e15a273bd78da1c63f77b90681d101df10bac62249833bb27a07c09216fb27f2" jruby
+install_package "jruby-1.6.5" "https://s3.amazonaws.com/jruby-org/downloads/1.6.5/jruby-bin-1.6.5.tar.gz#e15a273bd78da1c63f77b90681d101df10bac62249833bb27a07c09216fb27f2" jruby

--- a/share/ruby-build/jruby-1.6.5.1
+++ b/share/ruby-build/jruby-1.6.5.1
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.5.1" "http://jruby.org.s3.amazonaws.com/downloads/1.6.5.1/jruby-bin-1.6.5.1.tar.gz#0d2751a1aca147a5b9c6ddeef395440207374611ef39bc538e9e829270d811c8" jruby
+install_package "jruby-1.6.5.1" "https://s3.amazonaws.com/jruby-org/downloads/1.6.5.1/jruby-bin-1.6.5.1.tar.gz#0d2751a1aca147a5b9c6ddeef395440207374611ef39bc538e9e829270d811c8" jruby

--- a/share/ruby-build/jruby-1.6.6
+++ b/share/ruby-build/jruby-1.6.6
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.6" "http://jruby.org.s3.amazonaws.com/downloads/1.6.6/jruby-bin-1.6.6.tar.gz#1ef255ec73b80474602029a61f84062876873065c0f3398c30bc04ddd14aa34f" jruby
+install_package "jruby-1.6.6" "https://s3.amazonaws.com/jruby-org/downloads/1.6.6/jruby-bin-1.6.6.tar.gz#1ef255ec73b80474602029a61f84062876873065c0f3398c30bc04ddd14aa34f" jruby

--- a/share/ruby-build/jruby-1.6.7
+++ b/share/ruby-build/jruby-1.6.7
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.7" "http://jruby.org.s3.amazonaws.com/downloads/1.6.7/jruby-bin-1.6.7.tar.gz#88afbbb8fb4267547526a52f15d45ab447c1f2d1b197edc501e88dc9cb62a74c" jruby
+install_package "jruby-1.6.7" "https://s3.amazonaws.com/jruby-org/downloads/1.6.7/jruby-bin-1.6.7.tar.gz#88afbbb8fb4267547526a52f15d45ab447c1f2d1b197edc501e88dc9cb62a74c" jruby

--- a/share/ruby-build/jruby-1.6.7.2
+++ b/share/ruby-build/jruby-1.6.7.2
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.7.2" "http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-bin-1.6.7.2.tar.gz#6f04baa597941e48276a2edbb464afc6801f8f690fb978422e12029b7bfefe18" jruby
+install_package "jruby-1.6.7.2" "https://s3.amazonaws.com/jruby-org/downloads/1.6.7.2/jruby-bin-1.6.7.2.tar.gz#6f04baa597941e48276a2edbb464afc6801f8f690fb978422e12029b7bfefe18" jruby

--- a/share/ruby-build/jruby-1.6.8
+++ b/share/ruby-build/jruby-1.6.8
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.8" "http://jruby.org.s3.amazonaws.com/downloads/1.6.8/jruby-bin-1.6.8.tar.gz#e3b05f9cf0ba9b02e6cba75d5b62e2abf8ac7a4483c3713dc4eb83e3b8b162d4" jruby
+install_package "jruby-1.6.8" "https://s3.amazonaws.com/jruby-org/downloads/1.6.8/jruby-bin-1.6.8.tar.gz#e3b05f9cf0ba9b02e6cba75d5b62e2abf8ac7a4483c3713dc4eb83e3b8b162d4" jruby

--- a/share/ruby-build/jruby-1.7.0
+++ b/share/ruby-build/jruby-1.7.0
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.0" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0/jruby-bin-1.7.0.tar.gz#1da3292a47dfc51410b007cf52f5997d048440aeb2ab25033f114e46b84af273" jruby
+install_package "jruby-1.7.0" "https://s3.amazonaws.com/jruby-org/downloads/1.7.0/jruby-bin-1.7.0.tar.gz#1da3292a47dfc51410b007cf52f5997d048440aeb2ab25033f114e46b84af273" jruby

--- a/share/ruby-build/jruby-1.7.0-preview1
+++ b/share/ruby-build/jruby-1.7.0-preview1
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.0.preview1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-bin-1.7.0.preview1.tar.gz#155839462fcb8eaab6af49f406499722c8fb82d00127bc6ed4b55d06cb690caf" jruby
+install_package "jruby-1.7.0.preview1" "https://s3.amazonaws.com/jruby-org/downloads/1.7.0.preview1/jruby-bin-1.7.0.preview1.tar.gz#155839462fcb8eaab6af49f406499722c8fb82d00127bc6ed4b55d06cb690caf" jruby

--- a/share/ruby-build/jruby-1.7.0-preview2
+++ b/share/ruby-build/jruby-1.7.0-preview2
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.0.preview2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview2/jruby-bin-1.7.0.preview2.tar.gz#cac0881da9d53905fe591a692583cce1e5c40fbca19f0218b6490ff3305185bb" jruby
+install_package "jruby-1.7.0.preview2" "https://s3.amazonaws.com/jruby-org/downloads/1.7.0.preview2/jruby-bin-1.7.0.preview2.tar.gz#cac0881da9d53905fe591a692583cce1e5c40fbca19f0218b6490ff3305185bb" jruby

--- a/share/ruby-build/jruby-1.7.0-rc1
+++ b/share/ruby-build/jruby-1.7.0-rc1
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.0.RC1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.RC1/jruby-bin-1.7.0.RC1.tar.gz#a52ea970f116a11454a7c77c40b6700765def02ccbea45c16ed8cf110617fe94" jruby
+install_package "jruby-1.7.0.RC1" "https://s3.amazonaws.com/jruby-org/downloads/1.7.0.RC1/jruby-bin-1.7.0.RC1.tar.gz#a52ea970f116a11454a7c77c40b6700765def02ccbea45c16ed8cf110617fe94" jruby

--- a/share/ruby-build/jruby-1.7.0-rc2
+++ b/share/ruby-build/jruby-1.7.0-rc2
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.0.RC2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.0.RC2/jruby-bin-1.7.0.RC2.tar.gz#db409e892782e39584bd2daca8b9fb7e937512cf73b23f3961efa165c09dc895" jruby
+install_package "jruby-1.7.0.RC2" "https://s3.amazonaws.com/jruby-org/downloads/1.7.0.RC2/jruby-bin-1.7.0.RC2.tar.gz#db409e892782e39584bd2daca8b9fb7e937512cf73b23f3961efa165c09dc895" jruby

--- a/share/ruby-build/jruby-1.7.1
+++ b/share/ruby-build/jruby-1.7.1
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.1" "http://jruby.org.s3.amazonaws.com/downloads/1.7.1/jruby-bin-1.7.1.tar.gz#99cda09e0533752f83001c5bb76897d1edf4e58b96603d07e839719087c2a1bc" jruby
+install_package "jruby-1.7.1" "https://s3.amazonaws.com/jruby-org/downloads/1.7.1/jruby-bin-1.7.1.tar.gz#99cda09e0533752f83001c5bb76897d1edf4e58b96603d07e839719087c2a1bc" jruby

--- a/share/ruby-build/jruby-1.7.10
+++ b/share/ruby-build/jruby-1.7.10
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.10" "http://jruby.org.s3.amazonaws.com/downloads/1.7.10/jruby-bin-1.7.10.tar.gz#223285ee2fca5a4825f017b8a441232ec05d3fba5de213336c7ef6b6a36de651" jruby
+install_package "jruby-1.7.10" "https://s3.amazonaws.com/jruby-org/downloads/1.7.10/jruby-bin-1.7.10.tar.gz#223285ee2fca5a4825f017b8a441232ec05d3fba5de213336c7ef6b6a36de651" jruby

--- a/share/ruby-build/jruby-1.7.11
+++ b/share/ruby-build/jruby-1.7.11
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.11" "http://jruby.org.s3.amazonaws.com/downloads/1.7.11/jruby-bin-1.7.11.tar.gz#d634ffc692a8ee5bae513266956609d41d785f912facf11749609a7763120fb3" jruby
+install_package "jruby-1.7.11" "https://s3.amazonaws.com/jruby-org/downloads/1.7.11/jruby-bin-1.7.11.tar.gz#d634ffc692a8ee5bae513266956609d41d785f912facf11749609a7763120fb3" jruby

--- a/share/ruby-build/jruby-1.7.12
+++ b/share/ruby-build/jruby-1.7.12
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.12" "http://jruby.org.s3.amazonaws.com/downloads/1.7.12/jruby-bin-1.7.12.tar.gz#2c15858dbc06d6346a30704fb6dcc779f2e67053566c9c21973f96e309eac609" jruby
+install_package "jruby-1.7.12" "https://s3.amazonaws.com/jruby-org/downloads/1.7.12/jruby-bin-1.7.12.tar.gz#2c15858dbc06d6346a30704fb6dcc779f2e67053566c9c21973f96e309eac609" jruby

--- a/share/ruby-build/jruby-1.7.13
+++ b/share/ruby-build/jruby-1.7.13
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.13" "http://jruby.org.s3.amazonaws.com/downloads/1.7.13/jruby-bin-1.7.13.tar.gz#faa1cd590f32f3cb92044d9abedf66ccea1d93a24236c877810c9b30e1e0577c" jruby
+install_package "jruby-1.7.13" "https://s3.amazonaws.com/jruby-org/downloads/1.7.13/jruby-bin-1.7.13.tar.gz#faa1cd590f32f3cb92044d9abedf66ccea1d93a24236c877810c9b30e1e0577c" jruby

--- a/share/ruby-build/jruby-1.7.14
+++ b/share/ruby-build/jruby-1.7.14
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.14" "http://jruby.org.s3.amazonaws.com/downloads/1.7.14/jruby-bin-1.7.14.tar.gz#6c24d6dcf7a329f105e42293c89aa2d5564afdf145b03a492e8c44a4fbe9c371" jruby
+install_package "jruby-1.7.14" "https://s3.amazonaws.com/jruby-org/downloads/1.7.14/jruby-bin-1.7.14.tar.gz#6c24d6dcf7a329f105e42293c89aa2d5564afdf145b03a492e8c44a4fbe9c371" jruby

--- a/share/ruby-build/jruby-1.7.15
+++ b/share/ruby-build/jruby-1.7.15
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.15" "http://jruby.org.s3.amazonaws.com/downloads/1.7.15/jruby-bin-1.7.15.tar.gz#894a905db860f8789e24a29e5178afedc497beb21ba914e8b1a315b31d6fdd5f" jruby
+install_package "jruby-1.7.15" "https://s3.amazonaws.com/jruby-org/downloads/1.7.15/jruby-bin-1.7.15.tar.gz#894a905db860f8789e24a29e5178afedc497beb21ba914e8b1a315b31d6fdd5f" jruby

--- a/share/ruby-build/jruby-1.7.16
+++ b/share/ruby-build/jruby-1.7.16
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.16" "http://jruby.org.s3.amazonaws.com/downloads/1.7.16/jruby-bin-1.7.16.tar.gz#aa6efc47e7227556ffb60fcb054af06ee62d5abe053ea5f84e0db3158bbd61fc" jruby
+install_package "jruby-1.7.16" "https://s3.amazonaws.com/jruby-org/downloads/1.7.16/jruby-bin-1.7.16.tar.gz#aa6efc47e7227556ffb60fcb054af06ee62d5abe053ea5f84e0db3158bbd61fc" jruby

--- a/share/ruby-build/jruby-1.7.2
+++ b/share/ruby-build/jruby-1.7.2
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.2" "http://jruby.org.s3.amazonaws.com/downloads/1.7.2/jruby-bin-1.7.2.tar.gz#abe8fac0568add96240b1369c30e62480fcc00e1d142a594c52722333d95764b" jruby
+install_package "jruby-1.7.2" "https://s3.amazonaws.com/jruby-org/downloads/1.7.2/jruby-bin-1.7.2.tar.gz#abe8fac0568add96240b1369c30e62480fcc00e1d142a594c52722333d95764b" jruby

--- a/share/ruby-build/jruby-1.7.3
+++ b/share/ruby-build/jruby-1.7.3
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.3" "http://jruby.org.s3.amazonaws.com/downloads/1.7.3/jruby-bin-1.7.3.tar.gz#7809456743e058dc27e650ec62e5b527f51c65f3c5df7ddd3ad7296c74d3e35d" jruby
+install_package "jruby-1.7.3" "https://s3.amazonaws.com/jruby-org/downloads/1.7.3/jruby-bin-1.7.3.tar.gz#7809456743e058dc27e650ec62e5b527f51c65f3c5df7ddd3ad7296c74d3e35d" jruby

--- a/share/ruby-build/jruby-1.7.4
+++ b/share/ruby-build/jruby-1.7.4
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.4" "http://jruby.org.s3.amazonaws.com/downloads/1.7.4/jruby-bin-1.7.4.tar.gz#ef6dead787780f18a43758003689fd9ba40e64abc04cd41a6ff1eaf1557dfa69" jruby
+install_package "jruby-1.7.4" "https://s3.amazonaws.com/jruby-org/downloads/1.7.4/jruby-bin-1.7.4.tar.gz#ef6dead787780f18a43758003689fd9ba40e64abc04cd41a6ff1eaf1557dfa69" jruby

--- a/share/ruby-build/jruby-1.7.5
+++ b/share/ruby-build/jruby-1.7.5
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.5" "http://jruby.org.s3.amazonaws.com/downloads/1.7.5/jruby-bin-1.7.5.tar.gz#9ebd082cf9f29697c76e503e00b79d30e3e9b87071afb8823c3b8b033f5f5723" jruby
+install_package "jruby-1.7.5" "https://s3.amazonaws.com/jruby-org/downloads/1.7.5/jruby-bin-1.7.5.tar.gz#9ebd082cf9f29697c76e503e00b79d30e3e9b87071afb8823c3b8b033f5f5723" jruby

--- a/share/ruby-build/jruby-1.7.6
+++ b/share/ruby-build/jruby-1.7.6
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.6" "http://jruby.org.s3.amazonaws.com/downloads/1.7.6/jruby-bin-1.7.6.tar.gz#16a64c56319fed34ec877cf151f2735c60457abe6c73d9dc32c56cce52b0ce45" jruby
+install_package "jruby-1.7.6" "https://s3.amazonaws.com/jruby-org/downloads/1.7.6/jruby-bin-1.7.6.tar.gz#16a64c56319fed34ec877cf151f2735c60457abe6c73d9dc32c56cce52b0ce45" jruby

--- a/share/ruby-build/jruby-1.7.7
+++ b/share/ruby-build/jruby-1.7.7
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.7" "http://jruby.org.s3.amazonaws.com/downloads/1.7.7/jruby-bin-1.7.7.tar.gz#907b24578604c3eded40b84a6380b7c64ab76a6b76b31cf343afdde8dbfeffd4" jruby
+install_package "jruby-1.7.7" "https://s3.amazonaws.com/jruby-org/downloads/1.7.7/jruby-bin-1.7.7.tar.gz#907b24578604c3eded40b84a6380b7c64ab76a6b76b31cf343afdde8dbfeffd4" jruby

--- a/share/ruby-build/jruby-1.7.8
+++ b/share/ruby-build/jruby-1.7.8
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.8" "http://jruby.org.s3.amazonaws.com/downloads/1.7.8/jruby-bin-1.7.8.tar.gz#034ff3b501605a1d8e740387a5eae193faa96f7d07088b6727d2bcf2892db84a" jruby
+install_package "jruby-1.7.8" "https://s3.amazonaws.com/jruby-org/downloads/1.7.8/jruby-bin-1.7.8.tar.gz#034ff3b501605a1d8e740387a5eae193faa96f7d07088b6727d2bcf2892db84a" jruby

--- a/share/ruby-build/jruby-1.7.9
+++ b/share/ruby-build/jruby-1.7.9
@@ -1,1 +1,1 @@
-install_package "jruby-1.7.9" "http://jruby.org.s3.amazonaws.com/downloads/1.7.9/jruby-bin-1.7.9.tar.gz#c7acd09c932941f04e231d43f47606eb2b6a2d6898ae3dc97dd432dcf1501824" jruby
+install_package "jruby-1.7.9" "https://s3.amazonaws.com/jruby-org/downloads/1.7.9/jruby-bin-1.7.9.tar.gz#c7acd09c932941f04e231d43f47606eb2b6a2d6898ae3dc97dd432dcf1501824" jruby


### PR DESCRIPTION
See https://twitter.com/jruby/status/525726366533443584 which expresses
the desire to see this change.

The CloudFront mirror doesn't use TLS, so currently this only comes into play when the user manually bypasses or changes it. That would be a great next step, and I'd be happy to donate the funds for a certificate if needed.
