### PR TITLE
Old crubies (1.8.5, 1.8.6, 1.8.7, 1.9.0, 1.9.1, 1.9.2, and 1.9.3)

### DIFF
--- a/share/ruby-build/1.8.5-p113
+++ b/share/ruby-build/1.8.5-p113
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.5-p113" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p113.tar.bz2#216600f9ad07648c501766a25069009c5c543010821da2ad916dd2ca808efd01" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p114
+++ b/share/ruby-build/1.8.5-p114
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.5-p114" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p114.tar.bz2#c503ae8eb47db72f78fb7a79fe1874ffef40a7094f7e803bacbf994a924244d9" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p115
+++ b/share/ruby-build/1.8.5-p115
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.5-p115" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p115.tar.bz2#3b5b799d6445b4ec8bc8b2944c6797dbd031b22e1756c9ae8b08c1f5d6cdc398" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p231
+++ b/share/ruby-build/1.8.5-p231
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.5-p231" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p231.tar.bz2#b31a8db0a3b538c28bca1c9b08a07eb55a39547fdaad00c045f073851019639c" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p52
+++ b/share/ruby-build/1.8.5-p52
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.5-p52" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p52.tar.bz2#17e4bde8e6fc93866774e66c556fe581104f5cdf162a07430a9e976e46915500" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6
+++ b/share/ruby-build/1.8.6
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2#0fc6ad0b31d8ec3997db2a56a2ac1c235283a3607abb876300fc711b3f8e3dd7" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p110
+++ b/share/ruby-build/1.8.6-p110
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p110" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p110.tar.bz2#88a8a63dae9219fa38faa6c308dbfc9ac9e9c15f6d8f6848c452b9c920183169" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p111
+++ b/share/ruby-build/1.8.6-p111
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p111" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p111.tar.bz2#85c694678313818a5083bcfd66ae389fc053b506d93b5ad46f3764981c120fbb" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p114
+++ b/share/ruby-build/1.8.6-p114
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p114" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p114.tar.bz2#4ac0d0271324c54525210f775e5fcc9a37e3d8a10b96d68cdfeeb361c6f64a63" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p230
+++ b/share/ruby-build/1.8.6-p230
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p230" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p230.tar.bz2#603708301fc3fd7ef1c47bb4a24d7799c26e28db08d69cda240adcbdbff514d7" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p286
+++ b/share/ruby-build/1.8.6-p286
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p286" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p286.tar.bz2#d800552900e1157bbeaae39a4c253683b2444820a5d1ba0a207a13cc469168b7" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p287
+++ b/share/ruby-build/1.8.6-p287
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p287" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p287.tar.bz2#ac15a1cb78c50ec9cc7e831616a143586bdd566bc865c6b769a0c47b3b3936ce" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p36
+++ b/share/ruby-build/1.8.6-p36
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p36" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p36.tar.bz2#a9b9715235580e1ba9248aeef5f9a8d329824b04d1b0af2a30ab74d3123c801c" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p368
+++ b/share/ruby-build/1.8.6-p368
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p368" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.tar.bz2#1bd398a125040261f8e9e74289277c82063aae174ada9f300d2bea0a42ccdcc1" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p369
+++ b/share/ruby-build/1.8.6-p369
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p369" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p369.tar.bz2#fb6974ab8a0de52511e846eacf113432b5227a867e3c9741d65775f162e13715" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p388
+++ b/share/ruby-build/1.8.6-p388
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p388" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p388.tar.bz2#8536b18413f2475698fa275b356daff6ceab5232bc503496f4afbee64e8b4abc" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p398
+++ b/share/ruby-build/1.8.6-p398
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p398" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p398.tar.bz2#9890c5eb899f19d5bca7b9b04bba597d14ec6627e992ee376143147c19e3990d" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p399
+++ b/share/ruby-build/1.8.6-p399
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.6-p399" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p399.tar.bz2#20ca08aeefa21ca2581a9791f8f9ace3addc92bd978cf36f2f95c109085a50a7" warn_eol auto_tcltk standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.7
+++ b/share/ruby-build/1.8.7
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7.tar.bz2#65f2a862ba5e88bac7a78cff15bcb88d7534e741b51a1ffb79a0136c7041359a" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p160
+++ b/share/ruby-build/1.8.7-p160
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p160" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.bz2#e524a086212d2142c03eb6b82cd602adcac9dcf8bf60049e89aa4ca69864984d" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p17
+++ b/share/ruby-build/1.8.7-p17
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p17" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p17.tar.bz2#f205c586764ffbd944b4ec6439bd08286e3e7b27bc9448e74949e76c63f6016b" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p173
+++ b/share/ruby-build/1.8.7-p173
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p173" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p173.tar.bz2#7cec49bc4afb82188ca4bdb5a0400ec7ede6bf0937af9dd6acaca4e54b8aa760" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p174
+++ b/share/ruby-build/1.8.7-p174
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p174" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p174.tar.bz2#203978b6db1cc77a79ff03d141d162f6f17d86c3574f76de9eae9d0c8cb920bc" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p22
+++ b/share/ruby-build/1.8.7-p22
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p22" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p22.tar.bz2#477968408e27d067ef56f552d7fc2a9e6f5cae2d1a72f17cd838ebf5e0d30149" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p248
+++ b/share/ruby-build/1.8.7-p248
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p248" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p248.tar.bz2#3d238c4cf0988797d33169ab05829f1a483194e7cacae4232f3a0e2cc01b6bfc" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p299
+++ b/share/ruby-build/1.8.7-p299
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p299" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p299.tar.bz2#3d8a1e4204f1fb69c9e9ffd637c7f7661a062fc2246c559f25fda5312cfd65d8" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p301
+++ b/share/ruby-build/1.8.7-p301
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p301" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p301.tar.bz2#6ddd929722d177240c52e9fafa637dae4d7f8a30825faabb33b1c5391b004029" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p330
+++ b/share/ruby-build/1.8.7-p330
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p330" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p330.tar.bz2#486c73b023b564c07e062e2e61114e81de970913b04fac6798d0fbe8b7723790" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p373
+++ b/share/ruby-build/1.8.7-p373
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p373" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p373.tar.bz2#720029cb528a2d5a132bbff7f47413f0b731ecc558f68f613d319fa9442afcb5" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p71
+++ b/share/ruby-build/1.8.7-p71
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p71" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p71.tar.bz2#ce74802744b9dfcd77bdd365a1543d050a56d9b366ed5e7a9bf2df25028fd411" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p72
+++ b/share/ruby-build/1.8.7-p72
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-p72" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p72.tar.bz2#a8f8a28e286dd76747d8e97ea5cfe7a315eb896906ab8c8606d687d9f6f6146e" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview1
+++ b/share/ruby-build/1.8.7-preview1
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-preview1" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview1.tar.bz2#e432ab1ab9b4570c0b7fe5c0c2730de0fda4c49a47811ea3a9170a311cf110b9" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview2
+++ b/share/ruby-build/1.8.7-preview2
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-preview2" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview2.tar.bz2#d02c1d22bff5c8365aa4adb25387950c0b58206a18cb18afcc4f2bd9401997e5" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview3
+++ b/share/ruby-build/1.8.7-preview3
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-preview3" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview3.tar.bz2#a73649f8c595cae34dc74e0d6c8b74998cc708d26d7d7300b16254d876dc7fe0" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview4
+++ b/share/ruby-build/1.8.7-preview4
@@ -1,0 +1,3 @@
+require_gcc
+install_package "ruby-1.8.7-preview4" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview4.tar.bz2#9f81d584a5b1bda92d933c48a336edd0ce6818eaa3a4e95cab59a73c85a7b285" warn_eol auto_tcltk standard
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.9.0-0
+++ b/share/ruby-build/1.9.0-0
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.0-0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.bz2#7995fdb2879cbb67b1ae4b5bbdf5460f70221598086f4e48e15fa5f48f2866e3" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-1
+++ b/share/ruby-build/1.9.0-1
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.0-1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-1.tar.bz2#88427424d6249c7544ddc53b31d871f1a6dce1dbded402cacc6306feb8d97f3b" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-2
+++ b/share/ruby-build/1.9.0-2
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.0-2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-2.tar.bz2#913d2bfd03e4285f61e3d343925ab8286ebfc5f7f4a7c861de7a160219cd1351" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-3
+++ b/share/ruby-build/1.9.0-3
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.0-3" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-3.tar.bz2#d5ca832db445e3251113c4027f2528d17e32ed9508d2dd507c469e546ad180db" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-4
+++ b/share/ruby-build/1.9.0-4
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.0-4" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-4.tar.bz2#09a91a60fba308a45ab8d3e691ec5ab279b36b646e75ad68d1d45679bdc4cbce" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-5
+++ b/share/ruby-build/1.9.0-5
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.0-5" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-5.tar.bz2#6641148785a8bd3b352c2f990e5b20c1bd244f61275150139671b9b84610d996" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p0
+++ b/share/ruby-build/1.9.1-p0
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2#de7d33aeabdba123404c21230142299ac1de88c944c9f3215b816e824dd33321" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p129
+++ b/share/ruby-build/1.9.1-p129
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-p129" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2#cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p243
+++ b/share/ruby-build/1.9.1-p243
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-p243" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p243.tar.bz2#39c9850841c0dd5d368f96b854f97c19b21eb28a02200f8b4e151f608092e687" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p376
+++ b/share/ruby-build/1.9.1-p376
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-p376" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p376.tar.bz2#79164e647e23bb7c705195e0075ce6020c30dd5ec4f8c8a12a100fe0eb0d6783" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p429
+++ b/share/ruby-build/1.9.1-p429
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p429.tar.bz2#e0b9471d77354628a8041068f45734eb2d99f5b5df08fe5a76d785d989a47bfb" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p431
+++ b/share/ruby-build/1.9.1-p431
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-p431" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p431.tar.bz2#81a46c947cd0c3ab99bc727e1465dab334432df7fbbfd0acfc08cf7111eb0c6c" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-preview1
+++ b/share/ruby-build/1.9.1-preview1
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-preview1.tar.bz2#dc39000537d7c7528ef26af8e1c3a6215b30b6c579c615eaec7013513410456a" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-preview2
+++ b/share/ruby-build/1.9.1-preview2
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-preview2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-preview2.tar.bz2#2c419dc325c6a75fb7b961496c0dd54f2729e6e01730589c4fb06e34ddd7a7cc" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-rc1
+++ b/share/ruby-build/1.9.1-rc1
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.tar.bz2#35acfb6b8d9dd9159ef308ac763c629092cda2e8c9f41254e72a7b9fa454c27f" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-rc2
+++ b/share/ruby-build/1.9.1-rc2
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.1-rc2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc2.tar.bz2#acb5061123fa7170597e713ef773e21ddd9dd167f27aaae2c5440b5ec12df2ec" warn_eol standard
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.2-p136
+++ b/share/ruby-build/1.9.2-p136
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.2-p136" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p136.tar.bz2#33092509aad118f07f0483a3db1d4c5adaccf4bb0324cd43f44e3bd3dd1858cb" warn_eol standard
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-preview1
+++ b/share/ruby-build/1.9.2-preview1
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.2-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-preview1.tar.bz2#0681204e52207153250da80b3cc46812f94107807458a7d64b17554b6df71120" warn_eol standard
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-preview3
+++ b/share/ruby-build/1.9.2-preview3
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.2-preview3" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-preview3.tar.bz2#94aee45432fb1a4ce6c3c9c74d17d2efc4fe4ad278997a850d55e5ca901cf256" warn_eol standard
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-rc1
+++ b/share/ruby-build/1.9.2-rc1
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.2-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-rc1.tar.bz2#c2a680aa5472c8d04a71625afa2b0f75c030d3655a3063fe364cfda8b33c1480" warn_eol standard
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-rc2
+++ b/share/ruby-build/1.9.2-rc2
@@ -1,0 +1,4 @@
+require_gcc
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.2-rc2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-rc2.tar.bz2#692ebae991b104482dc9f0d220c1afb6b690a338b3b815aaa4f62954d2fa1b4a" warn_eol standard
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p105
+++ b/share/ruby-build/1.9.3-p105
@@ -1,0 +1,5 @@
+[ -n "$CC" ] || export CC=cc
+install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.3-p105" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p105.tar.bz2#8a149dee6498553fe5d25618ccce8002ca076affca57c857503235d00a35f9d1" warn_eol standard
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p426
+++ b/share/ruby-build/1.9.3-p426
@@ -1,0 +1,3 @@
+install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
+install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
+install_package "ruby-1.9.3-p426" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p426.tar.bz2#54ac09a5579562ce6d3ba04413d24b5486d3bd3c0632968c7bd49cb76725186a" warn_eol standard


