### PR TITLE
Convert MRI definitions to use bz2 tarballs instead of gz ones

### DIFF
--- a/share/ruby-build/1.8.6-p383
+++ b/share/ruby-build/1.8.6-p383
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.6-p383" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.gz#cea6c67f737727007ec89d1c93fd7d0dba035220f981706091b8642d7a43c03a" auto_tcltk standard
+install_package "ruby-1.8.6-p383" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.bz2#c39dd7e211cb7245d08d9a7a3d4fe0c7b9f796a4bed9f92fed500ad58bb53d1a" auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p420
+++ b/share/ruby-build/1.8.6-p420
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.6-p420" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.gz#118e6f24afce8e8a10dced23635168e58da6c9121a21f120c82f425d40a1e321" auto_tcltk standard
+install_package "ruby-1.8.6-p420" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.bz2#5ed3e6b9ebcb51baf59b8263788ec9ec8a65fbb82286d952dd3eb66e22d9a09f" auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.7-p249
+++ b/share/ruby-build/1.8.7-p249
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p249" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.gz#a969f5ec00f096f01650bfa594bc408f2e5cfc3de21b533ab62b4f29eb8ca653" auto_tcltk standard
+install_package "ruby-1.8.7-p249" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.bz2#8b89448fc79df6862660e9f77e884f06c76da28f078d8edd2f17567a615f3af5" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p302
+++ b/share/ruby-build/1.8.7-p302
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p302" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz#5883df5204de70762602ce885b18c8bf6c856d33298c35df9151031b2ce044a1" auto_tcltk standard
+install_package "ruby-1.8.7-p302" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2#3537cc81cc2378a2bc319cd16c4237ddee14a2839cfd1515b27dce108d061a68" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p334
+++ b/share/ruby-build/1.8.7-p334
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p334" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz#68f68d6480955045661fab3be614c504bfcac167d070c6fdbfc9dbe2c5444bc0" auto_tcltk standard
+install_package "ruby-1.8.7-p334" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.bz2#3e7f1a15fb2c205ac9eb0da804983b83bf8c0ffeb2f146d1eb9e0579ea2507da" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p352
+++ b/share/ruby-build/1.8.7-p352
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p352" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.gz#2325b9f9ab2af663469d057c6a1ef59d914a649808e9f6d1a4877c8973c2dad0" auto_tcltk standard
+install_package "ruby-1.8.7-p352" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.bz2#9df4e9108387f7d24a6ab8950984d0c0f8cdbc1dad63194e744f1a176d1c5576" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p357
+++ b/share/ruby-build/1.8.7-p357
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p357" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.gz#2fdcac4eb37b2eba1a4eef392a2922e07a9222fc86d781d92154d716434b962c" auto_tcltk standard
+install_package "ruby-1.8.7-p357" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.bz2#5c64b63a597b4cb545887364e1fd1e0601a7aeb545e576e74a6d8e88a2765a37" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p358
+++ b/share/ruby-build/1.8.7-p358
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p358" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.gz#9e0856d58830e08f1e38233947d859898ae09d4780cb1a502108e41308de33cb" auto_tcltk standard
+install_package "ruby-1.8.7-p358" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.bz2#309ccd427e47ef41a70f96462bd3c2ef2e7911ce1b22432ab502f5bc6e949c1b" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p370
+++ b/share/ruby-build/1.8.7-p370
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p370" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.gz#bcd8db47adf6f5e3822b60a04785eedb1b97d41fbd7cb595d02759faa36581c6" auto_tcltk standard
+install_package "ruby-1.8.7-p370" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.bz2#6359b03a1c8ba16630a96fcb5f972c7af15bd33b752e324cd87964224ab1fe31" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p371
+++ b/share/ruby-build/1.8.7-p371
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p371" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.gz#e60a322f8f2a616eba01651f5ab620e7e48e4f8adfe711aec61cc74a91d54d3c" auto_tcltk standard
+install_package "ruby-1.8.7-p371" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.bz2#2dd0e463cd82039beb75c9b9f4ee20bef5f5b5ff68527008e5aee61cfb3b55e1" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p374
+++ b/share/ruby-build/1.8.7-p374
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p374" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.gz#876eeeaaeeab10cbf4767833547d66d86d6717ef48fd3d89e27db8926a65276c" auto_tcltk standard
+install_package "ruby-1.8.7-p374" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.bz2#b4e34703137f7bfb8761c4ea474f7438d6ccf440b3d35f39cc5e4d4e239c07e3" auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.1-p378" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz#b2960c330aa097c0cf90157a3133c6553ccdf8198e4c717c72cbe87c7f277547"
+install_package "ruby-1.9.1-p378" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.bz2#649e623f77190990d990089a819bc4ee60e21816f682ec37cee98d43adb46e51"
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p430
+++ b/share/ruby-build/1.9.1-p430
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.1-p430" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.gz#6d28120e792a4a1cf32dd5f90c1643ecb48760157322a1bb267dd784d14fcb3a"
+install_package "ruby-1.9.1-p430" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.bz2#8d5cc11d819e476fb651db783f714cc4100922f47447f7acdce87ed769cf9d97"
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.2-p0
+++ b/share/ruby-build/1.9.2-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz#8c0c4e261a921b5c406bf9e76ac23bf3c915651534e9d1b9e8c5d0bee4a7285c"
+install_package "ruby-1.9.2-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2#e9710990ed8c2e794123aba509010471915fb13c27dae0118831d2001a9c8d3b"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p180
+++ b/share/ruby-build/1.9.2-p180
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz#9027a5abaaadc2af85005ed74aeb628ce2326441874bf3d4f1a842663cde04f4"
+install_package "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.bz2#06520c4d4b4512d08000f7dfff11d1fabc1d458c3c289c76a2f1ddb7f5a03f4d"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz#1cc817575c4944d3d78959024320ed1d5b7c2b4931a855772dacad7c3f6ebd7e"
+install_package "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.bz2#403b3093fbe8a08dc69c269753b8c6e7bd8f87fb79a7dd7d676913efe7642487"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p318
+++ b/share/ruby-build/1.9.2-p318
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz#891f707714cb7585ffc76dfaf855e4fcd5b2c0a64655b62d9b23b6a3985a2749"
+install_package "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.bz2#9fcd60aaa118c35ec41c7e9974f1d771b1e632315661fd60f907c21357b082ce"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p320
+++ b/share/ruby-build/1.9.2-p320
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz#39a1f046e8756c1885cde42b234bc608196e50feadf1d0f202f7634f4a4b1245"
+install_package "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.bz2#6777f865cfa21ffdc167fcc4a7da05cb13aab1bd9e59bfcda82c4b32f75e6b51"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p330
+++ b/share/ruby-build/1.9.2-p330
@@ -1,5 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p330" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz#23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9"
+install_package "ruby-1.9.2-p330" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2#6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
-

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,5 +1,5 @@
 require_gcc
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz#3b910042e3561f4296fd95d96bf30322e53eecf083992e5042a7680698cfa34e"
+install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.bz2#ca8ba4e564fc5f98b210a5784e43dfffef9471222849e46f8e848b37e9f38acf"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,5 +1,5 @@
 [ -n "$CC" ] || export CC=cc
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz#8b3c035cf4f0ad6420f447d6a48e8817e5384d0504514939aeb156e251d44cce"
+install_package "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.bz2#c67a59443052b5a9219eb4cee3892bdfbc6f250f0c8e214e02256a4cc7ef5526"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p194
+++ b/share/ruby-build/1.9.3-p194
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.gz#46e2fa80be7efed51bd9cdc529d1fe22ebc7567ee0f91db4ab855438cf4bd8bb"
+install_package "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.bz2#a9d1ea9eaea075c60048369a63b35b3b5a06a30aa214a3d990e0bb71212db8fa"

