### PR TITLE
safer teardown

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -10,7 +10,7 @@ if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
 fi
 
 teardown() {
-  rm -fr "$TMP"/*
+  rm -fr "${TMP:?}"/*
 }
 
 stub() {


### PR DESCRIPTION
Ensure that if `TMP` is empty, we don't do bad things, like `rm -rf /*`