### PR TITLE
New urls for old Rubinius versions and unavailable versions removed

### DIFF
--- a/share/ruby-build/rbx-1.2.4
+++ b/share/ruby-build/rbx-1.2.4
@@ -1,3 +1,0 @@
-require_llvm 2.8
-install_package "rubinius-1.2.4" "https://s3.amazonaws.com/asset.rubini.us/rubinius-1.2.4-20110705.tar.gz#d474fb6f50292bff5211aaa80b1cead1fb3ed5c7c49223c51fddb8ffc5c3f23d" rbx
-install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/rbx-2.0.0
+++ b/share/ruby-build/rbx-2.0.0
@@ -1,3 +1,0 @@
-require_llvm 3.2
-install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_package "rubinius-2.0.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.0.0.tar.bz2#df039c7c52e9e42a2f3e0d0b67bf2c9b255769d1f8c3bac2333469ca8c0e04c4" rbx

--- a/share/ruby-build/rbx-2.0.0-dev
+++ b/share/ruby-build/rbx-2.0.0-dev
@@ -1,3 +1,0 @@
-require_llvm 3.2
-install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_git "rubinius-2.0.0-dev" "https://github.com/rubinius/rubinius.git" "master" rbx

--- a/share/ruby-build/rbx-2.0.0-rc1
+++ b/share/ruby-build/rbx-2.0.0-rc1
@@ -1,3 +1,0 @@
-require_llvm 3.2
-install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_package "rubinius-release-2.0.0-rc1" "https://nodeload.github.com/rubinius/rubinius/tar.gz/release-2.0.0-rc1#ac1f5a657682904ec227fe5e2410dbdfbfa0abf86cdee722c81fa6b3609c8ab3" rbx

--- a/share/ruby-build/rbx-2.1.0
+++ b/share/ruby-build/rbx-2.1.0
@@ -1,3 +1,0 @@
-require_llvm 3.2
-install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_package "rubinius-2.1.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.1.0.tar.bz2#78d7c2af7ebdf9b477a682cf4793e56e4139abed3cd752282e422d56e63b65b6" rbx

--- a/share/ruby-build/rbx-2.1.1
+++ b/share/ruby-build/rbx-2.1.1
@@ -1,3 +1,0 @@
-require_llvm 3.2
-install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_package "rubinius-2.1.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.1.1.tar.bz2#e142c3f201e4ae9f3a6e6671298baabbd9bd906509c663adcf080bff4181ee96" rbx

--- a/share/ruby-build/rbx-2.2.0
+++ b/share/ruby-build/rbx-2.2.0
@@ -1,2 +1,0 @@
-require_llvm 3.2
-install_package "rubinius-2.2.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.0.tar.bz2#50e214b4d2f18d06453b8ef30dfd8268c5e94f8e97ccae877b90457d4c2b9a7e" rbx

--- a/share/ruby-build/rbx-2.2.1
+++ b/share/ruby-build/rbx-2.2.1
@@ -1,2 +1,0 @@
-require_llvm 3.2
-install_package "rubinius-2.2.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.1.tar.bz2#2a2a4705cf517470b86b4a8e27e16b11ec363789b690411c792e0f8908c06cb0" rbx

--- a/share/ruby-build/rbx-2.2.10
+++ b/share/ruby-build/rbx-2.2.10
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.10" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.10.tar.bz2#3cb1a6ab2eba19b6dc84734666bb17a34332d247641b1a88b4c9324c69347780" rbx
+install_package "rubinius-2.2.10" "https://github.com/rubinius/rubinius/releases/download/v2.2.10/rubinius-2.2.10.tar.bz2#3cb1a6ab2eba19b6dc84734666bb17a34332d247641b1a88b4c9324c69347780" rbx

--- a/share/ruby-build/rbx-2.2.2
+++ b/share/ruby-build/rbx-2.2.2
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.2" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.2.tar.bz2#a49d596f889405e4fc511da64b8afe5eccfafdcee5ea99be15d3ad36290ec2ba" rbx
+install_package "rubinius-2.2.2" "https://github.com/rubinius/rubinius/releases/download/v2.2.2/rubinius-2.2.2.tar.bz2#a49d596f889405e4fc511da64b8afe5eccfafdcee5ea99be15d3ad36290ec2ba" rbx

--- a/share/ruby-build/rbx-2.2.3
+++ b/share/ruby-build/rbx-2.2.3
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.3" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.3.tar.bz2#b3426aa6996420f1d9d8a7926a94160b84d8bdf725793c64462b27b74f2f2acf" rbx
+install_package "rubinius-2.2.3" "https://github.com/rubinius/rubinius/releases/download/v2.2.3/rubinius-2.2.3.tar.bz2#b3426aa6996420f1d9d8a7926a94160b84d8bdf725793c64462b27b74f2f2acf" rbx

