### PR TITLE
Added definition of Ruby 2.1.9

### DIFF
--- a/share/ruby-build/2.1.9
+++ b/share/ruby-build/2.1.9
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
This adds the definition for Ruby 2.1.9 based on the definition of 2.1.8 (also uses `openssl-1.0.2g`).
https://www.ruby-lang.org/en/news/2016/03/30/ruby-2-1-9-released/