### PR TITLE
Rbenv cleanup

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -74,9 +74,6 @@ unset HAS_PATCH
 parse_options "$@"
 for option in "${OPTIONS[@]}"; do
   case "$option" in
-  "h" | "help" )
-    usage 0
-    ;;
   "l" | "list" )
     echo "Available versions:"
     definitions | indent

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -24,10 +24,6 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-if [ -z "$RBENV_ROOT" ]; then
-  RBENV_ROOT="${HOME}/.rbenv"
-fi
-
 # Add `share/ruby-build/` directory from each rbenv plugin to the list of
 # paths where build definitions are looked up.
 shopt -s nullglob

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -27,10 +27,6 @@ if [ -z "$RBENV_ROOT" ]; then
   RBENV_ROOT="${HOME}/.rbenv"
 fi
 
-if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
-  usage 0
-fi
-
 unset FORCE
 if [ "$1" = "-f" ] || [ "$1" = "--force" ]; then
   FORCE=true

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -23,10 +23,6 @@ usage() {
   [ -z "$1" ] || exit "$1"
 }
 
-if [ -z "$RBENV_ROOT" ]; then
-  RBENV_ROOT="${HOME}/.rbenv"
-fi
-
 unset FORCE
 if [ "$1" = "-f" ] || [ "$1" = "--force" ]; then
   FORCE=true

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -171,15 +171,6 @@ OUT
   unstub rbenv-help
 }
 
-@test "show help for rbenv-install" {
-  stub_ruby_build
-  stub rbenv-help 'install : true'
-
-  run rbenv-install -h
-  assert_success
-  unstub rbenv-help
-}
-
 @test "rbenv-install has usage help preface" {
   run head "$(which rbenv-install)"
   assert_output_contains 'Usage: rbenv install'
@@ -198,14 +189,6 @@ OUT
 
   run rbenv-uninstall 2.1.1 2.1.2
   assert_failure
-  unstub rbenv-help
-}
-
-@test "show help for rbenv-uninstall" {
-  stub rbenv-help 'uninstall : true'
-
-  run rbenv-uninstall -h
-  assert_success
   unstub rbenv-help
 }
 


### PR DESCRIPTION
rbenv 1.0 now handles `--help` automatically so we don't need to handle it manually. (also remove the tests for it) Downside is that rbenv doesn't handle `-h`. However, I think it's preferable to lose the `-h` flag and slim the code down. Doing so also makes rbenv-install/rbenv-uninstall more consistent with the other rbenv plugins that have only ever supported `--help`.

Additionally, rbenv ensures `RBENV_ROOT` is set for the plugins, so there is no need to provide the `~/.rbenv` fallback.