--- a/share/ruby-build/1.9.3-p286
+++ b/share/ruby-build/1.9.3-p286
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.gz#e94367108751fd6bce79401d947baa66096c757fd3a0856350a2abd05d26d89d"
+install_package "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.bz2#5281656c7a0ae48b64f28d845a96b4dfa16ba1357a911265752787585fb5ea64"

--- a/share/ruby-build/1.9.3-p327
+++ b/share/ruby-build/1.9.3-p327
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz#51dd76462d3f6eb2c659a75e90f949f56da58c42bfb5766212478160b7f23d71"
+install_package "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.bz2#d989465242f9b11a8a3aa8cbd2c75a9b3a8c0ec2f14a087a0c7b51abf164e488"

--- a/share/ruby-build/1.9.3-p362
+++ b/share/ruby-build/1.9.3-p362
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.gz#eb593607862b16a28176ae6d086dbe3bd9bd41935ec999a8cd5ef8773e8239d6"
+install_package "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.bz2#9ed456711a4c0fb2969d9144a81a706d2d506070a35a6d5bc98bb5c8407f9985"

--- a/share/ruby-build/1.9.3-p374
+++ b/share/ruby-build/1.9.3-p374
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.gz#0d0e32a3554867e3eddbb23fbf30a72c4748622e010c23e31302d899fc005574"
+install_package "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.bz2#712944f691b79f22f655547826400c26b13bc8c9e7bdc73a4abea45d5e766d85"

