### PR TITLE
Add rbx-2.6.0, rbx-2.7.0, rbx-2.8.0, rbx-2.9.0

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -564,7 +564,20 @@ build_package_rbx() {
       mkdir -p vendor
       ln -s "$RUBY_BUILD_CACHE_PATH" vendor/prebuilt
     fi
-    RUBYOPT="-rubygems $RUBYOPT" ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS "${RUBY_CONFIGURE_OPTS_ARRAY[@]}"
+
+    local opt
+    local -a configure_opts
+    for opt in "${RUBY_CONFIGURE_OPTS_ARRAY[@]}"; do
+      if [[ $opt == --with-openssl-dir=* ]]; then
+        local openssl_dir="${opt#*=}"
+        configure_opts[${#configure_opts[@]}]="--with-lib-dir=${openssl_dir}/lib"
+        configure_opts[${#configure_opts[@]}]="--with-include-dir=${openssl_dir}/include"
+      else
+        configure_opts[${#configure_opts[@]}]="$opt"
+      fi
+    done
+
+    RUBYOPT="-rubygems $RUBYOPT" ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS "${configure_opts[@]}"
     rake install
     fix_rbx_gem_binstubs "$PREFIX_PATH"
     fix_rbx_irb "$PREFIX_PATH"

--- a/share/ruby-build/rbx-2.5.8
+++ b/share/ruby-build/rbx-2.5.8
@@ -1,2 +1,3 @@
 require_llvm 3.5
+install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.5.8" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.8.tar.bz2#d6b411732aa035865f2855845abe5405119560f0979062672d576601de89e59a" rbx

--- a/share/ruby-build/rbx-2.6.0
+++ b/share/ruby-build/rbx-2.6.0
@@ -1,0 +1,3 @@
+require_llvm 3.5
+install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-2.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.6.tar.bz2#f63bbcca7d1bc71b4c20a3bd5748430be001f3a39b14a903d3d4ca39a657cfe0" rbx

--- a/share/ruby-build/rbx-2.7.0
+++ b/share/ruby-build/rbx-2.7.0
@@ -1,0 +1,3 @@
+require_llvm 3.5
+install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-2.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.7.tar.bz2#6f121cccbbd5ad0183024bf2405ca627982d1890307c059c754a1847e19eadd1" rbx

--- a/share/ruby-build/rbx-2.8.0
+++ b/share/ruby-build/rbx-2.8.0
@@ -1,0 +1,3 @@
+require_llvm 3.5
+install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-2.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.8.tar.bz2#93e798b4c79800d0543d8d78aa1066b4285af209ed9908c35e54260c13bc7e9d" rbx

--- a/share/ruby-build/rbx-2.9.0
+++ b/share/ruby-build/rbx-2.9.0
@@ -1,0 +1,3 @@
+require_llvm 3.5
+install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-2.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.9.tar.bz2#9f8ad067ce494d201dae359d132ddac275d0bd13315dc8fdd094c9aa661ce8b1" rbx


### PR DESCRIPTION
Also, support Rubinius linking against Homebrew openssl due to OS X not shipping with system OpenSSL headers anymore.