### PR TITLE
Leverage assertion test helpers

### DIFF
--- a/test/build.bats
+++ b/test/build.bats
@@ -546,7 +546,7 @@ install_package "jruby-9000.dev" "http://lafo.ssw.uni-linz.ac.at/jruby-9000+graa
 DEF
   assert_success
 
-  assert [ ! -e "$INSTALL_ROOT/build.log" ]
+  refute [ -e "$INSTALL_ROOT/build.log" ]
 }
 
 @test "JRuby Java 7 missing" {

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -15,7 +15,7 @@ setup() {
   install_fixture definitions/without-checksum
 
   assert_success
-  [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
+  assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
   unstub curl
 }
@@ -29,7 +29,7 @@ setup() {
   install_fixture definitions/without-checksum
 
   assert_success
-  [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
+  assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
   unstub curl
 }
@@ -44,8 +44,8 @@ setup() {
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
-  [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
   unstub curl
   unstub shasum
@@ -65,9 +65,9 @@ setup() {
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
-  [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
-  diff -q "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" "${FIXTURE_ROOT}/package-1.0.0.tar.gz"
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
+  assert diff -q "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" "${FIXTURE_ROOT}/package-1.0.0.tar.gz"
 
   unstub curl
   unstub shasum
@@ -82,8 +82,8 @@ setup() {
   install_fixture definitions/without-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
-  [ ! -d "$RUBY_BUILD_CACHE_PATH" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ ! -d "$RUBY_BUILD_CACHE_PATH" ]
 
   unstub curl
 }

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -83,7 +83,7 @@ setup() {
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
-  assert [ ! -d "$RUBY_BUILD_CACHE_PATH" ]
+  refute [ -d "$RUBY_BUILD_CACHE_PATH" ]
 
   unstub curl
 }

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -38,7 +38,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-invalid-checksum
 
   assert_failure
-  assert [ ! -f "${INSTALL_ROOT}/bin/package" ]
+  refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -94,7 +94,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-checksum
 
   assert_failure
-  assert [ ! -f "${INSTALL_ROOT}/bin/package" ]
+  refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -151,7 +151,7 @@ install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.g
 DEF
 
   assert_failure
-  assert [ ! -f "${INSTALL_ROOT}/bin/package" ]
+  refute [ -f "${INSTALL_ROOT}/bin/package" ]
   assert_output_contains "unexpected checksum length: 29 (checksum_of_unexpected_length)"
   assert_output_contains "expected 0 (no checksum), 32 (MD5), or 64 (SHA2-256)"
 }

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -9,8 +9,9 @@ export RUBY_BUILD_CACHE_PATH=
   stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
-  [ "$status" -eq 0 ]
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  assert_success
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
 }
@@ -23,7 +24,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -37,7 +38,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-invalid-checksum
 
   assert_failure
-  [ ! -f "${INSTALL_ROOT}/bin/package" ]
+  assert [ ! -f "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -51,7 +52,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -65,7 +66,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-md5-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub md5
@@ -79,7 +80,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-md5-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub md5
@@ -93,7 +94,7 @@ export RUBY_BUILD_CACHE_PATH=
   install_fixture definitions/with-checksum
 
   assert_failure
-  [ ! -f "${INSTALL_ROOT}/bin/package" ]
+  assert [ ! -f "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -115,7 +116,7 @@ install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.g
 DEF
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub shasum
 }
@@ -137,7 +138,7 @@ install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.g
 DEF
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub shasum
 }
@@ -150,7 +151,7 @@ install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.g
 DEF
 
   assert_failure
-  [ ! -f "${INSTALL_ROOT}/bin/package" ]
+  assert [ ! -f "${INSTALL_ROOT}/bin/package" ]
   assert_output_contains "unexpected checksum length: 29 (checksum_of_unexpected_length)"
   assert_output_contains "expected 0 (no checksum), 32 (MD5), or 64 (SHA2-256)"
 }

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -13,7 +13,7 @@ NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
 
 @test "custom RUBY_BUILD_ROOT: nonexistent" {
   export RUBY_BUILD_ROOT="$TMP"
-  assert [ ! -e "${RUBY_BUILD_ROOT}/share/ruby-build" ]
+  refute [ -e "${RUBY_BUILD_ROOT}/share/ruby-build" ]
   run ruby-build --definitions
   assert_success ""
 }

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -52,5 +52,5 @@ rehashed
 after.
 OUT
 
-  assert [ ! -d "${RBENV_ROOT}/versions/2.0.0" ]
+  refute [ -d "${RBENV_ROOT}/versions/2.0.0" ]
 }

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -14,7 +14,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   echo "$output" >&2
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -28,7 +28,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -46,7 +46,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -64,7 +64,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -84,7 +84,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   echo "$output" >&2
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum
@@ -102,7 +102,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   install_fixture definitions/with-checksum
 
   assert_success
-  [ -x "${INSTALL_ROOT}/bin/package" ]
+  assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
   unstub curl
   unstub shasum

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -97,7 +97,7 @@ OUT
 }
 
 @test "no build definitions from plugins" {
-  assert [ ! -e "${RBENV_ROOT}/plugins" ]
+  refute [ -e "${RBENV_ROOT}/plugins" ]
   stub_ruby_build 'echo $RUBY_BUILD_DEFINITIONS'
 
   run rbenv-install 2.1.2

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -71,6 +71,12 @@ assert() {
   fi
 }
 
+refute() {
+  if "$@"; then
+    flunk "expected to fail: $@"
+  fi
+}
+
 flunk() {
   { if [ "$#" -eq 0 ]; then cat -
     else echo "$@"


### PR DESCRIPTION
The current test suite uses the `assert` inconsistently. In some cases, `assert` is used. In others, the bash test built-in is used (or other 'naked' command).

The assert helper provides a marginal improvement in the error output when it fails, but this is minimal. Rather, I think the assert (and refute) test helpers improve the clarity of the test itself in signifiying the purpose of the commands. It helps clarify the arrange/act/assert sub-sections of each test.