--- a/share/ruby-build/1.9.3-p385
+++ b/share/ruby-build/1.9.3-p385
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.gz#4b15df007f5935ec9696d427d8d6265b121d944d237a2342d5beeeba9b8309d0"
+install_package "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.bz2#f991ee50414dc795696bad0fc5c7b0b94d93b9b38fed943326d20ce4e9dda42b"

--- a/share/ruby-build/1.9.3-p392
+++ b/share/ruby-build/1.9.3-p392
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz#8861ddadb2cd30fb30e42122741130d12f6543c3d62d05906cd41076db70975f"
+install_package "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.bz2#5a7334dfdf62966879bf539b8a9f0b889df6f3b3824fb52a9303c3c3d3a58391"

--- a/share/ruby-build/1.9.3-p429
+++ b/share/ruby-build/1.9.3-p429
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz#d192d1afc46a7ef27b9d0a3c7a67b509048984db2c38907aa82641bdf980acf4"
+install_package "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.bz2#9d8949c24cf6fe810b65fb466076708b842a3b0bac7799f79b7b6a8791dc2a70"

--- a/share/ruby-build/1.9.3-p448
+++ b/share/ruby-build/1.9.3-p448
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz#2f35e186543a03bec5e603296d6d8828b94ca58bab049b67b1ceb61d381bc8a7"
+install_package "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.bz2#a7372230357bfff8e4525fb8019046da521561fe66b02c25d8efc10c9877bc91"

--- a/share/ruby-build/1.9.3-p484
+++ b/share/ruby-build/1.9.3-p484
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz#d684bc3a5ba72cda9ef30039f783c0f8cdc325bae5c8738c7bf05577cbe8f31d"
+install_package "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.bz2#0fdc6e860d0023ba7b94c7a0cf1f7d32908b65b526246de9dfd5bb39d0d7922b"

--- a/share/ruby-build/1.9.3-p545
+++ b/share/ruby-build/1.9.3-p545
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.gz#05fb00ebd374ef800475eb40b71ebc42cc18c1f61f4885c11737f310d3d23111"
+install_package "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.bz2#2533de9f56d62f11c06a02dd32b5ab6d22a8f268c94b8e1e1ade6536adfd1aab"

--- a/share/ruby-build/1.9.3-p547
+++ b/share/ruby-build/1.9.3-p547
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.gz#9ba118e4aba04c430bc4d5efb09b31a0277e101c9fd2ef3b80b9c684d7ae57a1"
+install_package "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.bz2#ef588ed3ff53009b4c1833c83187ae252dd6c20db45e21a326cd4a16a102ef4c"

