### PR TITLE
Don't use cloudfront for cache.ruby-lang.org

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -327,7 +327,14 @@ fetch_tarball() {
     package_url="${package_url%%#*}"
 
     if [ -n "$RUBY_BUILD_MIRROR_URL" ]; then
-      mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
+      case "$package_url" in
+      https://cache.ruby-lang.org/*)
+        # This is Fastly.
+        ;;
+      *)
+        mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
+        ;;
+    esac
     fi
   fi
 


### PR DESCRIPTION
cache.ruby-lang.org is CDN powered by Fastly.
https://www.ruby-lang.org/en/about/website/

```
% host cache.ruby-lang.org
cache.ruby-lang.org is an alias for j.global-ssl.fastly.net.
j.global-ssl.fastly.net has address 103.245.222.68
```