### PR TITLE
Checksum refactor

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -265,14 +265,16 @@ verify_checksum() {
   [ -e "$filename" ] || return 0
 
   case "${#expected_checksum}" in
-  # If expected checksum is empty, return success
-  0) return 0 ;;
-  # MD5
+  0) return 0 ;; # empty checksum; return success
   32) checksum_command="compute_md5" ;;
-  # SHA2 256
   64) checksum_command="compute_sha2" ;;
-  # unknown checksum algorithm, return failure
-  *) return 1 ;;
+  *)
+    { echo
+      echo "unexpected checksum length: ${#expected_checksum} (${expected_checksum})"
+      echo "expected 0 (no checksum), 32 (MD5), or 64 (SHA2-256)"
+      echo
+    } >&4
+    return 1 ;;
   esac
 
   # If chosen provided checksum algorithm isn't supported, return success

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -246,6 +246,12 @@ compute_md5() {
   fi
 }
 
+declare -a HAS_CHECKSUM_SUPPORT
+has_checksum_support() {
+  local checksum_command="$1"
+  return ${HAS_CHECKSUM_SUPPORT[$checksum_command]:=$(echo test | "$checksum_command" >/dev/null; echo $?)}
+}
+
 verify_checksum() {
   local checksum_command
   local filename="$1"
@@ -255,21 +261,18 @@ verify_checksum() {
   [ -e "$filename" ] || return 0
 
   case "${#expected_checksum}" in
-  0) # If there's no expected checksum, return success
-    return 0
-    ;;
-  32) # MD5
-    [ -n "$HAS_MD5_SUPPORT" ] || return 0
-    checksum_command="compute_md5"
-    ;;
-  64) # SHA2 256
-    [ -n "$HAS_SHA2_SUPPORT" ] || return 0
-    checksum_command="compute_sha2"
-    ;;
-  *) # unknown checksum algorithm, return failure
-    return 1
-    ;;
+  # If expected checksum is empty, return success
+  0) return 0 ;;
+  # MD5
+  32) checksum_command="compute_md5" ;;
+  # SHA2 256
+  64) checksum_command="compute_sha2" ;;
+  # unknown checksum algorithm, return failure
+  *) return 1 ;;
   esac
+
+  # If chosen provided checksum algorithm isn't supported, return success
+  has_checksum_support "$checksum_command" || return 0
 
   # If the computed checksum is empty, return failure
   local computed_checksum=`echo "$($checksum_command < "$filename")" | tr [A-Z] [a-z]`
@@ -1225,21 +1228,8 @@ else
   RUBY_BUILD_DEFAULT_MIRROR=
 fi
 
-if [ -n "$RUBY_BUILD_SKIP_MIRROR" ]; then
+if [ -n "$RUBY_BUILD_SKIP_MIRROR" ] || ! has_checksum_support compute_sha2; then
   unset RUBY_BUILD_MIRROR_URL
-fi
-
-if echo test | compute_sha2 >/dev/null; then
-  HAS_SHA2_SUPPORT=1
-else
-  unset HAS_SHA2_SUPPORT
-  unset RUBY_BUILD_MIRROR_URL
-fi
-
-if echo test | compute_md5 >/dev/null; then
-  HAS_MD5_SUPPORT=1
-else
-  unset HAS_MD5_SUPPORT
 fi
 
 SEED="$(date "+%Y%m%d%H%M%S").$$"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -247,7 +247,7 @@ compute_md5() {
 }
 
 verify_checksum() {
-  local checksum_command="compute_sha2"
+  local checksum_command
 
   # If the specified filename doesn't exist, return success
   local filename="$1"
@@ -265,6 +265,9 @@ verify_checksum() {
   64) # SHA2 256
     [ -n "$HAS_SHA2_SUPPORT" ] || return 0
     checksum_command="compute_sha2"
+    ;;
+  *) # unknown checksum algorithm, return failure
+    return 1
     ;;
   esac
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -259,11 +259,12 @@ verify_checksum() {
   local expected_checksum=`echo "$2" | tr [A-Z] [a-z]`
   [ -n "$expected_checksum" ] || return 0
 
-  # If the checksum length is 32 chars, assume MD5, otherwise SHA2
-  if [ "${#expected_checksum}" -eq 32 ]; then
+  case "${#expected_checksum}" in
+  32) # MD5
     [ -n "$HAS_MD5_SUPPORT" ] || return 0
     checksum_command="compute_md5"