--- a/share/ruby-build/1.9.3-p550
+++ b/share/ruby-build/1.9.3-p550
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p550" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p550.tar.gz#d6cf008d9f3a9aeed2ef04428f19d66e28aed8a71456f7edba68627d3302cd6b"
+install_package "ruby-1.9.3-p550" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p550.tar.bz2#d3da003896db47fb10ba4d2e0285eea7fe8cdc785b86c02ebad5bc9cdeaa4748"

--- a/share/ruby-build/1.9.3-p551
+++ b/share/ruby-build/1.9.3-p551
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz#bb5be55cd1f49c95bb05b6f587701376b53d310eb1bb7c76fbd445a1c75b51e8"
+install_package "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2#b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e"

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,5 +1,5 @@
 require_gcc
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz#75c2dd57cabd67d8078a61db4ae86b22dc6f262b84460e5b95a0d8a327b36642"
+install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2#a15d7924d74a45ffe48d5421c5fc4ff83b7009676054fa5952b890711afef6fc"
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,4 +1,4 @@
 require_gcc
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.gz#bb1ae474d30e8681df89599520e766270c8e16450efdc01e099810f5e401eb94"
+install_package "ruby-1.9.3-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.bz2#951a8810086abca0e200f81767a518ee2730d6dc9b0cc2c7e3587dcfc3bf5fc8"

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.gz#aff85ba5ceb70303cb7fb616f5db8b95ec47a8820116198d1c866cc4fff151ed" standard verify_openssl
+install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.bz2#c680d392ccc4901c32067576f5b474ee186def2fcd3fcbfa485739168093295f" standard verify_openssl

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.gz#a2fe8d44eac3c27d191ca2d0ee2d871f9aed873c74491b2a8df229bfdc4e5a93" standard verify_openssl
+install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.bz2#0be32aef7a7ab6e3708cc1d65cd3e0a99fa801597194bbedd5799c11d652eb5b" standard verify_openssl

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz#3e71042872c77726409460e8647a2f304083a15ae0defe90d8000a69917e20d3" standard verify_openssl
+install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.bz2#08e3d4b85b8a1118a8e81261f59dd8b4ddcfd70b6ae554e0ec5ceb99c3185e8a" standard verify_openssl

--- a/share/ruby-build/2.0.0-p353
+++ b/share/ruby-build/2.0.0-p353
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz#465afc77d201b5815bb7ce3660a1f5a131f4429a3fa483c126ce66923e4726cc" standard verify_openssl
+install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.bz2#3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9" standard verify_openssl

--- a/share/ruby-build/2.0.0-p451
+++ b/share/ruby-build/2.0.0-p451
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.gz#e6d6900eb4084053058349cfdbf63ad1414b6a8d75d58b47ed81010a9947e73b" standard verify_openssl
+install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2#5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5" standard verify_openssl

--- a/share/ruby-build/2.0.0-p481
+++ b/share/ruby-build/2.0.0-p481
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz#00dd3d72435eb77f2bd94537c1738e5219ca42b6d68df3d4f20c183f4bd12d0f" standard verify_openssl
+install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.bz2#0762dad7e96d8091bdf33b3e3176c2066fbf3dc09dfe85fbf40e74e83c63d8e2" standard verify_openssl

--- a/share/ruby-build/2.0.0-p576
+++ b/share/ruby-build/2.0.0-p576
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.gz#9f5a593d81768c856155be6b2d2e357b961b5c43e04ba54c1ee511987fac2b66" standard verify_openssl
+install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2#8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059" standard verify_openssl

--- a/share/ruby-build/2.0.0-p594
+++ b/share/ruby-build/2.0.0-p594
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.gz#ee515dd7b17cdbc106396cd432f5662bb0b5afc05044469175914aab65f3c6e7" standard verify_openssl
+install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2#e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4" standard verify_openssl

--- a/share/ruby-build/2.0.0-p598
+++ b/share/ruby-build/2.0.0-p598
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz#4136bf7d764cbcc1c7da2824ed2826c3550f2b62af673c79ddbf9049b12095fd" standard verify_openssl
+install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2#67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f" standard verify_openssl