--- a/share/ruby-build/rbx-2.2.4
+++ b/share/ruby-build/rbx-2.2.4
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.4" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.4.tar.bz2#7d06d63d12d9eecff196d8f53953bd520c17fbb9baa921c5481c43af8129d85e" rbx
+install_package "rubinius-2.2.4" "https://github.com/rubinius/rubinius/releases/download/v2.2.4/rubinius-2.2.4.tar.bz2#7d06d63d12d9eecff196d8f53953bd520c17fbb9baa921c5481c43af8129d85e" rbx

--- a/share/ruby-build/rbx-2.2.5
+++ b/share/ruby-build/rbx-2.2.5
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.5" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.5.tar.bz2#42cfae89d481dfa5e0ccb53a67720f109fc6c2e1b6ca68a8ae9676be6d0457de" rbx
+install_package "rubinius-2.2.5" "https://github.com/rubinius/rubinius/releases/download/v2.2.5/rubinius-2.2.5.tar.bz2#42cfae89d481dfa5e0ccb53a67720f109fc6c2e1b6ca68a8ae9676be6d0457de" rbx

--- a/share/ruby-build/rbx-2.2.6
+++ b/share/ruby-build/rbx-2.2.6
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.6" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.6.tar.bz2#8ad2cada05a20c708379c75607fd0c8259623b3699d36be41e509052164eb103" rbx
+install_package "rubinius-2.2.6" "https://github.com/rubinius/rubinius/releases/download/v2.2.6/rubinius-2.2.6.tar.bz2#8ad2cada05a20c708379c75607fd0c8259623b3699d36be41e509052164eb103" rbx

--- a/share/ruby-build/rbx-2.2.7
+++ b/share/ruby-build/rbx-2.2.7
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.7" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.7.tar.bz2#e1244b60ed790a3a33a7126a587c35acd041dcb2022b894833518490e872dc3d" rbx
+install_package "rubinius-2.2.7" "https://github.com/rubinius/rubinius/releases/download/v2.2.7/rubinius-2.2.7.tar.bz2#e1244b60ed790a3a33a7126a587c35acd041dcb2022b894833518490e872dc3d" rbx

--- a/share/ruby-build/rbx-2.2.8
+++ b/share/ruby-build/rbx-2.2.8
@@ -1,0 +1,2 @@
+require_llvm 3.2
+install_package "rubinius-2.2.8" "https://github.com/rubinius/rubinius/releases/download/v2.2.8/rubinius-2.2.8.tar.bz2#dc29a67016eb6c7c2e3d0fd256594cf40d88f3b29989c0099fef2dcecf251fc8" rbx

--- a/share/ruby-build/rbx-2.2.9
+++ b/share/ruby-build/rbx-2.2.9
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.9" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.9.tar.bz2#7b01a7f2508167e73b5273b4e55e6616fc7fd975e79c84c4d2e3ef83d849d2ce" rbx
+install_package "rubinius-2.2.9" "https://github.com/rubinius/rubinius/releases/download/v2.2.9/rubinius-2.2.9.tar.bz2#7b01a7f2508167e73b5273b4e55e6616fc7fd975e79c84c4d2e3ef83d849d2ce" rbx

--- a/share/ruby-build/rbx-2.3.0
+++ b/share/ruby-build/rbx-2.3.0
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.3.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.3.0.tar.bz2#9953c3af5e9694540859eaf55164a38d0c32c3ad35457e4351d20c28a25fecaa" rbx
+install_package "rubinius-2.3.0" "https://github.com/rubinius/rubinius/releases/download/v2.3.0/rubinius-2.3.0.tar.bz2#9953c3af5e9694540859eaf55164a38d0c32c3ad35457e4351d20c28a25fecaa" rbx

--- a/share/ruby-build/rbx-2.4.0
+++ b/share/ruby-build/rbx-2.4.0
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.4.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.4.0.tar.bz2#89390e8dd890ac4b8ad931e6277714e3d55560ee2f236b756bb4f83ee26eb9b0" rbx
+install_package "rubinius-2.4.0" "https://github.com/rubinius/rubinius/releases/download/v2.4.0/rubinius-2.4.0.tar.bz2#89390e8dd890ac4b8ad931e6277714e3d55560ee2f236b756bb4f83ee26eb9b0" rbx

--- a/share/ruby-build/rbx-2.4.1
+++ b/share/ruby-build/rbx-2.4.1
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.4.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.4.1.tar.bz2#a5967afe9f9305c08f97a22dd210922c33be79b293fc346f617ff31f280f136e" rbx
+install_package "rubinius-2.4.1" "https://github.com/rubinius/rubinius/releases/download/v2.4.1/rubinius-2.4.1.tar.bz2#a5967afe9f9305c08f97a22dd210922c33be79b293fc346f617ff31f280f136e" rbx

--- a/share/ruby-build/rbx-2.5.0
+++ b/share/ruby-build/rbx-2.5.0
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.0.tar.bz2#9f14a47080e8f175afb94f6e600812115185c91f2e081f976262aea7804e4ceb" rbx
+install_package "rubinius-2.5.0" "https://github.com/rubinius/rubinius/releases/download/v2.5.0/rubinius-2.5.0.tar.bz2#9f14a47080e8f175afb94f6e600812115185c91f2e081f976262aea7804e4ceb" rbx

