### PR TITLE
`aria2c` doesn't support writing remote content to stdout

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -317,7 +317,12 @@ http_head_aria2c() {
 }
 
 http_get_aria2c() {
-  aria2c -o "${2:--}" ${ARIA2_OPTS} "$1"
+  local out="${2:-$(mktemp "out.XXXXXX")}"
+  if aria2c --allow-overwrite=true -o "${out}" ${ARIA2_OPTS} "$1" >&4; then
+    [ -n "$2" ] || cat "${out}"
+  else
+    false
+  fi
 }
 
 http_head_curl() {

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -313,12 +313,12 @@ http() {
 }
 
 http_head_aria2c() {
-  aria2c --dry-run ${ARIA2_OPTS} "$1" >&4 2>&1
+  aria2c --dry-run --no-conf=true ${ARIA2_OPTS} "$1" >&4 2>&1
 }
 
 http_get_aria2c() {
   local out="${2:-$(mktemp "out.XXXXXX")}"
-  if aria2c --allow-overwrite=true -o "${out}" ${ARIA2_OPTS} "$1" >&4; then
+  if aria2c --allow-overwrite=true --no-conf=true -o "${out}" ${ARIA2_OPTS} "$1" >&4; then
     [ -n "$2" ] || cat "${out}"
   else
     false

--- a/test/build.bats
+++ b/test/build.bats
@@ -11,7 +11,7 @@ setup() {
   ensure_not_found_in_path aria2c
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
-  stub aria2c false
+  stub curl false
 }
 
 executable() {

--- a/test/build.bats
+++ b/test/build.bats
@@ -8,6 +8,7 @@ export CC=cc
 export -n RUBY_CONFIGURE_OPTS
 
 setup() {
+  ensure_not_found_in_path aria2c
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
   stub aria2c false

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -11,7 +11,7 @@ setup() {
 
 
 @test "packages are saved to download cache" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/without-checksum
 
@@ -59,7 +59,7 @@ setup() {
 
   stub shasum true "echo invalid" "echo $checksum"
   stub aria2c "--dry-run * : true" \
-    "-o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2"
+    "--allow-overwrite=true -o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   touch "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz"
 
@@ -76,7 +76,7 @@ setup() {
 
 
 @test "nonexistent cache directory is ignored" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   export RUBY_BUILD_CACHE_PATH="${TMP}/nonexistent"
 

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -6,6 +6,7 @@ export RUBY_BUILD_CACHE_PATH="$TMP/cache"
 export RUBY_BUILD_ARIA2_OPTS=
 
 setup() {
+  ensure_not_found_in_path aria2c
   mkdir "$RUBY_BUILD_CACHE_PATH"
 }
 

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -3,7 +3,7 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH="$TMP/cache"
-export RUBY_BUILD_ARIA2_OPTS=
+export RUBY_BUILD_CURL_OPTS=
 
 setup() {
   ensure_not_found_in_path aria2c
@@ -12,19 +12,19 @@ setup() {
 
 
 @test "packages are saved to download cache" {
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
 
   assert_success
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
-  unstub aria2c
+  unstub curl
 }
 
 
 @test "cached package without checksum" {
-  stub aria2c
+  stub curl
 
   cp "${FIXTURE_ROOT}/package-1.0.0.tar.gz" "$RUBY_BUILD_CACHE_PATH"
 
@@ -33,13 +33,13 @@ setup() {
   assert_success
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
-  unstub aria2c
+  unstub curl
 }
 
 
 @test "cached package with valid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c
+  stub curl
 
   cp "${FIXTURE_ROOT}/package-1.0.0.tar.gz" "$RUBY_BUILD_CACHE_PATH"
 
@@ -49,7 +49,7 @@ setup() {
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -59,8 +59,8 @@ setup() {
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo invalid" "echo $checksum"
-  stub aria2c "--dry-run * : true" \
-    "--allow-overwrite=true -o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+  stub curl "-*I* : true" \
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   touch "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz"
 
@@ -71,13 +71,13 @@ setup() {
   assert [ -e "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" ]
   assert diff -q "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz" "${FIXTURE_ROOT}/package-1.0.0.tar.gz"
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "nonexistent cache directory is ignored" {
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   export RUBY_BUILD_CACHE_PATH="${TMP}/nonexistent"
 
@@ -87,5 +87,5 @@ setup() {
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
   refute [ -d "$RUBY_BUILD_CACHE_PATH" ]
 
-  unstub aria2c
+  unstub curl
 }

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -7,7 +7,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 
 @test "package URL without checksum" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/without-checksum
 
@@ -20,7 +20,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package URL with valid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -34,7 +34,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package URL with invalid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-invalid-checksum
 
@@ -48,7 +48,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package URL with checksum but no shasum support" {
   stub shasum false
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -62,7 +62,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package URL with valid md5 checksum" {
   stub md5 true "echo 83e6d7725e20166024a1eb74cde80677"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
@@ -76,7 +76,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package URL with md5 checksum but no md5 support" {
   stub md5 false
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
@@ -90,7 +90,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package with invalid checksum" {
   stub shasum true "echo invalid"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -126,7 +126,7 @@ DEF
   stub shasum true \
     "echo invalid" \
     "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   export -n RUBY_BUILD_CACHE_PATH
   export RUBY_BUILD_BUILD_PATH="${TMP}/build"
@@ -145,7 +145,7 @@ DEF
 }
 
 @test "package URL with checksum of unexpected length" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#checksum_of_unexpected_length" copy

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -3,107 +3,107 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
-export RUBY_BUILD_ARIA2_OPTS=
+export RUBY_BUILD_CURL_OPTS=
 
 
 @test "package URL without checksum" {
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
 }
 
 
 @test "package URL with valid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with invalid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-invalid-checksum
 
   assert_failure
   refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with checksum but no shasum support" {
   stub shasum false
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with valid md5 checksum" {
   stub md5 true "echo 83e6d7725e20166024a1eb74cde80677"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub md5
 }
 
 
 @test "package URL with md5 checksum but no md5 support" {
   stub md5 false
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub md5
 }
 
 
 @test "package with invalid checksum" {
   stub shasum true "echo invalid"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_failure
   refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 @test "existing tarball in build location is reused" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c false
+  stub curl false
   stub wget false
 
   export -n RUBY_BUILD_CACHE_PATH
@@ -126,7 +126,7 @@ DEF
   stub shasum true \
     "echo invalid" \
     "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   export -n RUBY_BUILD_CACHE_PATH
   export RUBY_BUILD_BUILD_PATH="${TMP}/build"
@@ -145,7 +145,7 @@ DEF
 }
 
 @test "package URL with checksum of unexpected length" {
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#checksum_of_unexpected_length" copy

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -21,7 +21,7 @@ setup() {
 }
 
 @test "using aria2c if available" {
-  stub aria2c "* -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub aria2c "--allow-overwrite=true --no-conf=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
 
   install_fixture definitions/without-checksum
   assert_success

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -11,7 +11,7 @@ setup() {
 }
 
 @test "failed download displays error message" {
-  stub aria2c false
+  stub curl false
 
   install_fixture definitions/without-checksum
   assert_failure

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -3,6 +3,7 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
+export RUBY_BUILD_ARIA2_OPTS=
 
 setup() {
   ensure_not_found_in_path aria2c
@@ -17,6 +18,20 @@ setup() {
   assert_failure
   assert_output_contains "> http://example.com/packages/package-1.0.0.tar.gz"
   assert_output_contains "error: failed to download package-1.0.0.tar.gz"
+}
+
+@test "using aria2c if available" {
+  stub aria2c "* -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+
+  install_fixture definitions/without-checksum
+  assert_success
+  assert_output <<OUT
+Downloading package-1.0.0.tar.gz...
+-> http://example.com/packages/package-1.0.0.tar.gz
+Installing package-1.0.0...
+Installed package-1.0.0 to ${TMP}/install
+OUT
+  unstub aria2c
 }
 
 @test "fetching from git repository" {

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -5,6 +5,7 @@ export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
 
 setup() {
+  ensure_not_found_in_path aria2c
   export RUBY_BUILD_BUILD_PATH="${TMP}/source"
   mkdir -p "${RUBY_BUILD_BUILD_PATH}"
 }

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -3,6 +3,7 @@
 load test_helper
 
 setup() {
+  ensure_not_found_in_path aria2c
   export RBENV_ROOT="${TMP}/rbenv"
   export HOOK_PATH="${TMP}/i has hooks"
   mkdir -p "$HOOK_PATH"

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -9,7 +9,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package URL without checksum bypasses mirror" {
   stub shasum true
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/without-checksum
   echo "$output" >&2
@@ -24,7 +24,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
 @test "package URL with checksum but no shasum support bypasses mirror" {
   stub shasum false
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -42,7 +42,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo $checksum"
   stub aria2c "--dry-run $mirror_url : true" \
-    "-o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2"
+    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   install_fixture definitions/with-checksum
 
@@ -60,7 +60,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo $checksum"
   stub aria2c "--dry-run $mirror_url : false" \
-    "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -78,8 +78,8 @@ export RUBY_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo invalid" "echo $checksum"
   stub aria2c "--dry-run $mirror_url : true" \
-    "-o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2" \
-    "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
   echo "$output" >&2
@@ -98,7 +98,7 @@ export RUBY_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo $checksum"
   stub aria2c "--dry-run : true" \
-    "-o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2" \
+    "--allow-overwrite=true -o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
 
   install_fixture definitions/with-checksum
 
@@ -115,7 +115,7 @@ export RUBY_BUILD_ARIA2_OPTS=
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub aria2c "-o * https://cache.ruby-lang.org/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * https://cache.ruby-lang.org/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "https://cache.ruby-lang.org/packages/package-1.0.0.tar.gz#ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5" copy

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -4,12 +4,12 @@ load test_helper
 export RUBY_BUILD_SKIP_MIRROR=
 export RUBY_BUILD_CACHE_PATH=
 export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
-export RUBY_BUILD_ARIA2_OPTS=
+export RUBY_BUILD_CURL_OPTS=
 
 
 @test "package URL without checksum bypasses mirror" {
   stub shasum true
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
   echo "$output" >&2
@@ -17,21 +17,21 @@ export RUBY_BUILD_ARIA2_OPTS=
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with checksum but no shasum support bypasses mirror" {
   stub shasum false
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -41,15 +41,15 @@ export RUBY_BUILD_ARIA2_OPTS=
   local mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--dry-run $mirror_url : true" \
-    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+  stub curl "-*I* $mirror_url : true" \
+    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -59,15 +59,15 @@ export RUBY_BUILD_ARIA2_OPTS=
   local mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--dry-run $mirror_url : false" \
-    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-*I* $mirror_url : false" \
+    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -77,9 +77,9 @@ export RUBY_BUILD_ARIA2_OPTS=
   local mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo invalid" "echo $checksum"
-  stub aria2c "--dry-run $mirror_url : true" \
-    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
-    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-*I* $mirror_url : true" \
+    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
   echo "$output" >&2
@@ -87,7 +87,7 @@ export RUBY_BUILD_ARIA2_OPTS=
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -97,15 +97,15 @@ export RUBY_BUILD_ARIA2_OPTS=
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--dry-run : true" \
-    "--allow-overwrite=true -o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+  stub curl "-*I* : true" \
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -115,7 +115,7 @@ export RUBY_BUILD_ARIA2_OPTS=
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--allow-overwrite=true -o * https://cache.ruby-lang.org/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* https://cache.ruby-lang.org/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "https://cache.ruby-lang.org/packages/package-1.0.0.tar.gz#ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5" copy
@@ -124,6 +124,6 @@ DEF
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -4,6 +4,7 @@ load test_helper
 export RBENV_ROOT="${TMP}/rbenv"
 
 setup() {
+  ensure_not_found_in_path aria2c
   stub rbenv-hooks 'install : true'
   stub rbenv-rehash 'true'
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -9,6 +9,39 @@ if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export PATH
 fi
 
+remove_command_from_path() {
+  OLDIFS="${IFS}"
+  local cmd="$1"
+  local path
+  local paths=()
+  IFS=:
+  for path in ${PATH}; do
+    if [ -e "${path}/${cmd}" ]; then
+      local tmp_path="$(mktemp -d "${TMP}/path.XXXXX")"
+      ln -fs "${path}"/* "${tmp_path}"
+      rm -f "${tmp_path}/${cmd}"
+      paths["${#paths[@]}"]="${tmp_path}"
+    else
+      paths["${#paths[@]}"]="${path}"
+    fi
+  done
+  export PATH="${paths[*]}"
+  IFS="${OLDIFS}"
+}
+
+ensure_not_found_in_path() {
+  local cmd
+  for cmd; do
+    if command -v "${cmd}" 1>/dev/null 2>&1; then
+      remove_command_from_path "${cmd}"
+    fi
+  done
+}
+
+setup() {
+  ensure_not_found_in_path aria2c
+}
+
 teardown() {
   rm -fr "${TMP:?}"/*
 }


### PR DESCRIPTION
I've implemented `aria2c` support in #904. However, I finally realized that `aria2c` doesn't support writing remote content to stdout (https://github.com/aria2/aria2/issues/190).

I confirmed that basically this must be not a problem for ruby-build since it doesn't rely on `http get` without filename ([the only usage of http get](https://github.com/rbenv/ruby-build/blob/3304f96296c9912eaee27347e87e93a3e8fc5a29/bin/ruby-build#L412) is specifying its destination filename). It'd be better to be fixed though.