--- a/share/ruby-build/2.0.0-p643
+++ b/share/ruby-build/2.0.0-p643
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.gz#4bd267a4187e4bc25c1db08f9f9bdc0ce595a705569cac460d98c4f5b02e614e" standard verify_openssl
+install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.bz2#1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0" standard verify_openssl

--- a/share/ruby-build/2.0.0-p645
+++ b/share/ruby-build/2.0.0-p645
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz#5e9f8effffe97cba5ef0015feec6e1e5f3bacf6ace78cd1cdf72708cd71cf4ab" standard verify_openssl
+install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.bz2#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" standard verify_openssl

--- a/share/ruby-build/2.0.0-p647
+++ b/share/ruby-build/2.0.0-p647
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz#c88aaf5b4ec72e2cb7d290ff854f04d135939f6134f517002a9d65d5fc5e5bec" standard verify_openssl
+install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.bz2#3c3782e313d1ec3ed06c104eafd133cc54ff5183b991786ece9e957fd6cf1cb9" standard verify_openssl

--- a/share/ruby-build/2.0.0-p648
+++ b/share/ruby-build/2.0.0-p648
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.gz#8690bd6b4949c333b3919755c4e48885dbfed6fd055fe9ef89930bde0d2376f8" standard verify_openssl
+install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2#087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.gz#94b585560c05cb40fadd03e675bd3beb8271c2e976b45644cc765bf854cfd80c" standard verify_openssl
+install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.bz2#79e5605003bf6766fbd123ce00a0027df716ba6d28494c35185909f7e61a5bdf" standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.gz#03d15c7c643f737906c7736820bf4d6f3a71aa8f1dce343284240fee5665f970" standard verify_openssl
+install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.bz2#cea98c000a113f10cb7d55753c759da1f1baa7ca9b3edf75fc19fa5f44bf71a0" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.gz#f9ca3e5b539ccf6bca6875d448a1aec34e73f7c173af180e58500c6f47096916" standard verify_openssl
+install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.bz2#4033ddadd0b44eecfcb7686231ebd109ee6f22bf09797a7e15882b9df0b1ee81" standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.gz#87072ab3e6d393d47f7402682364e4f24efe1c518969795cc01fcdeeb0e646f3" standard verify_openssl
+install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2#d55f897bb04283c5fa80223d96d990fe8ecb598508dd59443b356cbba1f66145" standard verify_openssl

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz#3538ec1f6af96ed9deb04e0965274528162726cc9ba3625dcf23648df872d09d" standard verify_openssl
+install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" standard verify_openssl

