### PR TITLE
Require LLVM 3.6 when building Rubinius 3.30+

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -865,20 +865,21 @@ require_llvm() {
       3.2 )
         package_option ruby configure --prebuilt-name="llvm-3.2-x86_64-apple-darwin13.tar.bz2"
         ;;
-      3.5 )
+      3.[56] )
         local llvm_config="$(locate_llvm "$llvm_version")"
         if [ -n "$llvm_config" ]; then
           package_option ruby configure --llvm-config="$llvm_config"
         else
+          local homebrew_package="llvm${llvm_version//.}"
           { echo
             colorize 1 "ERROR"
             echo ": Rubinius will not be able to compile using Apple's LLVM-based "
-            echo "build tools on OS X. You will need to install LLVM 3.5 first."
+            echo "build tools on OS X. You will need to install LLVM $llvm_version first."
             echo
             colorize 1 "TO FIX THE PROBLEM"
             echo ": Install Homebrew's llvm package with this"
             echo -n "command: "
-            colorize 4 "brew tap homebrew/versions ; brew install llvm35"
+            colorize 4 "brew tap homebrew/versions ; brew install $homebrew_package"
             echo
           } >&3
           return 1

--- a/share/ruby-build/rbx-3.30
+++ b/share/ruby-build/rbx-3.30
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.30" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.30.tar.bz2#5294f406679d41160abe46ec1ff14b76c4353a75756227cc691108bb57f4bd16" rbx

--- a/share/ruby-build/rbx-3.31
+++ b/share/ruby-build/rbx-3.31
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.31" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.31.tar.bz2#1c7a7763ab7cf36ad6b2e328ff1d78fb6587721b8667f8598d15354d0704de72" rbx

--- a/share/ruby-build/rbx-3.32
+++ b/share/ruby-build/rbx-3.32
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.32" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.32.tar.bz2#f88d6d277efe1f9774da1201ce4c8a8fd7cb2ea29620c1727a4471e3a0eed1dc" rbx

--- a/share/ruby-build/rbx-3.33
+++ b/share/ruby-build/rbx-3.33
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.33" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.33.tar.bz2#1455940fc3a17b6efbb787c9316ff86a260187ebbaba6b32746dd27cebe14907" rbx

--- a/share/ruby-build/rbx-3.34
+++ b/share/ruby-build/rbx-3.34
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.34" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.34.tar.bz2#90f5d5b53dbc6494b8a81ecd3569950b1d85d0c463dd537cab677fab82e2b300" rbx

--- a/share/ruby-build/rbx-3.35
+++ b/share/ruby-build/rbx-3.35
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.35" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.35.tar.bz2#d72c8ec1a1cd6e1c77381e6d1e1d21811d71948a08f108d8a064884c379d2465" rbx

--- a/share/ruby-build/rbx-3.36
+++ b/share/ruby-build/rbx-3.36
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.36" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.36.tar.bz2#660c6eaad9ab0ef3813942e906b14d1f02d071c6e25f60b9d6c8dfbab278b754" rbx

--- a/share/ruby-build/rbx-3.37
+++ b/share/ruby-build/rbx-3.37
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.37" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.37.tar.bz2#85d855a0734c315d67b592675481458ddddac075426dbf6dc39a8ad34b8cb2d1" rbx

--- a/share/ruby-build/rbx-3.38
+++ b/share/ruby-build/rbx-3.38
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.38" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.38.tar.bz2#2e038ee1e1dcee5b0d574cc446ad7bf2d98ea70ced35090f1680a90c6b9d6333" rbx

--- a/share/ruby-build/rbx-3.39
+++ b/share/ruby-build/rbx-3.39
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.39" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.39.tar.bz2#f6f8132b44eadb4c07f8b26af16ce0a5470309ada33ef6f20ab76770a44193e0" rbx

--- a/share/ruby-build/rbx-3.40
+++ b/share/ruby-build/rbx-3.40
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.40" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.40.tar.bz2#09f6590515bf6180427544fb217a34330a689784ea05b03f0a98db2a197bb20f" rbx

--- a/share/ruby-build/rbx-3.41
+++ b/share/ruby-build/rbx-3.41
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.41" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.41.tar.bz2#b06966230e647aa0e5b64da14ba213256074c34f3bb8614be1ce81ef1434c41f" rbx

--- a/share/ruby-build/rbx-3.42
+++ b/share/ruby-build/rbx-3.42
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.42" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.42.tar.bz2#4fc4413101100f6393894632eef522c2667a821856ac32eb99ccecab2aeeae85" rbx

--- a/share/ruby-build/rbx-3.43
+++ b/share/ruby-build/rbx-3.43
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.43" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.43.tar.bz2#2c573257518774e464036515cc7283bc934a41566599afe94612c605844481ad" rbx

--- a/share/ruby-build/rbx-3.44
+++ b/share/ruby-build/rbx-3.44
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.44" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.44.tar.bz2#c9e08b2e1d745798a0b32bef773e287361769c07a0eb9512377020661e2e4236" rbx

--- a/share/ruby-build/rbx-3.45
+++ b/share/ruby-build/rbx-3.45
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.45" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.45.tar.bz2#5cadc3842c9c6d574bf5897354c384d8d688d9fa285b0d6083bdcc386bd6de96" rbx

--- a/share/ruby-build/rbx-3.46
+++ b/share/ruby-build/rbx-3.46
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.46" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.46.tar.bz2#6bf24221ebd2c4d69e2388be1a3fa06d41009eeee00bfcdd86de8d57892d3fb2" rbx

--- a/share/ruby-build/rbx-3.47
+++ b/share/ruby-build/rbx-3.47
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.47" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.47.tar.bz2#be734298ccad4dcadaa1f566d9655a971a4f12abc7629db045fd5c63e1685d16" rbx

--- a/share/ruby-build/rbx-3.48
+++ b/share/ruby-build/rbx-3.48
@@ -1,3 +1,3 @@
-require_llvm 3.5
+require_llvm 3.6
 install_package "openssl-1.0.2h" "https://www.openssl.org/source/openssl-1.0.2h.tar.gz#1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.48" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.48.tar.bz2#1180ea6a3de81bcd99c25b394fb05c010411bf4d3b48ee9881539b8043aeb561" rbx


### PR DESCRIPTION
From 3.30 onwards, Rubinius requires LLVM 3.6 or newer: https://github.com/rubinius/rubinius/commit/2dd51a1c285d1adae7224d4c966f664a11ed447e

Previously discussed here: https://github.com/rbenv/ruby-build/pull/765#issuecomment-105488542