### PR TITLE
Remove suite-wide setup

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1222,9 +1222,9 @@ if [ -z "$MAKE" ]; then
       export MAKE="gmake"
     else
       if [ "$(uname -r | sed 's/[^[:digit:]].*//')" -lt 10 ]; then
-	export MAKE="gmake"
+        export MAKE="gmake"
       else
-	export MAKE="make"
+        export MAKE="make"
       fi
     fi
   else

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -5,6 +5,10 @@ export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
 export RUBY_BUILD_CURL_OPTS=
 
+setup() {
+  ensure_not_found_in_path aria2c
+}
+
 
 @test "package URL without checksum" {
   stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -3,7 +3,6 @@
 load test_helper
 
 setup() {
-  ensure_not_found_in_path aria2c
   export RBENV_ROOT="${TMP}/rbenv"
   export HOOK_PATH="${TMP}/i has hooks"
   mkdir -p "$HOOK_PATH"

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -6,6 +6,10 @@ export RUBY_BUILD_CACHE_PATH=
 export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
 export RUBY_BUILD_CURL_OPTS=
 
+setup() {
+  ensure_not_found_in_path aria2c
+}
+
 
 @test "package URL without checksum bypasses mirror" {
   stub shasum true

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -4,7 +4,6 @@ load test_helper
 export RBENV_ROOT="${TMP}/rbenv"
 
 setup() {
-  ensure_not_found_in_path aria2c
   stub rbenv-hooks 'install : true'
   stub rbenv-rehash 'true'
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -38,10 +38,6 @@ ensure_not_found_in_path() {
   done
 }
 
-setup() {
-  ensure_not_found_in_path aria2c
-}
-
 teardown() {
   rm -fr "${TMP:?}"/*
 }


### PR DESCRIPTION
Bats doesn't support both suite-wide setup (in helper) *and* file-wide
setup. Which means the existance of any file-level setup() function
overwrites any setup() function from test_helper. This can be confusing,
and (IMO) easier to simply avoid the overwriting and remove any
_implied_ suite-wide setup function from test_helper.

This turns out to not be so bad for the recently added setup function,
because the only test files that actually need aria2c removed from PATH
are those that actually invoke curl. These can be found because they are
the only test files that stub curl; half of which already had
file-specific setup() functions. So the only ones which need a
file-local setup() function added were: checksum.bats and mirror.bats

Along these lines, rbenv.bats and hooks.bats were removing aria2c from
PATH but don't actually need to. (curl isn't stubbed in these tests so
the existance of aria2c wouldn't affect the tests)

Lastly, fixed a tab/spaces whitespace mixup that was introduced by:
750c086d11d8cc6ccb041f5c19278c994a50854f