### PR TITLE
Add metadata for Rubinius 3.0 aka rbx-3.0.0.

### DIFF
--- a/share/ruby-build/rbx-3.0.0
+++ b/share/ruby-build/rbx-3.0.0
@@ -1,0 +1,3 @@
+require_llvm 3.5
+install_package "openssl-1.0.2e" "https://www.openssl.org/source/openssl-1.0.2e.tar.gz#e23ccafdb75cfcde782da0151731aa2185195ac745eea3846133f2e05c0e0bff" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.0.tar.bz2#fd4c9687af6e29939100610a231f13951ed763a9028c85878505f313857c43ca" rbx


### PR DESCRIPTION
I'm aware of issue #862 but in the meantime, hoping it will get resolved w/o removing rubinius support, here is the file for rbx-3.0.0 — a simple copy from 2.11.0 w/ SHA and filenames edited. It builds and installs fine.

Thanks.