### PR TITLE
use official CDN for ruby

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1189,7 +1189,7 @@ else
 fi
 
 if [ -z "$RUBY_BUILD_MIRROR_URL" ]; then
-  RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
+  RUBY_BUILD_MIRROR_URL="https://cache.ruby-lang.org"
 else
   RUBY_BUILD_MIRROR_URL="${RUBY_BUILD_MIRROR_URL%/}"
 fi


### PR DESCRIPTION
I have been prepared official CDN named "https://cache.ruby-lang.org" using HTTPS. We should use official CDN instead of third party's CDN. cache.ruby-lang.org provided by fastly has desitributed function for world wide.

@mislav @sferik How do you think this?