--- a/share/ruby-build/2.1.0-preview1
+++ b/share/ruby-build/2.1.0-preview1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.gz#747472fb33bcc529f1000e5320605a7e166a095d3805520b989e73b33c05b046" standard verify_openssl
+install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.bz2#860b90d28b214393fd9d77ac2ad65b384d8249cd59b658c668cf0c7bad1db341" standard verify_openssl

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.gz#a9b1dbc16090ddff8f6c6adbc1fd0473bcae8c69143cecabe65d55f95f6dbbfb" standard verify_openssl
+install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.bz2#780fddf0e3c8a219057d578e83367ecfac5e945054b9f132b3b93ded4802d1ce" standard verify_openssl

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.gz#1b467f13be6d3b3648a4de76b34b748781fe4f504a19c08ffa348c75dd62635e" standard verify_openssl
+install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.bz2#af828bc0fe6aee5ffad0f8f10b48ee25964f54d5118570937ac7cf1c1df0edd3" standard verify_openssl

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz#c843df31ae88ed49f5393142b02b9a9f5a6557453805fd489a76fbafeae88941" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz#f22a6447811a81f3c808d1c2a5ce3b5f5f0955c68c9a749182feb425589e6635" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.3
+++ b/share/ruby-build/2.1.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.gz#0818beb7b10ce9a058cd21d85cfe1dcd233e98b7342d32e9a5d4bebe98347f01" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.4
+++ b/share/ruby-build/2.1.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.gz#bf9952cdeb3a0c6a5a27745c9b4c0e5e264e92b669b2b08efb363f5156549204" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.5
+++ b/share/ruby-build/2.1.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz#4305cc6ceb094df55210d83548dcbeb5117d74eea25196a9b14fa268d354b100" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz#1e1362ae7427c91fa53dc9c05aee4ee200e2d7d8970a891c5bd76bee28d28be4" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz#f59c1596ac39cc7e60126e7d3698c19f482f04060674fdfe0124e1752ba6dd81" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.8
+++ b/share/ruby-build/2.1.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz#afd832b8d5ecb2e3e1477ec6a9408fdf9898ee73e4c5df17a2b2cb36bd1c355d" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0
+++ b/share/ruby-build/2.2.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz#7671e394abfb5d262fbcd3b27a71bf78737c7e9347fa21c39e58b0bb9c4840fc" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2#1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0-preview1
+++ b/share/ruby-build/2.2.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview1.tar.gz#7a49493d148a38eff9ab13e88601686985cadf2de86276ae796f5443deab3abb" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview1.tar.bz2#a3614c389de06b1636d8b919f2cd07e85311486bda2cb226a5549657a3610af5" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0-preview2
+++ b/share/ruby-build/2.2.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.gz#dfcef7b01bd3acb41da6689993ac8dd30e2ecd4fd14bc1a833f46188a9fe2614" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.bz2#9e49583f3fad3888fefc85b719fdb210a88ef54d80f9eac439b7ca4232fa7f0b" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0-rc1
+++ b/share/ruby-build/2.2.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-rc1.tar.gz#a59c8db71b967015ad7c259ba8ef638c7943ec78580412bb86e97791a9322b6b" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-rc1.tar.bz2#e6a1f8d45ea749bdc92eb1269b77ec475bc600b66039ff90d77db8f50820a896" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.1
+++ b/share/ruby-build/2.2.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.gz#5a4de38068eca8919cb087d338c0c2e3d72c9382c804fb27ab746e6c7819ab28" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.bz2#4e5676073246b7ade207be3e80a930567a88100513591a0f19fc38e247370065" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.2
+++ b/share/ruby-build/2.2.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz#5ffc0f317e429e6b29d4a98ac521c3ce65481bfd22a8cf845fa02a7b113d9b44" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.bz2#f3b8ffa6089820ee5bdc289567d365e5748d4170e8aa246d2ea6576f24796535" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.3
+++ b/share/ruby-build/2.2.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz#df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.bz2#c745cb98b29127d7f19f1bf9e0a63c384736f4d303b83c4f4bda3c2ee3c5e41f" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.4
+++ b/share/ruby-build/2.2.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.4" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.gz#b6eff568b48e0fda76e5a36333175df049b204e91217aa32a65153cc0cdcb761" ldflags_dirs standard verify_openssl
+install_package "ruby-2.2.4" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2#31203696adbfdda6f2874a2de31f7c5a1f3bcb6628f4d1a241de21b158cd5c76" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0
+++ b/share/ruby-build/2.3.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.gz#ba5ba60e5f1aa21b4ef8e9bf35b9ddb57286cb546aac4b5a28c71f459467e507" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0-preview1
+++ b/share/ruby-build/2.3.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.gz#dc8f9d48392a2bb226df5f4b4fd2074d81af155cdf3f3799139a6e31e012aefe" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.bz2#42b9c9e1740a5abe2855d11803524370bd95744c8dcb0068572ed5c969ac7f0f" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0-preview2
+++ b/share/ruby-build/2.3.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.gz#cb1c745bda33ba9e812b48c87852571ef6486f985c5e6ff4508a137d1c9734a3" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.bz2#e9b0464e50b2e5c31546e6b8ca8cad71fe2d2146ccf88b7419bbe9626af741cb" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
`bzip2` offers more effective compression algorithm than `gzip`. An user can download less data.