### PR TITLE
Mirror checksums

### DIFF
--- a/script/mirror
+++ b/script/mirror
@@ -15,8 +15,8 @@ test_mirrored() {
 }
 
 compute_checksum() {
-  local digest="$1"
-  local output="$(openssl dgst -"$digest")"
+  local digest_type="$1"
+  local output="$(openssl dgst -"$digest_type")"
   echo "${output##* }" | tr '[:upper:]' '[:lower:]'
 }
 
@@ -25,16 +25,16 @@ download_package() {
 }
 
 download_and_verify() {
-  local checksum digest
+  local checksum digest_type
   local url="$1"
   local file="$2"
   local expected="$3"
   download_package "$url" "$file"
 
   case "${#expected}" in
-  32) digest="md5" ;;
-  64) digest="sha256" ;;
-  128) digest="sha512" ;;
+  32) digest_type="md5" ;;
+  64) digest_type="sha256" ;;
+  128) digest_type="sha512" ;;
   *)
     { echo "Error: unexpected checksum length: ${#expected} (${expected})"
       echo "expected 32 (MD5), 64 (SHA-256), or 128 (SHA-512)"
@@ -42,7 +42,7 @@ download_and_verify() {
     return 1 ;;
   esac
 
-  checksum="$(compute_checksum "$digest" < "$file")"
+  checksum="$(compute_checksum "$digest_type" < "$file")"
   if [ "$checksum" != "$expected" ]; then
     echo "Error: $url doesn't match its checksum $expected" >&2
     return 1

--- a/script/mirror
+++ b/script/mirror
@@ -16,7 +16,7 @@ test_mirrored() {
 
 compute_sha256() {
   local output="$(openssl dgst -sha256)"
-  echo "${output##* }" | tr '[A-Z]' '[a-z]'
+  echo "${output##* }" | tr '[:upper:]' '[:lower:]'
 }
 
 download_package() {

--- a/script/mirror
+++ b/script/mirror
@@ -14,7 +14,7 @@ test_mirrored() {
   curl -qsSfIL "$RUBY_BUILD_MIRROR_URL/$1" >/dev/null 2>&1
 }
 
-compute_sha2() {
+compute_sha256() {
   local output="$(openssl dgst -sha256)"
   echo "${output##* }" | tr '[A-Z]' '[a-z]'
 }
@@ -29,7 +29,7 @@ download_and_verify() {
   local file="$2"
   local expected="$3"
   download_package "$url" "$file"
-  checksum="$(compute_sha2 < "$file")"
+  checksum="$(compute_sha256 < "$file")"
   if [ "$checksum" != "$expected" ]; then
     echo "Error: $url doesn't match its checksum $expected" >&2
     return 1

--- a/script/mirror
+++ b/script/mirror
@@ -14,8 +14,9 @@ test_mirrored() {
   curl -qsSfIL "$RUBY_BUILD_MIRROR_URL/$1" >/dev/null 2>&1
 }
 
-compute_sha256() {
-  local output="$(openssl dgst -sha256)"
+compute_checksum() {
+  local digest="$1"
+  local output="$(openssl dgst -"$digest")"
   echo "${output##* }" | tr '[:upper:]' '[:lower:]'
 }
 
@@ -29,7 +30,7 @@ download_and_verify() {
   local file="$2"
   local expected="$3"
   download_package "$url" "$file"
-  checksum="$(compute_sha256 < "$file")"
+  checksum="$(compute_checksum sha256 < "$file")"
   if [ "$checksum" != "$expected" ]; then
     echo "Error: $url doesn't match its checksum $expected" >&2
     return 1

--- a/script/mirror
+++ b/script/mirror
@@ -32,11 +32,12 @@ download_and_verify() {
   download_package "$url" "$file"
 
   case "${#expected}" in
+  32) digest="md5" ;;
   64) digest="sha256" ;;
   128) digest="sha512" ;;
   *)
     { echo "Error: unexpected checksum length: ${#expected} (${expected})"
-      echo "expected 64 (SHA-256) or 128 (SHA-512)"
+      echo "expected 32 (MD5), 64 (SHA-256), or 128 (SHA-512)"
     } >&2
     return 1 ;;
   esac

--- a/script/mirror
+++ b/script/mirror
@@ -25,12 +25,23 @@ download_package() {
 }
 
 download_and_verify() {
-  local checksum
+  local checksum digest
   local url="$1"
   local file="$2"
   local expected="$3"
   download_package "$url" "$file"
-  checksum="$(compute_checksum sha256 < "$file")"
+
+  case "${#expected}" in
+  64) digest="sha256" ;;
+  128) digest="sha512" ;;
+  *)
+    { echo "Error: unexpected checksum length: ${#expected} (${expected})"
+      echo "expected 64 (SHA-256) or 128 (SHA-512)"
+    } >&2
+    return 1 ;;
+  esac
+
+  checksum="$(compute_checksum "$digest" < "$file")"
   if [ "$checksum" != "$expected" ]; then
     echo "Error: $url doesn't match its checksum $expected" >&2
     return 1


### PR DESCRIPTION
As hinted from #878, this adds mult-digest support to the mirroring script.

In its present form, it adds MD5 and SHA-512 support to the existing SHA-256 behavior. The md5 support is isolated to its own commit, so it can be dropped from this PR if desired. (It was added for completeness sake.)

I'm not really sure how to test this, so it hasn't really been tested :/ Other than the fact it's mostly copied from https://github.com/rbenv/ruby-build/blob/8dc4568ea9f02db55ddf26de9b48d01e0bdb1d05/bin/ruby-build#L267-L278
