### PR TITLE
Warn when installing an unsupported or end-of-lifed Ruby

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -508,6 +508,26 @@ package_option() {
   eval "$variable=( \"\${value[@]}\" )"
 }
 
+build_package_warn_eol() {
+  local package_name="$1"
+
+  { echo
+    echo "WARNING: $package_name is past its end of life and is now unsupported."
+    echo "It no longer receives bug fixes or critical security updates."
+    echo
+  } >&3
+}
+
+build_package_warn_unsupported() {
+  local package_name="$1"
+
+  { echo
+    echo "WARNING: $package_name is nearing its end of life."
+    echo "It only receives critical security updates, no bug fixes."
+    echo
+  } >&3
+}
+
 build_package_standard() {
   local package_name="$1"
 

--- a/share/ruby-build/1.8.6-p383
+++ b/share/ruby-build/1.8.6-p383
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.6-p383" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.bz2#c39dd7e211cb7245d08d9a7a3d4fe0c7b9f796a4bed9f92fed500ad58bb53d1a" auto_tcltk standard
+install_package "ruby-1.8.6-p383" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.bz2#c39dd7e211cb7245d08d9a7a3d4fe0c7b9f796a4bed9f92fed500ad58bb53d1a" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p420
+++ b/share/ruby-build/1.8.6-p420
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.6-p420" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.bz2#5ed3e6b9ebcb51baf59b8263788ec9ec8a65fbb82286d952dd3eb66e22d9a09f" auto_tcltk standard
+install_package "ruby-1.8.6-p420" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.bz2#5ed3e6b9ebcb51baf59b8263788ec9ec8a65fbb82286d952dd3eb66e22d9a09f" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.7-p249
+++ b/share/ruby-build/1.8.7-p249
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p249" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.bz2#8b89448fc79df6862660e9f77e884f06c76da28f078d8edd2f17567a615f3af5" auto_tcltk standard
+install_package "ruby-1.8.7-p249" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.bz2#8b89448fc79df6862660e9f77e884f06c76da28f078d8edd2f17567a615f3af5" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p302
+++ b/share/ruby-build/1.8.7-p302
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p302" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2#3537cc81cc2378a2bc319cd16c4237ddee14a2839cfd1515b27dce108d061a68" auto_tcltk standard
+install_package "ruby-1.8.7-p302" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2#3537cc81cc2378a2bc319cd16c4237ddee14a2839cfd1515b27dce108d061a68" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p334
+++ b/share/ruby-build/1.8.7-p334
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p334" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.bz2#3e7f1a15fb2c205ac9eb0da804983b83bf8c0ffeb2f146d1eb9e0579ea2507da" auto_tcltk standard
+install_package "ruby-1.8.7-p334" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.bz2#3e7f1a15fb2c205ac9eb0da804983b83bf8c0ffeb2f146d1eb9e0579ea2507da" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p352
+++ b/share/ruby-build/1.8.7-p352
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p352" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.bz2#9df4e9108387f7d24a6ab8950984d0c0f8cdbc1dad63194e744f1a176d1c5576" auto_tcltk standard
+install_package "ruby-1.8.7-p352" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.bz2#9df4e9108387f7d24a6ab8950984d0c0f8cdbc1dad63194e744f1a176d1c5576" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p357
+++ b/share/ruby-build/1.8.7-p357
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p357" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.bz2#5c64b63a597b4cb545887364e1fd1e0601a7aeb545e576e74a6d8e88a2765a37" auto_tcltk standard
+install_package "ruby-1.8.7-p357" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.bz2#5c64b63a597b4cb545887364e1fd1e0601a7aeb545e576e74a6d8e88a2765a37" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p358
+++ b/share/ruby-build/1.8.7-p358
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p358" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.bz2#309ccd427e47ef41a70f96462bd3c2ef2e7911ce1b22432ab502f5bc6e949c1b" auto_tcltk standard
+install_package "ruby-1.8.7-p358" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.bz2#309ccd427e47ef41a70f96462bd3c2ef2e7911ce1b22432ab502f5bc6e949c1b" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p370
+++ b/share/ruby-build/1.8.7-p370
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p370" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.bz2#6359b03a1c8ba16630a96fcb5f972c7af15bd33b752e324cd87964224ab1fe31" auto_tcltk standard
+install_package "ruby-1.8.7-p370" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.bz2#6359b03a1c8ba16630a96fcb5f972c7af15bd33b752e324cd87964224ab1fe31" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p371
+++ b/share/ruby-build/1.8.7-p371
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p371" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.bz2#2dd0e463cd82039beb75c9b9f4ee20bef5f5b5ff68527008e5aee61cfb3b55e1" auto_tcltk standard
+install_package "ruby-1.8.7-p371" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.bz2#2dd0e463cd82039beb75c9b9f4ee20bef5f5b5ff68527008e5aee61cfb3b55e1" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p374
+++ b/share/ruby-build/1.8.7-p374
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-1.8.7-p374" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.bz2#b4e34703137f7bfb8761c4ea474f7438d6ccf440b3d35f39cc5e4d4e239c07e3" auto_tcltk standard
+install_package "ruby-1.8.7-p374" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.bz2#b4e34703137f7bfb8761c4ea474f7438d6ccf440b3d35f39cc5e4d4e239c07e3" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p375
+++ b/share/ruby-build/1.8.7-p375
@@ -1,3 +1,3 @@
 require_gcc
-install_svn "ruby-1.8.7-p375" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8_7" "44351" autoconf auto_tcltk standard
+install_svn "ruby-1.8.7-p375" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8_7" "44351" warn_eol autoconf auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.1-p378" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.bz2#649e623f77190990d990089a819bc4ee60e21816f682ec37cee98d43adb46e51"
+install_package "ruby-1.9.1-p378" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.bz2#649e623f77190990d990089a819bc4ee60e21816f682ec37cee98d43adb46e51" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p430
+++ b/share/ruby-build/1.9.1-p430
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.1-p430" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.bz2#8d5cc11d819e476fb651db783f714cc4100922f47447f7acdce87ed769cf9d97"
+install_package "ruby-1.9.1-p430" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.bz2#8d5cc11d819e476fb651db783f714cc4100922f47447f7acdce87ed769cf9d97" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.2-p0
+++ b/share/ruby-build/1.9.2-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2#e9710990ed8c2e794123aba509010471915fb13c27dae0118831d2001a9c8d3b"
+install_package "ruby-1.9.2-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2#e9710990ed8c2e794123aba509010471915fb13c27dae0118831d2001a9c8d3b" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p180
+++ b/share/ruby-build/1.9.2-p180
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.bz2#06520c4d4b4512d08000f7dfff11d1fabc1d458c3c289c76a2f1ddb7f5a03f4d"
+install_package "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.bz2#06520c4d4b4512d08000f7dfff11d1fabc1d458c3c289c76a2f1ddb7f5a03f4d" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.bz2#403b3093fbe8a08dc69c269753b8c6e7bd8f87fb79a7dd7d676913efe7642487"
+install_package "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.bz2#403b3093fbe8a08dc69c269753b8c6e7bd8f87fb79a7dd7d676913efe7642487" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p318
+++ b/share/ruby-build/1.9.2-p318
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.bz2#9fcd60aaa118c35ec41c7e9974f1d771b1e632315661fd60f907c21357b082ce"
+install_package "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.bz2#9fcd60aaa118c35ec41c7e9974f1d771b1e632315661fd60f907c21357b082ce" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p320
+++ b/share/ruby-build/1.9.2-p320
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.bz2#6777f865cfa21ffdc167fcc4a7da05cb13aab1bd9e59bfcda82c4b32f75e6b51"
+install_package "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.bz2#6777f865cfa21ffdc167fcc4a7da05cb13aab1bd9e59bfcda82c4b32f75e6b51" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p326
+++ b/share/ruby-build/1.9.2-p326
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_svn "ruby-1.9.2-p326" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_2" "44353" autoconf standard
+install_svn "ruby-1.9.2-p326" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_2" "44353" warn_eol autoconf standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p330
+++ b/share/ruby-build/1.9.2-p330
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.2-p330" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2#6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f"
+install_package "ruby-1.9.2-p330" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2#6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-dev
+++ b/share/ruby-build/1.9.3-dev
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_git "ruby-1.9.3-dev" "https://github.com/ruby/ruby.git" "ruby_1_9_3" autoconf standard
+install_git "ruby-1.9.3-dev" "https://github.com/ruby/ruby.git" "ruby_1_9_3" warn_eol autoconf standard

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,5 +1,5 @@
 require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.bz2#ca8ba4e564fc5f98b210a5784e43dfffef9471222849e46f8e848b37e9f38acf"
+install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.bz2#ca8ba4e564fc5f98b210a5784e43dfffef9471222849e46f8e848b37e9f38acf" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,5 +1,5 @@
 [ -n "$CC" ] || export CC=cc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.bz2#c67a59443052b5a9219eb4cee3892bdfbc6f250f0c8e214e02256a4cc7ef5526"
+install_package "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.bz2#c67a59443052b5a9219eb4cee3892bdfbc6f250f0c8e214e02256a4cc7ef5526" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p194
+++ b/share/ruby-build/1.9.3-p194
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.bz2#a9d1ea9eaea075c60048369a63b35b3b5a06a30aa214a3d990e0bb71212db8fa"
+install_package "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.bz2#a9d1ea9eaea075c60048369a63b35b3b5a06a30aa214a3d990e0bb71212db8fa" warn_eol standard

--- a/share/ruby-build/1.9.3-p286
+++ b/share/ruby-build/1.9.3-p286
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.bz2#5281656c7a0ae48b64f28d845a96b4dfa16ba1357a911265752787585fb5ea64"
+install_package "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.bz2#5281656c7a0ae48b64f28d845a96b4dfa16ba1357a911265752787585fb5ea64" warn_eol standard

--- a/share/ruby-build/1.9.3-p327
+++ b/share/ruby-build/1.9.3-p327
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.bz2#d989465242f9b11a8a3aa8cbd2c75a9b3a8c0ec2f14a087a0c7b51abf164e488"
+install_package "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.bz2#d989465242f9b11a8a3aa8cbd2c75a9b3a8c0ec2f14a087a0c7b51abf164e488" warn_eol standard

--- a/share/ruby-build/1.9.3-p362
+++ b/share/ruby-build/1.9.3-p362
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.bz2#9ed456711a4c0fb2969d9144a81a706d2d506070a35a6d5bc98bb5c8407f9985"
+install_package "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.bz2#9ed456711a4c0fb2969d9144a81a706d2d506070a35a6d5bc98bb5c8407f9985" warn_eol standard

--- a/share/ruby-build/1.9.3-p374
+++ b/share/ruby-build/1.9.3-p374
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.bz2#712944f691b79f22f655547826400c26b13bc8c9e7bdc73a4abea45d5e766d85"
+install_package "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.bz2#712944f691b79f22f655547826400c26b13bc8c9e7bdc73a4abea45d5e766d85" warn_eol standard

--- a/share/ruby-build/1.9.3-p385
+++ b/share/ruby-build/1.9.3-p385
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.bz2#f991ee50414dc795696bad0fc5c7b0b94d93b9b38fed943326d20ce4e9dda42b"
+install_package "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.bz2#f991ee50414dc795696bad0fc5c7b0b94d93b9b38fed943326d20ce4e9dda42b" warn_eol standard

--- a/share/ruby-build/1.9.3-p392
+++ b/share/ruby-build/1.9.3-p392
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.bz2#5a7334dfdf62966879bf539b8a9f0b889df6f3b3824fb52a9303c3c3d3a58391"
+install_package "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.bz2#5a7334dfdf62966879bf539b8a9f0b889df6f3b3824fb52a9303c3c3d3a58391" warn_eol standard

--- a/share/ruby-build/1.9.3-p429
+++ b/share/ruby-build/1.9.3-p429
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.bz2#9d8949c24cf6fe810b65fb466076708b842a3b0bac7799f79b7b6a8791dc2a70"
+install_package "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.bz2#9d8949c24cf6fe810b65fb466076708b842a3b0bac7799f79b7b6a8791dc2a70" warn_eol standard

--- a/share/ruby-build/1.9.3-p448
+++ b/share/ruby-build/1.9.3-p448
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.bz2#a7372230357bfff8e4525fb8019046da521561fe66b02c25d8efc10c9877bc91"
+install_package "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.bz2#a7372230357bfff8e4525fb8019046da521561fe66b02c25d8efc10c9877bc91" warn_eol standard

--- a/share/ruby-build/1.9.3-p484
+++ b/share/ruby-build/1.9.3-p484
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.bz2#0fdc6e860d0023ba7b94c7a0cf1f7d32908b65b526246de9dfd5bb39d0d7922b"
+install_package "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.bz2#0fdc6e860d0023ba7b94c7a0cf1f7d32908b65b526246de9dfd5bb39d0d7922b" warn_eol standard

--- a/share/ruby-build/1.9.3-p545
+++ b/share/ruby-build/1.9.3-p545
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.bz2#2533de9f56d62f11c06a02dd32b5ab6d22a8f268c94b8e1e1ade6536adfd1aab"
+install_package "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.bz2#2533de9f56d62f11c06a02dd32b5ab6d22a8f268c94b8e1e1ade6536adfd1aab" warn_eol standard

--- a/share/ruby-build/1.9.3-p547
+++ b/share/ruby-build/1.9.3-p547
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.bz2#ef588ed3ff53009b4c1833c83187ae252dd6c20db45e21a326cd4a16a102ef4c"
+install_package "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.bz2#ef588ed3ff53009b4c1833c83187ae252dd6c20db45e21a326cd4a16a102ef4c" warn_eol standard

--- a/share/ruby-build/1.9.3-p550
+++ b/share/ruby-build/1.9.3-p550
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p550" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p550.tar.bz2#d3da003896db47fb10ba4d2e0285eea7fe8cdc785b86c02ebad5bc9cdeaa4748"
+install_package "ruby-1.9.3-p550" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p550.tar.bz2#d3da003896db47fb10ba4d2e0285eea7fe8cdc785b86c02ebad5bc9cdeaa4748" warn_eol standard

--- a/share/ruby-build/1.9.3-p551
+++ b/share/ruby-build/1.9.3-p551
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2#b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e"
+install_package "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2#b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e" warn_eol standard

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,5 +1,5 @@
 require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2#a15d7924d74a45ffe48d5421c5fc4ff83b7009676054fa5952b890711afef6fc"
+install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2#a15d7924d74a45ffe48d5421c5fc4ff83b7009676054fa5952b890711afef6fc" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,4 +1,4 @@
 require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-1.9.3-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.bz2#951a8810086abca0e200f81767a518ee2730d6dc9b0cc2c7e3587dcfc3bf5fc8"
+install_package "ruby-1.9.3-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.bz2#951a8810086abca0e200f81767a518ee2730d6dc9b0cc2c7e3587dcfc3bf5fc8" warn_eol standard

--- a/share/ruby-build/2.0.0-dev
+++ b/share/ruby-build/2.0.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_0_0" autoconf standard verify_openssl
+install_git "ruby-2.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_0_0" warn_eol autoconf standard verify_openssl

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.bz2#c680d392ccc4901c32067576f5b474ee186def2fcd3fcbfa485739168093295f" standard verify_openssl
+install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.bz2#c680d392ccc4901c32067576f5b474ee186def2fcd3fcbfa485739168093295f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.bz2#0be32aef7a7ab6e3708cc1d65cd3e0a99fa801597194bbedd5799c11d652eb5b" standard verify_openssl
+install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.bz2#0be32aef7a7ab6e3708cc1d65cd3e0a99fa801597194bbedd5799c11d652eb5b" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.bz2#08e3d4b85b8a1118a8e81261f59dd8b4ddcfd70b6ae554e0ec5ceb99c3185e8a" standard verify_openssl
+install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.bz2#08e3d4b85b8a1118a8e81261f59dd8b4ddcfd70b6ae554e0ec5ceb99c3185e8a" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p353
+++ b/share/ruby-build/2.0.0-p353
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.bz2#3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9" standard verify_openssl
+install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.bz2#3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p451
+++ b/share/ruby-build/2.0.0-p451
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2#5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5" standard verify_openssl
+install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2#5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p481
+++ b/share/ruby-build/2.0.0-p481
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.bz2#0762dad7e96d8091bdf33b3e3176c2066fbf3dc09dfe85fbf40e74e83c63d8e2" standard verify_openssl
+install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.bz2#0762dad7e96d8091bdf33b3e3176c2066fbf3dc09dfe85fbf40e74e83c63d8e2" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p576
+++ b/share/ruby-build/2.0.0-p576
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2#8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059" standard verify_openssl
+install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2#8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p594
+++ b/share/ruby-build/2.0.0-p594
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2#e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4" standard verify_openssl
+install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2#e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p598
+++ b/share/ruby-build/2.0.0-p598
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2#67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f" standard verify_openssl
+install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2#67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p643
+++ b/share/ruby-build/2.0.0-p643
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.bz2#1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0" standard verify_openssl
+install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.bz2#1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p645
+++ b/share/ruby-build/2.0.0-p645
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.bz2#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" standard verify_openssl
+install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.bz2#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p647
+++ b/share/ruby-build/2.0.0-p647
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.bz2#3c3782e313d1ec3ed06c104eafd133cc54ff5183b991786ece9e957fd6cf1cb9" standard verify_openssl
+install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.bz2#3c3782e313d1ec3ed06c104eafd133cc54ff5183b991786ece9e957fd6cf1cb9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p648
+++ b/share/ruby-build/2.0.0-p648
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2#087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166" standard verify_openssl
+install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2#087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.bz2#79e5605003bf6766fbd123ce00a0027df716ba6d28494c35185909f7e61a5bdf" standard verify_openssl
+install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.bz2#79e5605003bf6766fbd123ce00a0027df716ba6d28494c35185909f7e61a5bdf" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.bz2#cea98c000a113f10cb7d55753c759da1f1baa7ca9b3edf75fc19fa5f44bf71a0" standard verify_openssl
+install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.bz2#cea98c000a113f10cb7d55753c759da1f1baa7ca9b3edf75fc19fa5f44bf71a0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.bz2#4033ddadd0b44eecfcb7686231ebd109ee6f22bf09797a7e15882b9df0b1ee81" standard verify_openssl
+install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.bz2#4033ddadd0b44eecfcb7686231ebd109ee6f22bf09797a7e15882b9df0b1ee81" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2#d55f897bb04283c5fa80223d96d990fe8ecb598508dd59443b356cbba1f66145" standard verify_openssl
+install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2#d55f897bb04283c5fa80223d96d990fe8ecb598508dd59443b356cbba1f66145" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.0-dev
+++ b/share/ruby-build/2.1.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_1" ldflags_dirs autoconf standard verify_openssl
+install_git "ruby-2.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_1" warn_unsupported ldflags_dirs autoconf standard verify_openssl

--- a/share/ruby-build/2.1.0-preview1
+++ b/share/ruby-build/2.1.0-preview1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.bz2#860b90d28b214393fd9d77ac2ad65b384d8249cd59b658c668cf0c7bad1db341" standard verify_openssl
+install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.bz2#860b90d28b214393fd9d77ac2ad65b384d8249cd59b658c668cf0c7bad1db341" warn_unsupported standard verify_openssl

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.bz2#780fddf0e3c8a219057d578e83367ecfac5e945054b9f132b3b93ded4802d1ce" standard verify_openssl
+install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.bz2#780fddf0e3c8a219057d578e83367ecfac5e945054b9f132b3b93ded4802d1ce" warn_unsupported standard verify_openssl

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.bz2#af828bc0fe6aee5ffad0f8f10b48ee25964f54d5118570937ac7cf1c1df0edd3" standard verify_openssl
+install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.bz2#af828bc0fe6aee5ffad0f8f10b48ee25964f54d5118570937ac7cf1c1df0edd3" warn_unsupported standard verify_openssl

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.10
+++ b/share/ruby-build/2.1.10
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.10" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2#a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.10" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2#a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.3
+++ b/share/ruby-build/2.1.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.4
+++ b/share/ruby-build/2.1.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.5
+++ b/share/ruby-build/2.1.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.8
+++ b/share/ruby-build/2.1.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.9
+++ b/share/ruby-build/2.1.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/jruby-1.5.6
+++ b/share/ruby-build/jruby-1.5.6
@@ -1,1 +1,1 @@
-install_package "jruby-1.5.6" "https://s3.amazonaws.com/jruby-org/downloads/1.5.6/jruby-bin-1.5.6.tar.gz#545148197f98a4483276cdef5cedda0542a518d68d771c122f310195d8925089" jruby
+install_package "jruby-1.5.6" "https://s3.amazonaws.com/jruby-org/downloads/1.5.6/jruby-bin-1.5.6.tar.gz#545148197f98a4483276cdef5cedda0542a518d68d771c122f310195d8925089" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.3
+++ b/share/ruby-build/jruby-1.6.3
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.3" "https://s3.amazonaws.com/jruby-org/downloads/1.6.3/jruby-bin-1.6.3.tar.gz#9432fe3951782393d9755493585865190d7802e0bd162ff599e9c374605840ca" jruby
+install_package "jruby-1.6.3" "https://s3.amazonaws.com/jruby-org/downloads/1.6.3/jruby-bin-1.6.3.tar.gz#9432fe3951782393d9755493585865190d7802e0bd162ff599e9c374605840ca" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.4
+++ b/share/ruby-build/jruby-1.6.4
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.4" "https://s3.amazonaws.com/jruby-org/downloads/1.6.4/jruby-bin-1.6.4.tar.gz#64fb1a850f3982d88166d68a3f830afbc81d14c1a20884a8076da010daa66e8a" jruby
+install_package "jruby-1.6.4" "https://s3.amazonaws.com/jruby-org/downloads/1.6.4/jruby-bin-1.6.4.tar.gz#64fb1a850f3982d88166d68a3f830afbc81d14c1a20884a8076da010daa66e8a" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.5
+++ b/share/ruby-build/jruby-1.6.5
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.5" "https://s3.amazonaws.com/jruby-org/downloads/1.6.5/jruby-bin-1.6.5.tar.gz#e15a273bd78da1c63f77b90681d101df10bac62249833bb27a07c09216fb27f2" jruby
+install_package "jruby-1.6.5" "https://s3.amazonaws.com/jruby-org/downloads/1.6.5/jruby-bin-1.6.5.tar.gz#e15a273bd78da1c63f77b90681d101df10bac62249833bb27a07c09216fb27f2" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.5.1
+++ b/share/ruby-build/jruby-1.6.5.1
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.5.1" "https://s3.amazonaws.com/jruby-org/downloads/1.6.5.1/jruby-bin-1.6.5.1.tar.gz#0d2751a1aca147a5b9c6ddeef395440207374611ef39bc538e9e829270d811c8" jruby
+install_package "jruby-1.6.5.1" "https://s3.amazonaws.com/jruby-org/downloads/1.6.5.1/jruby-bin-1.6.5.1.tar.gz#0d2751a1aca147a5b9c6ddeef395440207374611ef39bc538e9e829270d811c8" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.6
+++ b/share/ruby-build/jruby-1.6.6
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.6" "https://s3.amazonaws.com/jruby-org/downloads/1.6.6/jruby-bin-1.6.6.tar.gz#1ef255ec73b80474602029a61f84062876873065c0f3398c30bc04ddd14aa34f" jruby
+install_package "jruby-1.6.6" "https://s3.amazonaws.com/jruby-org/downloads/1.6.6/jruby-bin-1.6.6.tar.gz#1ef255ec73b80474602029a61f84062876873065c0f3398c30bc04ddd14aa34f" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.7
+++ b/share/ruby-build/jruby-1.6.7
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.7" "https://s3.amazonaws.com/jruby-org/downloads/1.6.7/jruby-bin-1.6.7.tar.gz#88afbbb8fb4267547526a52f15d45ab447c1f2d1b197edc501e88dc9cb62a74c" jruby
+install_package "jruby-1.6.7" "https://s3.amazonaws.com/jruby-org/downloads/1.6.7/jruby-bin-1.6.7.tar.gz#88afbbb8fb4267547526a52f15d45ab447c1f2d1b197edc501e88dc9cb62a74c" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.7.2
+++ b/share/ruby-build/jruby-1.6.7.2
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.7.2" "https://s3.amazonaws.com/jruby-org/downloads/1.6.7.2/jruby-bin-1.6.7.2.tar.gz#6f04baa597941e48276a2edbb464afc6801f8f690fb978422e12029b7bfefe18" jruby
+install_package "jruby-1.6.7.2" "https://s3.amazonaws.com/jruby-org/downloads/1.6.7.2/jruby-bin-1.6.7.2.tar.gz#6f04baa597941e48276a2edbb464afc6801f8f690fb978422e12029b7bfefe18" warn_eol jruby

--- a/share/ruby-build/jruby-1.6.8
+++ b/share/ruby-build/jruby-1.6.8
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.8" "https://s3.amazonaws.com/jruby-org/downloads/1.6.8/jruby-bin-1.6.8.tar.gz#e3b05f9cf0ba9b02e6cba75d5b62e2abf8ac7a4483c3713dc4eb83e3b8b162d4" jruby
+install_package "jruby-1.6.8" "https://s3.amazonaws.com/jruby-org/downloads/1.6.8/jruby-bin-1.6.8.tar.gz#e3b05f9cf0ba9b02e6cba75d5b62e2abf8ac7a4483c3713dc4eb83e3b8b162d4" warn_eol jruby

--- a/share/ruby-build/ree-1.8.7-2011.03
+++ b/share/ruby-build/ree-1.8.7-2011.03
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2011.03" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz#0c0ddbc43b3aef49686db27e761e55a23437f12e1f00b6fe55d94724637bff6b" ree_installer
+install_package "ruby-enterprise-1.8.7-2011.03" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz#0c0ddbc43b3aef49686db27e761e55a23437f12e1f00b6fe55d94724637bff6b" warn_eol ree_installer
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2011.12
+++ b/share/ruby-build/ree-1.8.7-2011.12
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2011.12" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.12.tar.gz#9a8efc4befc136e17a1360de549aac9e79283c7238a13215350720e4393c5da2" ree_installer
+install_package "ruby-enterprise-1.8.7-2011.12" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.12.tar.gz#9a8efc4befc136e17a1360de549aac9e79283c7238a13215350720e4393c5da2" warn_eol ree_installer
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2012.01
+++ b/share/ruby-build/ree-1.8.7-2012.01
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2012.01" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.01.tar.gz#c0c4779fc473fc9843c0008acfbae2e2bdf3472b454c7fe6ff0ac4139a691e65" ree_installer
+install_package "ruby-enterprise-1.8.7-2012.01" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.01.tar.gz#c0c4779fc473fc9843c0008acfbae2e2bdf3472b454c7fe6ff0ac4139a691e65" warn_eol ree_installer
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2012.02
+++ b/share/ruby-build/ree-1.8.7-2012.02
@@ -1,2 +1,2 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2012.02" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.02.tar.gz#ecf4a6d4c96b547b3bf4b6be14e082ddaa781e83ad7f69437cd3169fb7576e42" ree_installer
+install_package "ruby-enterprise-1.8.7-2012.02" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.02.tar.gz#ecf4a6d4c96b547b3bf4b6be14e082ddaa781e83ad7f69437cd3169fb7576e42" warn_eol ree_installer


### PR DESCRIPTION
```bash
$ ./bin/ruby-build 1.9.3-p551 foobar
Downloading ruby-1.9.3-p551.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2
Installing ruby-1.9.3-p551...

WARNING: ruby-1.9.3-p551 is past its end of life and is now unsupported.
It no longer receives bug fixes or critical security updates.

…
```

Introduces `warn_eol` (no bugfixes or sec updates) and `warn_unsupported` (sec updates only) build steps.

Fixes #742 