### PR TITLE
Ruby 2.3.0 branch and trunk

### DIFF
--- a/share/ruby-build/2.3.0-dev
+++ b/share/ruby-build/2.3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard verify_openssl
+install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" ldflags_dirs autoconf standard verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
+install_git "ruby-trunk" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
We branched stable version of ruby 2.3.0 today. I switched it in `2.3.0-dev` definition.

and added 2.4.0-dev definition. It version still uses `2.3.0`. but matz will bump version `2.4.0` at few days later :octocat: 