### PR TITLE
Restrict find command to subdirectories

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -694,7 +694,7 @@ after_install_package() {
 
 fix_directory_permissions() {
   # Ensure installed directories are not world-writable to avoid Bundler warnings
-  find "$PREFIX_PATH" -type d \( -perm -020 -o -perm -002 \) -exec chmod go-w {} \;
+  find "$PREFIX_PATH/bin" "$PREFIX_PATH/share" -type d \( -perm -020 -o -perm -002 \) -exec chmod go-w {} \;
 }
 
 fix_rbx_gem_binstubs() {


### PR DESCRIPTION
Fixes #902

The find command executed by `fix_directory_permissions` is too
inclusive.  It searches everything in the `$PREFIX_DIR`, which includes
directories that ruby-build does not care about, such as `lost+found`.
By restricting the find command to the `$PREFIX_DIR/bin` directory and
the `$PREFIX_DIR/share` directory, ruby-build will only change
permissions on the directories it touches, ignoring anything else that
might be in the `$PREFIX_DIR`, which could be anything.