### PR TITLE
Clean up usage documentation

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -5,6 +5,7 @@
 # Usage: rbenv install [-f|-s] [-kpv] <version>
 #        rbenv install [-f|-s] [-kpv] <definition-file>
 #        rbenv install -l|--list
+#        rbenv install --version
 #
 #   -l/--list          List all available versions
 #   -f/--force         Install even if the version appears to be installed already
@@ -16,6 +17,7 @@
 #                      (defaults to $RBENV_ROOT/sources)
 #   -p/--patch         Apply a patch from stdin before building
 #   -v/--verbose       Verbose mode: print compilation status to stdout
+#   --version          Show version of ruby-build
 #
 # For detailed information on installing Ruby versions with
 # ruby-build, including a list of environment variables for adjusting

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -45,8 +45,9 @@ if [ "$1" = "--complete" ]; then
   echo --force
   echo --skip-existing
   echo --keep
-  echo --verbose
   echo --patch
+  echo --verbose
+  echo --version
   exec ruby-build --definitions
 fi
 

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -2,8 +2,8 @@
 #
 # Summary: Install a Ruby version using ruby-build
 #
-# Usage: rbenv install [-f] [-kvp] <version>
-#        rbenv install [-f] [-kvp] <definition-file>
+# Usage: rbenv install [-f|-s] [-kpv] <version>
+#        rbenv install [-f|-s] [-kpv] <definition-file>
 #        rbenv install -l|--list
 #
 #   -l/--list          List all available versions
@@ -14,8 +14,8 @@
 #
 #   -k/--keep          Keep source tree in $RBENV_BUILD_ROOT after installation
 #                      (defaults to $RBENV_ROOT/sources)
-#   -v/--verbose       Verbose mode: print compilation status to stdout
 #   -p/--patch         Apply a patch from stdin before building
+#   -v/--verbose       Verbose mode: print compilation status to stdout
 #
 # For detailed information on installing Ruby versions with
 # ruby-build, including a list of environment variables for adjusting

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Usage: ruby-build [-kvp] <definition> <prefix>
+# Usage: ruby-build [-kpv] <definition> <prefix>
 #        ruby-build --definitions
 #
 #   -k/--keep        Do not remove source tree after installation
-#   -v/--verbose     Verbose mode: print compilation status to stdout
 #   -p/--patch       Apply a patch from stdin before building
+#   -v/--verbose     Verbose mode: print compilation status to stdout
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
 #   --definitions    List all built-in definitions

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -2,6 +2,7 @@
 #
 # Usage: ruby-build [-kpv] <definition> <prefix>
 #        ruby-build --definitions
+#        ruby-build --version
 #
 #   -k/--keep        Do not remove source tree after installation
 #   -p/--patch       Apply a patch from stdin before building
@@ -9,6 +10,7 @@
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
 #   --definitions    List all built-in definitions
+#   --version        Show version of ruby-build
 #
 
 RUBY_BUILD_VERSION="20160111"

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -145,8 +145,9 @@ OUT
 --force
 --skip-existing
 --keep
---verbose
 --patch
+--verbose
+--version
 
 ${RBENV_ROOT}/plugins/bar/share/ruby-build
 ${RBENV_ROOT}/plugins/foo/share/ruby-build


### PR DESCRIPTION
- Add missing `-4` and `-6` flags to ruby-build usage
- Add missing `--version` flag to ruby-build and rbenv-install usage
- Order flags alphabetically
- Add missing `-s` flag to rbenv-install usage

How should rbenv-install usage show that `-f` and `-s` are mutually exclusive? (Or rather that `-s` actually takes precedence?) Related, should the code be changed to error out (with usage help) when both `-f` and `-s` are present?