### PR TITLE
print when using homebrew packages

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -912,6 +912,7 @@ needs_yaml() {
 use_homebrew_yaml() {
   local libdir="$(brew --prefix libyaml 2>/dev/null || true)"
   if [ -d "$libdir" ]; then
+    echo "ruby-build: use libyaml from homebrew"
     package_option ruby configure --with-libyaml-dir="$libdir"
   else
     return 1
@@ -922,6 +923,7 @@ use_homebrew_readline() {
   if [[ "$RUBY_CONFIGURE_OPTS" != *--with-readline-dir=* ]]; then
     local libdir="$(brew --prefix readline 2>/dev/null || true)"
     if [ -d "$libdir" ]; then
+      echo "ruby-build: use readline from homebrew"
       package_option ruby configure --with-readline-dir="$libdir"
     else
       return 1
@@ -939,6 +941,7 @@ has_broken_mac_openssl() {
 use_homebrew_openssl() {
   local ssldir="$(brew --prefix openssl 2>/dev/null || true)"
   if [ -d "$ssldir" ]; then
+    echo "ruby-build: use openssl from homebrew"
     package_option ruby configure --with-openssl-dir="$ssldir"
   else
     return 1


### PR DESCRIPTION
When a user uses homebrew packages (e.g. openssl), then to upgrade them the user must update homebrew packages before rebuilding using ruby-build.
