### PR TITLE
Build scripts for latest 1.9, 2.0 and 2.1 with rails express patches

### DIFF
--- a/share/ruby-build/1.9.3-p551-railsexpress
+++ b/share/ruby-build/1.9.3-p551-railsexpress
@@ -1,0 +1,9 @@
+build_package_patch_ruby_railsexpress() {
+  fetch_git rvm-patchsets git://github.com/skaes/rvm-patchsets.git master
+  for p in rvm-patchsets/patches/ruby/1.9.3/p551/railsexpress/* ; do
+    patch -p1 < $p
+  done
+}
+
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.3-p551" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz#bb5be55cd1f49c95bb05b6f587701376b53d310eb1bb7c76fbd445a1c75b51e8" patch_ruby_railsexpress autoconf standard

--- a/share/ruby-build/2.0.0-p598-railsexpress
+++ b/share/ruby-build/2.0.0-p598-railsexpress
@@ -1,0 +1,9 @@
+build_package_patch_ruby_railsexpress() {
+  fetch_git rvm-patchsets git://github.com/skaes/rvm-patchsets.git master
+  for p in rvm-patchsets/patches/ruby/2.0.0/p598/railsexpress/* ; do
+    patch -p1 < $p
+  done
+}
+
+install_package "openssl-1.0.1j" "https://www.openssl.org/source/openssl-1.0.1j.tar.gz#1b60ca8789ba6f03e8ef20da2293b8dc131c39d83814e775069f02d26354edf3" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.0.0-p598" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz#4136bf7d764cbcc1c7da2824ed2826c3550f2b62af673c79ddbf9049b12095fd" patch_ruby_railsexpress standard verify_openssl

--- a/share/ruby-build/2.1.5-railsexpress
+++ b/share/ruby-build/2.1.5-railsexpress
@@ -1,0 +1,9 @@
+build_package_patch_ruby_railsexpress() {
+  fetch_git rvm-patchsets git://github.com/skaes/rvm-patchsets.git master
+  for p in rvm-patchsets/patches/ruby/2.1.5/railsexpress/* ; do
+    patch -p1 < $p
+  done
+}
+
+install_package "openssl-1.0.1j" "https://www.openssl.org/source/openssl-1.0.1j.tar.gz#1b60ca8789ba6f03e8ef20da2293b8dc131c39d83814e775069f02d26354edf3" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.1.5" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz#4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100" patch_ruby_railsexpress ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Stefan Kaes maintains a set of patches for Ruby: https://github.com/skaes/rvm-patchsets
These add support for memory profiling (most important for development) and various performance enhancements.

Stefan actively maintains these, and has patches for all major versions and many recent patchlevels. I volunteer to maintain rbenv scripts for current and future patchlevels.