### PR DESCRIPTION
Thanks to @hsbt, ruby-lang.org now has a manifest of published releases: http://cache.ruby-lang.org/pub/ruby/index.txt (Discussion leading to said manifest from: https://github.com/jasonkarns/ruby-build-update-defs/issues/3)

This has enabled a scraper to be written for cruby for use by the [ruby-build-update-defs plugin](https://github.com/jasonkarns/ruby-build-update-defs).

There are quite a few published releases of ruby available on ruby-lang.org (per the manifest) that don't have corresponding build definitions here in ruby-build. I used the scraper (tweaked per minor version) to generate the build definitions that are in this PR. The build-defs are chunked per minor version (1.8.5, 1.8.6, 1.8.7, 1.9.0, 1.9.1, 1.9.2, and 1.9.3)

If all these build definitions are added, then adding new build definitions to ruby-build becomes a simple matter of: `rbenv update-version-defs --cruby --destination share/ruby-build` (assuming the plugin is installed and the command is run from root of this repo). Indeed, the entire scrape/branch/pr process has been scripted for node-build using this scraper: https://github.com/nodenv/node-build/blob/master/script/submit-definitions

Some notes:

- 1.8.5: There weren't any existing build definitions for any 1.8.5 ruby so 1.8.6-p383 was used as the template:
    - require_gcc
    - warn_eol auto_tcltk standard
    - rubygems-1.3.7
- 1.8.6: (as the other 1.8.6 rubies)
    - require_gcc
    - warn_eol auto_tcltk standard
    - rubygems-1.3.7
- 1.8.7: (as the other 1.8.7 rubies)
    - require_gcc
    - warn_eol auto_tcltk standard
    - rubygems-1.6.2
- 1.9.0: There weren't any existing build definitions for any 1.9.0 ruby so 1.9.1-p378 was used as the template:
    - require_gcc
    - yaml-0.1.6
    - warn_eol standard
    - rubygems-1.3.7
- 1.9.1: (as the other 1.9.1 rubies)
    - require_gcc
    - yaml-0.1.6
    - warn_eol standard
    - rubygems-1.3.7
- 1.9.2: (as the other 1.9.2 rubies)
    - require_gcc
    - yaml-0.1.6
    - warn_eol standard
    - rubygems-1.8.23
- 1.9.3-p105 (modeled after 1.9.3-p125)
    - [ -n "$CC" ] || export CC=cc
    - openssl-1.0.2h
    - yaml-0.1.6
    - warn_eol standard
    - rubygems-1.8.23
- 1.9.3-p426 (modeled after 1.9.3-p429 and all the other 1.9.3 rubies)
    - openssl-1.0.2h
    - yaml-0.1.6
    - warn_eol standard


The 1.8.5 rubies and 1.9.3-p105 are the only definitions that I'm not confident in.