-  fi
+    ;;
+  esac
 
   # If the computed checksum is empty, return failure
   local computed_checksum=`echo "$($checksum_command < "$filename")" | tr [A-Z] [a-z]`

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -248,16 +248,16 @@ compute_md5() {
 
 verify_checksum() {
   local checksum_command
+  local filename="$1"
+  local expected_checksum="$(echo "$2" | tr [A-Z] [a-z])"
 
   # If the specified filename doesn't exist, return success
-  local filename="$1"
   [ -e "$filename" ] || return 0
 
-  # If there's no expected checksum, return success
-  local expected_checksum="$(echo "$2" | tr [A-Z] [a-z])"
-  [ -n "$expected_checksum" ] || return 0
-
   case "${#expected_checksum}" in
+  0) # If there's no expected checksum, return success
+    return 0
+    ;;
   32) # MD5
     [ -n "$HAS_MD5_SUPPORT" ] || return 0
     checksum_command="compute_md5"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -247,8 +247,6 @@ compute_md5() {
 }
 
 verify_checksum() {
-  # If there's no SHA2 support, return success
-  [ -n "$HAS_SHA2_SUPPORT" ] || return 0
   local checksum_command="compute_sha2"
 
   # If the specified filename doesn't exist, return success
@@ -256,13 +254,17 @@ verify_checksum() {
   [ -e "$filename" ] || return 0
 
   # If there's no expected checksum, return success
-  local expected_checksum=`echo "$2" | tr [A-Z] [a-z]`
+  local expected_checksum="$(echo "$2" | tr [A-Z] [a-z])"
   [ -n "$expected_checksum" ] || return 0
 
   case "${#expected_checksum}" in
   32) # MD5
     [ -n "$HAS_MD5_SUPPORT" ] || return 0
     checksum_command="compute_md5"
+    ;;
+  64) # SHA2 256
+    [ -n "$HAS_SHA2_SUPPORT" ] || return 0
+    checksum_command="compute_sha2"
     ;;
   esac
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -246,10 +246,14 @@ compute_md5() {
   fi
 }
 
-declare -a HAS_CHECKSUM_SUPPORT
 has_checksum_support() {
   local checksum_command="$1"
-  return ${HAS_CHECKSUM_SUPPORT[$checksum_command]:=$(echo test | "$checksum_command" >/dev/null; echo $?)}
+  local has_checksum_var="HAS_CHECKSUM_SUPPORT_${checksum_command}"
+
+  if [ -z "${!has_checksum_var+defined}" ]; then
+    printf -v "$has_checksum_var" "$(echo test | "$checksum_command" >/dev/null; echo $?)"
+  fi
+  return "${!has_checksum_var}"
 }
 
 verify_checksum() {

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -10,7 +10,6 @@ setup() {
 
 
 @test "packages are saved to download cache" {
-  stub shasum true
   stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
@@ -19,12 +18,10 @@ setup() {
   [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
   unstub curl
-  unstub shasum
 }
 
 
 @test "cached package without checksum" {
-  stub shasum true
   stub curl
 
   cp "${FIXTURE_ROOT}/package-1.0.0.tar.gz" "$RUBY_BUILD_CACHE_PATH"
@@ -35,7 +32,6 @@ setup() {
   [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
   unstub curl
-  unstub shasum
 }
 
 
@@ -79,7 +75,6 @@ setup() {
 
 
 @test "nonexistent cache directory is ignored" {
-  stub shasum true
   stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   export RUBY_BUILD_CACHE_PATH="${TMP}/nonexistent"
@@ -91,5 +86,4 @@ setup() {
   [ ! -d "$RUBY_BUILD_CACHE_PATH" ]
 
   unstub curl
-  unstub shasum
 }

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -6,7 +6,6 @@ export RUBY_BUILD_CACHE_PATH=
 
 
 @test "package URL without checksum" {
-  stub shasum true
   stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
@@ -14,7 +13,6 @@ export RUBY_BUILD_CACHE_PATH=
   [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
-  unstub shasum
 }
 
 

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -141,3 +141,16 @@ DEF
 
   unstub shasum
 }
+
+@test "package URL with checksum of unexpected length" {
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+
+  run_inline_definition <<DEF
+install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#checksum_of_unexpected_length" copy
+DEF
+
+  assert_failure
+  [ ! -f "${INSTALL_ROOT}/bin/package" ]
+  assert_output_contains "unexpected checksum length: 29 (checksum_of_unexpected_length)"
+  assert_output_contains "expected 0 (no checksum), 32 (MD5), or 64 (SHA2-256)"
+}

--- a/test/fixtures/definitions/with-invalid-checksum
+++ b/test/fixtures/definitions/with-invalid-checksum
@@ -1,1 +1,1 @@
-install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#invalid" copy
+install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#invalid_64_character_checksum_0000000000000000000000000000000000" copy


### PR DESCRIPTION
Per the discussion from #881, this PR is the refactor of checksum handling.

- `has_checksum_support` function tests for support of the provided checksum algorithm, memoizing results
- `verify_checksum` now picks the algorithm based on checksum length. unexpected lengths no longer default to sha1(256bit), but rather error out. (They would error out eventually, anyway, when the resulting checksum doesn't match.)
- `HAS_X_SUPPORT` variables are no longer necessary
- algorithm support is now checked lazily; it is no longer checked if it wouldn't be used