### PR TITLE
rbenv ensures RBENV_ROOT is set for us

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -24,10 +24,6 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-if [ -z "$RBENV_ROOT" ]; then
-  RBENV_ROOT="${HOME}/.rbenv"
-fi
-
 # Add `share/ruby-build/` directory from each rbenv plugin to the list of
 # paths where build definitions are looked up.
 shopt -s nullglob

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -23,10 +23,6 @@ usage() {
   [ -z "$1" ] || exit "$1"
 }
 
-if [ -z "$RBENV_ROOT" ]; then
-  RBENV_ROOT="${HOME}/.rbenv"
-fi
-
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   usage 0
 fi


### PR DESCRIPTION
Handled by rbenv itself: https://github.com/rbenv/rbenv/blob/3997a394d975136f468be196941492d3d0ef5143/libexec/rbenv#L53-L58

Extracted from #880