### PR TITLE
add message when bzip2 is missing and package type is bz2

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -342,6 +342,9 @@ fetch_tarball() {
   local package_filename="${package_name}.tar.gz"
 
   if [ "$package_url" != "${package_url%bz2}" ]; then
+    if ! type -p bzip2 >/dev/null; then
+      echo "warning: bzip2 not found; consider installing \`bzip2\` package" >&4
+    fi
     package_filename="${package_filename%.gz}.bz2"
     tar_args="${tar_args/z/j}"
   fi


### PR DESCRIPTION
When installing on a system without bzip2, build would fail with little help. Added a message to the log file that states bzip2 is missing from path, and when build fails, try installing bzip2.

#870 has further details