### PR TITLE
Use `aria2c` the "ultra fast" downloader if available

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -313,45 +313,27 @@ http() {
 }
 
 http_head_aria2c() {
-  options=""
-  [ -n "${IPV4}" ] && options="--disable-ipv6=true"
-  [ -n "${IPV6}" ] && options="--disable-ipv6=false"
-  aria2c --dry-run ${options} "$1" >&4 2>&1
+  aria2c --dry-run ${ARIA2_OPTS} "$1" >&4 2>&1
 }
 
 http_get_aria2c() {
-  options=""
-  [ -n "${IPV4}" ] && options="--disable-ipv6=true"
-  [ -n "${IPV6}" ] && options="--disable-ipv6=false"
-  aria2c -o "${2:--}" ${options} "$1"
+  aria2c -o "${2:--}" ${ARIA2_OPTS} "$1"
 }
 
 http_head_curl() {
-  options=""
-  [ -n "${IPV4}" ] && options="--ipv4"
-  [ -n "${IPV6}" ] && options="--ipv6"
-  curl -qsILf ${options} "$1" >&4 2>&1
+  curl -qsILf ${CURL_OPTS} "$1" >&4 2>&1
 }
 
 http_get_curl() {
-  options=""
-  [ -n "${IPV4}" ] && options="--ipv4"
-  [ -n "${IPV6}" ] && options="--ipv6"
-  curl -q -o "${2:--}" -sSLf ${options} "$1"
+  curl -q -o "${2:--}" -sSLf ${CURL_OPTS} "$1"
 }
 
 http_head_wget() {
-  options=""
-  [ -n "${IPV4}" ] && options="--inet4-only"
-  [ -n "${IPV6}" ] && options="--inet6-only"
-  wget -q --spider ${options} "$1" >&4 2>&1
+  wget -q --spider ${WGET_OPTS} "$1" >&4 2>&1
 }
 
 http_get_wget() {
-  options=""
-  [ -n "${IPV4}" ] && options="--inet4-only"
-  [ -n "${IPV6}" ] && options="--inet6-only"
-  wget -nv ${options} -O "${2:--}" "$1"
+  wget -nv ${WGET_OPTS} -O "${2:--}" "$1"
 }
 
 fetch_tarball() {
@@ -1234,6 +1216,10 @@ fi
 if [ -n "$RUBY_BUILD_SKIP_MIRROR" ] || ! has_checksum_support compute_sha2; then
   unset RUBY_BUILD_MIRROR_URL
 fi
+
+ARIA2_OPTS="${RUBY_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disable-ipv6=false}"
+CURL_OPTS="${RUBY_BUILD_CURL_OPTS} ${IPV4+--ipv4} ${IPV6+--ipv6}"
+WGET_OPTS="${RUBY_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
 
 SEED="$(date "+%Y%m%d%H%M%S").$$"
 LOG_PATH="${TMP}/ruby-build.${SEED}.log"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -300,14 +300,30 @@ http() {
   local file="$3"
   [ -n "$url" ] || return 1
 
-  if type curl &>/dev/null; then
+  if type aria2c &>/dev/null; then
+    "http_${method}_aria2c" "$url" "$file"
+  elif type curl &>/dev/null; then
     "http_${method}_curl" "$url" "$file"
   elif type wget &>/dev/null; then
     "http_${method}_wget" "$url" "$file"
   else
-    echo "error: please install \`curl\` or \`wget\` and try again" >&2
+    echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
     exit 1
   fi
+}
+
+http_head_aria2c() {
+  options=""
+  [ -n "${IPV4}" ] && options="--disable-ipv6=true"
+  [ -n "${IPV6}" ] && options="--disable-ipv6=false"
+  aria2c --dry-run ${options} "$1" >&4 2>&1
+}
+
+http_get_aria2c() {
+  options=""
+  [ -n "${IPV4}" ] && options="--disable-ipv6=true"
+  [ -n "${IPV6}" ] && options="--disable-ipv6=false"
+  aria2c -o "${2:--}" ${options} "$1"
 }
 
 http_head_curl() {

--- a/test/build.bats
+++ b/test/build.bats
@@ -10,7 +10,7 @@ export -n RUBY_CONFIGURE_OPTS
 setup() {
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
-  stub curl false
+  stub aria2c false
 }
 
 executable() {

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -10,19 +10,19 @@ setup() {
 
 
 @test "packages are saved to download cache" {
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/without-checksum
 
   assert_success
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
-  unstub curl
+  unstub aria2c
 }
 
 
 @test "cached package without checksum" {
-  stub curl
+  stub aria2c
 
   cp "${FIXTURE_ROOT}/package-1.0.0.tar.gz" "$RUBY_BUILD_CACHE_PATH"
 
@@ -31,13 +31,13 @@ setup() {
   assert_success
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
-  unstub curl
+  unstub aria2c
 }
 
 
 @test "cached package with valid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub curl
+  stub aria2c
 
   cp "${FIXTURE_ROOT}/package-1.0.0.tar.gz" "$RUBY_BUILD_CACHE_PATH"
 
@@ -47,7 +47,7 @@ setup() {
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
@@ -57,8 +57,8 @@ setup() {
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo invalid" "echo $checksum"
-  stub curl "-*I* : true" \
-    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+  stub aria2c "--dry-run * : true" \
+    "-o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2"
 
   touch "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz"
 
@@ -69,13 +69,13 @@ setup() {
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
   assert diff -q "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" "${FIXTURE_ROOT}/package-1.0.0.tar.gz"
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
 
 @test "nonexistent cache directory is ignored" {
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   export RUBY_BUILD_CACHE_PATH="${TMP}/nonexistent"
 
@@ -85,5 +85,5 @@ setup() {
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
   refute [ -d "$RUBY_BUILD_CACHE_PATH" ]
 
-  unstub curl
+  unstub aria2c
 }

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -3,6 +3,7 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH="$TMP/cache"
+export RUBY_BUILD_ARIA2_OPTS=
 
 setup() {
   mkdir "$RUBY_BUILD_CACHE_PATH"

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -6,103 +6,103 @@ export RUBY_BUILD_CACHE_PATH=
 
 
 @test "package URL without checksum" {
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/without-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
 }
 
 
 @test "package URL with valid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
 
 @test "package URL with invalid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-invalid-checksum
 
   assert_failure
   refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
 
 @test "package URL with checksum but no shasum support" {
   stub shasum false
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
 
 @test "package URL with valid md5 checksum" {
   stub md5 true "echo 83e6d7725e20166024a1eb74cde80677"
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-md5-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub md5
 }
 
 
 @test "package URL with md5 checksum but no md5 support" {
   stub md5 false
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-md5-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub md5
 }
 
 
 @test "package with invalid checksum" {
   stub shasum true "echo invalid"
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-checksum
 
   assert_failure
   refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
 @test "existing tarball in build location is reused" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub curl false
+  stub aria2c false
   stub wget false
 
   export -n RUBY_BUILD_CACHE_PATH
@@ -125,7 +125,7 @@ DEF
   stub shasum true \
     "echo invalid" \
     "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   export -n RUBY_BUILD_CACHE_PATH
   export RUBY_BUILD_BUILD_PATH="${TMP}/build"
@@ -144,7 +144,7 @@ DEF
 }
 
 @test "package URL with checksum of unexpected length" {
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#checksum_of_unexpected_length" copy

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -3,6 +3,7 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
+export RUBY_BUILD_ARIA2_OPTS=
 
 
 @test "package URL without checksum" {

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -10,7 +10,7 @@ setup() {
 }
 
 @test "failed download displays error message" {
-  stub curl false
+  stub aria2c false
 
   install_fixture definitions/without-checksum
   assert_failure

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -4,6 +4,7 @@ load test_helper
 export RUBY_BUILD_SKIP_MIRROR=
 export RUBY_BUILD_CACHE_PATH=
 export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
+export RUBY_BUILD_ARIA2_OPTS=
 
 
 @test "package URL without checksum bypasses mirror" {

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -8,7 +8,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
 
 @test "package URL without checksum bypasses mirror" {
   stub shasum true
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/without-checksum
   echo "$output" >&2
@@ -16,21 +16,21 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
 
 @test "package URL with checksum but no shasum support bypasses mirror" {
   stub shasum false
-  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
@@ -40,15 +40,15 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   local mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo $checksum"
-  stub curl "-*I* $mirror_url : true" \
-    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+  stub aria2c "--dry-run $mirror_url : true" \
+    "-o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
@@ -58,15 +58,15 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   local mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo $checksum"
-  stub curl "-*I* $mirror_url : false" \
-    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "--dry-run $mirror_url : false" \
+    "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
@@ -76,9 +76,9 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   local mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo invalid" "echo $checksum"
-  stub curl "-*I* $mirror_url : true" \
-    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
-    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "--dry-run $mirror_url : true" \
+    "-o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2" \
+    "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   install_fixture definitions/with-checksum
   echo "$output" >&2
@@ -86,7 +86,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
@@ -96,15 +96,15 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub curl "-*I* : true" \
-    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+  stub aria2c "--dry-run : true" \
+    "-o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2" \
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }
 
@@ -114,7 +114,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub curl "-q -o * -*S* https://cache.ruby-lang.org/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
+  stub aria2c "-o * https://cache.ruby-lang.org/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "https://cache.ruby-lang.org/packages/package-1.0.0.tar.gz#ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5" copy
@@ -123,6 +123,6 @@ DEF
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub curl
+  unstub aria2c
   unstub shasum
 }


### PR DESCRIPTION
[aria2](https://aria2.github.io/) is the "ultra fast" downloader and it supports parallel download with Range header, resuming failed download attempts, and so on. I received a feature request for this as yyuu/pyenv#534 from @luzfcb who is living in Brazil. I think this feature could be useful for all users who suffered by unstable internet connection.