--- a/share/ruby-build/rbx-2.5.1
+++ b/share/ruby-build/rbx-2.5.1
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.1.tar.bz2#00d6f23b7632d035d322209e736a9341155350a9d169e8471d38a554a8e26600" rbx
+install_package "rubinius-2.5.1" "https://github.com/rubinius/rubinius/releases/download/v2.5.1/rubinius-2.5.1.tar.bz2#00d6f23b7632d035d322209e736a9341155350a9d169e8471d38a554a8e26600" rbx

--- a/share/ruby-build/rbx-2.5.2
+++ b/share/ruby-build/rbx-2.5.2
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.2" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.2.tar.bz2#1b077537224d4ff1f8c628e5bbe0621dc6f833bc2d67a03aa10173b72299a1a8" rbx
+install_package "rubinius-2.5.2" "https://github.com/rubinius/rubinius/releases/download/v2.5.2/rubinius-2.5.2.tar.bz2#1b077537224d4ff1f8c628e5bbe0621dc6f833bc2d67a03aa10173b72299a1a8" rbx

--- a/share/ruby-build/rbx-2.5.3
+++ b/share/ruby-build/rbx-2.5.3
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.3" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.3.tar.bz2#9af4d6e9d1e78a586579c86b9eb9a082cb863885d4a7cf33989d73280461e5fc" rbx
+install_package "rubinius-2.5.3" "https://github.com/rubinius/rubinius/releases/download/v2.5.3/rubinius-2.5.3.tar.bz2#9af4d6e9d1e78a586579c86b9eb9a082cb863885d4a7cf33989d73280461e5fc" rbx

--- a/share/ruby-build/rbx-2.5.4
+++ b/share/ruby-build/rbx-2.5.4
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.4" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.4.tar.bz2#ed7104f6177dc2c5be346e5a7349118601d8b0b0a37eb76fa1a78da21b3fbcfc" rbx
+install_package "rubinius-2.5.4" "https://github.com/rubinius/rubinius/releases/download/v2.5.4/rubinius-2.5.4.tar.bz2#ed7104f6177dc2c5be346e5a7349118601d8b0b0a37eb76fa1a78da21b3fbcfc" rbx

--- a/share/ruby-build/rbx-2.5.5
+++ b/share/ruby-build/rbx-2.5.5
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.5" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.5.tar.bz2#217659849ca2c67322d24ce7167e760dc835f32a701ca6e558703914ca82d02f" rbx
+install_package "rubinius-2.5.5" "https://github.com/rubinius/rubinius/releases/download/v2.5.5/rubinius-2.5.5.tar.bz2#217659849ca2c67322d24ce7167e760dc835f32a701ca6e558703914ca82d02f" rbx

--- a/share/ruby-build/rbx-2.5.6
+++ b/share/ruby-build/rbx-2.5.6
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.6" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.6.tar.bz2#a81f57c6a9d38122a974df1debd5dd7900cb9d4a5cd621b2105de716990f807a" rbx
+install_package "rubinius-2.5.6" "https://github.com/rubinius/rubinius/releases/download/v2.5.6/rubinius-2.5.6.tar.bz2#a81f57c6a9d38122a974df1debd5dd7900cb9d4a5cd621b2105de716990f807a" rbx

--- a/share/ruby-build/rbx-2.5.7
+++ b/share/ruby-build/rbx-2.5.7
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.7" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.7.tar.bz2#8ba8e75835e6df38453f6b6f65bdd296abee2df89ce488e6cc914059b6e1b385" rbx
+install_package "rubinius-2.5.7" "https://github.com/rubinius/rubinius/releases/download/v2.5.7/rubinius-2.5.7.tar.bz2#8ba8e75835e6df38453f6b6f65bdd296abee2df89ce488e6cc914059b6e1b385" rbx

--- a/share/ruby-build/rbx-2.5.8
+++ b/share/ruby-build/rbx-2.5.8
@@ -1,3 +1,3 @@
 require_llvm 3.5
 install_package "openssl-1.0.1q" "https://www.openssl.org/source/openssl-1.0.1q.tar.gz#b3658b84e9ea606a5ded3c972a5517cd785282e7ea86b20c78aa4b773a047fb7" mac_openssl --if has_broken_mac_openssl
-install_package "rubinius-2.5.8" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.8.tar.bz2#d6b411732aa035865f2855845abe5405119560f0979062672d576601de89e59a" rbx
+install_package "rubinius-2.5.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.5.8.tar.bz2#d6b411732aa035865f2855845abe5405119560f0979062672d576601de89e59a" rbx


### PR DESCRIPTION
I found new urls for old Rubinius binaries on the Github. It seems the latest binary is for 2.2.2 (in ruby-build). See https://github.com/rubinius/rubinius/releases?after=v2.2.2. The rest is probably gone and nowhere publicly. So there is a question if Rubinius 2.2.1 and later should be removed.