### PR TITLE
Use HTTPS when fetching packages from cloudfront

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1097,7 +1097,7 @@ else
 fi
 
 if [ -z "$RUBY_BUILD_MIRROR_URL" ]; then
-  RUBY_BUILD_MIRROR_URL="http://dqw8nmjcqpjn7.cloudfront.net"
+  RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
 else
   RUBY_BUILD_MIRROR_URL="${RUBY_BUILD_MIRROR_URL%/}"
 fi


### PR DESCRIPTION
Fixes sstephenson/ruby-build#662
