### PR TITLE
Add script wrapper for running the ruby scraper

### DIFF
--- a/script/scrape-rubies
+++ b/script/scrape-rubies
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Usage: script/scrape-rubies
+#
+# All parameters are passed transparently to `rbenv update-version-defs`
+# see https://github.com/jasonkarns/ruby-build-update-defs
+#
+# Depends on ruby-build-update-defs plugin
+#
+# Runs the update-version-defs rbenv plugin to scrape new
+# ruby definitions and write them to share/ruby-build/.
+
+rbenv update-version-defs --destination share/ruby-build/ "$@"

--- a/script/scrape-rubies
+++ b/script/scrape-rubies
@@ -9,4 +9,4 @@
 # Runs the update-version-defs rbenv plugin to scrape new
 # ruby definitions and write them to share/ruby-build/.
 
-rbenv update-version-defs --destination share/ruby-build/ "$@"
+rbenv update-version-defs --cruby '>=2.3.1' --rubinius '>=3.30' --destination share/ruby-build/ "$@"

--- a/script/scrape-rubies
+++ b/script/scrape-rubies
@@ -9,4 +9,4 @@
 # Runs the update-version-defs rbenv plugin to scrape new
 # ruby definitions and write them to share/ruby-build/.
 
-rbenv update-version-defs --cruby '>=2.3.1' --rubinius '>=3.30' --destination share/ruby-build/ "$@"
+rbenv update-version-defs --cruby '>=2.3.1' --destination share/ruby-build/ "$@"


### PR DESCRIPTION
This script depends on the ruby-build-update-defs plugin. Assuming it is installed (doesn't matter how), then this script can be used to scrape new rubies and write the definitions to `share/ruby-build`. A second script is forthcoming that automates the branch+pr process for newly-scraped rubies.
