### PR TITLE
Add jruby-1.7.16.1

### DIFF
--- a/share/ruby-build/jruby-1.7.16.1
+++ b/share/ruby-build/jruby-1.7.16.1
@@ -1,0 +1,1 @@
+install_package "jruby-1.7.16.1" "https://s3.amazonaws.com/jruby.org/downloads/1.7.16.1/jruby-bin-1.7.16.1.tar.gz#855ed9f2c3c259a309f46b2c2d942615e87b1c3b5dda6911b739ad5a7e688f5b" jruby


### PR DESCRIPTION
1.7.16.1 is a security fix release for CVE-2014-8080. All users are strongly recommended to upgrade.

http://jruby.org/2014/10/28/jruby-1-7-16-1.
