### PR TITLE
Mention 'subversion' in error message when svn is missing

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -419,7 +419,7 @@ fetch_svn() {
   if type svn &>/dev/null; then
     svn co -r "$svn_rev" "$svn_url" "${package_name}" >&4 2>&1
   else
-    echo "error: please install \`svn\` and try again" >&2
+    echo "error: please install Subversion and try again" >&2
     exit 1
   fi
 }


### PR DESCRIPTION
Since the svn binary is brought by the "subversion" package in most systems, we should prompt the user to install the subversion package. Nonetheless there may be users of ruby-build who are unaware of svn being a command of the subversion scm.
