### PR TITLE
added build_package_enable_shared() for shared library control from d…

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1001,6 +1001,10 @@ build_package_ldflags_dirs() {
   done
 }
 
+build_package_enable_shared() {
+    package_option ruby configure --enable-shared
+}
+
 build_package_auto_tcltk() {
   if is_mac && [ ! -d /usr/include/X11 ]; then
     if [ -d /opt/X11/include ]; then


### PR DESCRIPTION
…efinition file. The definitions haven't been changed to enable it for any versions, though. Not sure what the policy or testing procedures are for the versions, so didn't touch that. But with this you just add enable_shared to the definition file.
Example:
`install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" ldflags_dirs enable_shared standard verify_openssl
`
Alternatively this could be rejected and the code added to build_package_standard() which wouldn't require changes to the definition files. But having it in the definition seems prudent to me.
