### PR TITLE
Remove builds of JRuby that bundle Graal

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -639,29 +639,10 @@ build_package_jruby() {
   fix_jruby_shebangs
 }
 
-graal_architecture() {
-  if [ "$(uname -m)" != "x86_64" ]; then
-    echo "no nightly builds available" >&2
-    exit 1
-  fi
-
-  case "$(uname -s)" in
-  "Darwin") echo "macosx-x86_64";;
-  "Linux") echo "linux-x86_64";;
-  *)
-    echo "no nightly builds available" >&2
-    exit 1;;
-  esac
-}
-
 install_jruby_launcher() {
-  # If this version of JRuby has been modified for Graal, don't overwrite the
-  # launcher scripts
-  if ! grep -q graalvm "${PREFIX_PATH}/bin/jruby"; then
-    cd "${PREFIX_PATH}/bin"
-    { ./ruby gem install jruby-launcher
-    } >&4 2>&1
-  fi
+  cd "${PREFIX_PATH}/bin"
+  { ./ruby gem install jruby-launcher
+  } >&4 2>&1
 }
 
 fix_jruby_shebangs() {

--- a/share/ruby-build/jruby-9.0.0.0+graal-dev
+++ b/share/ruby-build/jruby-9.0.0.0+graal-dev
@@ -1,1 +1,0 @@
-install_package "jruby-9.0.0.0-SNAPSHOT" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.0.0-SNAPSHOT+graal-$(graal_architecture)-bin.tar.gz" jruby

--- a/share/ruby-build/jruby-9.0.2.0+graal-dev
+++ b/share/ruby-build/jruby-9.0.2.0+graal-dev
@@ -1,1 +1,0 @@
-install_package "jruby-9.0.2.0-SNAPSHOT" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.2.0-SNAPSHOT+graal-$(graal_architecture)-bin.tar.gz" jruby

--- a/share/ruby-build/jruby-master+graal-dev
+++ b/share/ruby-build/jruby-master+graal-dev
@@ -1,1 +1,0 @@
-install_package "jruby-master" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-master+graal-$(graal_architecture)-bin.tar.gz" jruby

--- a/test/build.bats
+++ b/test/build.bats
@@ -533,22 +533,6 @@ nice gem things
 OUT
 }
 
-@test "JRuby+Graal does not install launchers" {
-  executable "${RUBY_BUILD_CACHE_PATH}/jruby-9000.dev/bin/jruby" <<OUT
-#!${BASH}
-# graalvm
-echo jruby "\$@" >> ../build.log
-OUT
-  cached_tarball "jruby-9000.dev"
-
-  run_inline_definition <<DEF
-install_package "jruby-9000.dev" "http://lafo.ssw.uni-linz.ac.at/jruby-9000+graal-macosx-x86_64.tar.gz" jruby
-DEF
-  assert_success
-
-  assert [ ! -e "$INSTALL_ROOT/build.log" ]
-}
-
 @test "JRuby Java 7 missing" {
   cached_tarball "jruby-9000.dev" bin/jruby
 


### PR DESCRIPTION
Thanks very much for accepting our definition files for JRuby that bundled Graal (our new JIT compiler for Java). This was really useful when there was no other way to get Graal, but now there are official experimental releases available from Oracle https://github.com/jruby/jruby/wiki/Downloading-GraalVM and soon it will be possible to just use an early access of Java 9 https://github.com/jruby/jruby/wiki/Using-Graal-in-JDK-9-EA-Builds, so these bundled versions aren't necessary any more and we can remove them.