### PR TITLE
Final dist filename change for JRuby 9000.

### DIFF
--- a/share/ruby-build/jruby-9.0.0.0+graal-dev
+++ b/share/ruby-build/jruby-9.0.0.0+graal-dev
@@ -1,1 +1,1 @@
-install_package "jruby-9.0.0.0.dev" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.0.0+graal-$(graal_architecture).dev-bin.tar.gz" jruby
+install_package "jruby-9.0.0.0-SNAPSHOT" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.0.0-SNAPSHOT+graal-$(graal_architecture)-bin.tar.gz" jruby

--- a/share/ruby-build/jruby-9.0.0.0-dev
+++ b/share/ruby-build/jruby-9.0.0.0-dev
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.dev-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-dist-9.0.0.0.dev-bin.tar.gz" jruby
+install_package "jruby-9.0.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-dist-9.0.0.0-SNAPSHOT-bin.tar.gz" jruby

--- a/share/ruby-build/jruby-9000+graal-dev
+++ b/share/ruby-build/jruby-9000+graal-dev
@@ -1,1 +1,1 @@
-install_package "jruby-9.0.0.0.dev" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.0.0+graal-$(graal_architecture).dev-bin.tar.gz" jruby
+install_package "jruby-9.0.0.0-SNAPSHOT" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.0.0-SNAPSHOT+graal-$(graal_architecture)-bin.tar.gz" jruby

--- a/share/ruby-build/jruby-9000-dev
+++ b/share/ruby-build/jruby-9000-dev
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.dev-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-dist-9.0.0.0.dev-bin.tar.gz" jruby
+install_package "jruby-9.0.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-dist-9.0.0.0-SNAPSHOT-bin.tar.gz" jruby


### PR DESCRIPTION
Sorry for the additional change...but as far as I can tell, JRuby 9000 is the only build in here using a snapshot/nightly, and things have been in flux. Once we have releases of 9000 we can update this again and it should be ok.

I would like to clarify, however, how snapshot/nightly builds are supposed to work in ruby-build. As we rev JRuby, the snapshot builds will change.... 9.0.0.1-SNAPSHOT and so on. Should we make the filename the same for snapshots on a given branch or something?
