### PR TITLE
support FreeBSD 11-RELEASE

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -931,13 +931,14 @@ use_freebsd_pkg() {
       # check if 11-R or later
       release="$(uname -r)"
       if [ "${release%%.*}" -ge 11 ]; then
-	  if pkg info -e libedit > /dev/null; then
+	  # prefers readline to compile most of ruby versions
+	  if pkg info -e readline > /dev/null; then
+	      # use readline from Ports Collection
+	      package_option ruby configure --with-readline-dir="/usr/local"
+	  elif pkg info -e libedit > /dev/null; then
 	      # use libedit from Ports Collection
 	      package_option ruby configure --enable-libedit
 	      package_option ruby configure --with-libedit-dir="/usr/local"
-	  elif pkg info -e readline > /dev/null; then
-	      # use readline from Ports Collection
-	      package_option ruby configure --with-readline-dir="/usr/local"
 	  fi
       fi
   fi

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -920,15 +920,21 @@ use_homebrew_yaml() {
 }
 
 use_freebsd_pkg() {
-  # check if FreeBSD 11-R or later
+  # check if FreeBSD
   if [ "FreeBSD" = "$(uname -s)" ]; then
+      # use openssl if installed from Ports Collection
+      if [ -f /usr/local/include/openssl/ssl.h ]; then
+	  package_option ruby configure --with-openssl-dir="/usr/local"
+      fi
+
+      # check if 11-R or later
       if [ "$(uname -r | sed 's/[^[:digit:]].*//')" -ge 11 ]; then
 	  if $(pkg info -e libedit); then
-	      # use if libedit is installed
+	      # use libedit from Ports Collection
 	      package_option ruby configure --enable-libedit
 	      package_option ruby configure --with-libedit-dir="/usr/local"
 	  elif $(pkg info -e readline); then
-	      # use if readline is installed
+	      # use readline from Ports Collection
 	      package_option ruby configure --with-readline-dir="/usr/local"
 	  fi
       fi

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -553,6 +553,7 @@ build_package_standard() {
   local PACKAGE_CFLAGS="${package_var_name}_CFLAGS"
 
   [ "$package_var_name" = "RUBY" ] && use_homebrew_readline || true
+  [ "$package_var_name" = "RUBY" ] && use_freebsd_pkg || true
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
       export CFLAGS="$CFLAGS ${!PACKAGE_CFLAGS}"
@@ -915,6 +916,22 @@ use_homebrew_yaml() {
     package_option ruby configure --with-libyaml-dir="$libdir"
   else
     return 1
+  fi
+}
+
+use_freebsd_pkg() {
+  # check if FreeBSD 11-R or later
+  if [ "FreeBSD" = "$(uname -s)" ]; then
+      if [ "$(uname -r | sed 's/[^[:digit:]].*//')" -ge 11 ]; then
+	  if $(pkg info -e libedit); then
+	      # use if libedit is installed
+	      package_option ruby configure --enable-libedit
+	      package_option ruby configure --with-libedit-dir="/usr/local"
+	  elif $(pkg info -e readline); then
+	      # use if readline is installed
+	      package_option ruby configure --with-readline-dir="/usr/local"
+	  fi
+      fi
   fi
 }
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -552,8 +552,9 @@ build_package_standard() {
   local PACKAGE_MAKE_INSTALL_OPTS_ARRAY="${package_var_name}_MAKE_INSTALL_OPTS_ARRAY[@]"
   local PACKAGE_CFLAGS="${package_var_name}_CFLAGS"
 
-  [ "$package_var_name" = "RUBY" ] && use_homebrew_readline || true
-  [ "$package_var_name" = "RUBY" ] && use_freebsd_pkg || true
+  if [ "$package_var_name" = "RUBY" ]; then
+      use_homebrew_readline || use_freebsd_pkg ||true
+  fi
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
       export CFLAGS="$CFLAGS ${!PACKAGE_CFLAGS}"
@@ -928,12 +929,13 @@ use_freebsd_pkg() {
       fi
 
       # check if 11-R or later
-      if [ "$(uname -r | sed 's/[^[:digit:]].*//')" -ge 11 ]; then
-	  if $(pkg info -e libedit); then
+      release="$(uname -r)"
+      if [ "${release%%.*}" -ge 11 ]; then
+	  if pkg info -e libedit > /dev/null; then
 	      # use libedit from Ports Collection
 	      package_option ruby configure --enable-libedit
 	      package_option ruby configure --with-libedit-dir="/usr/local"
-	  elif $(pkg info -e readline); then
+	  elif pkg info -e readline > /dev/null; then
 	      # use readline from Ports Collection
 	      package_option ruby configure --with-readline-dir="/usr/local"
 	  fi

--- a/test/build.bats
+++ b/test/build.bats
@@ -204,7 +204,7 @@ OUT
 @test "number of CPU cores defaults to 2" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Darwin'
+  stub uname '-s : echo Darwin' false
   stub sysctl false
   stub_make_install
 
@@ -227,7 +227,7 @@ OUT
 @test "number of CPU cores is detected on Mac" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Darwin'
+  stub uname '-s : echo Darwin' false
   stub sysctl '-n hw.ncpu : echo 4'
   stub_make_install
 
@@ -251,7 +251,7 @@ OUT
 @test "number of CPU cores is detected on FreeBSD" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo FreeBSD'
+  stub uname '-s : echo FreeBSD' false
   stub sysctl '-n hw.ncpu : echo 1'
   stub_make_install
 
@@ -324,7 +324,7 @@ OUT
 @test "make on FreeBSD 9 defaults to gmake" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname "-s : echo FreeBSD" "-r : echo 9.1"
+  stub uname "-s : echo FreeBSD" "-r : echo 9.1" false
   MAKE=gmake stub_make_install
 
   MAKE= install_fixture definitions/vanilla-ruby
@@ -337,7 +337,7 @@ OUT
 @test "make on FreeBSD 10" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE"
+  stub uname "-s : echo FreeBSD" "-r : echo 10.0-RELEASE" false
   stub_make_install
 
   MAKE= install_fixture definitions/vanilla-ruby

--- a/test/compiler.bats
+++ b/test/compiler.bats
@@ -55,7 +55,7 @@ DEF
   mkdir -p "$INSTALL_ROOT"
   cd "$INSTALL_ROOT"
 
-  stub uname '-s : echo Darwin'
+  stub uname '-s : echo Darwin' '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
   stub cc 'false'
   stub brew 'false'


### PR DESCRIPTION
ruby-build fails when I use on FreeBSD 11-RELEASE.

```
$ rbenv install 2.3.1
Downloading ruby-2.3.1.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2
Installing ruby-2.3.1...

BUILD FAILED (FreeBSD 11.0-RELEASE-p2 using ruby-build 20160913-13-g8ef0c34)

Inspect or clean up the working tree at /tmp/ruby-build.20161104153337.41276
Results logged to /tmp/ruby-build.20161104153337.41276.log

Last 10 log lines:
                              rake 10.4.2
installing rdoc:              /home/yuichiro/.rbenv/versions/2.3.1/share/ri/2.3.0/system
installing capi-docs:         /home/yuichiro/.rbenv/versions/2.3.1/share/doc/ruby
The Ruby readline extension was not compiled.
ERROR: Ruby install aborted due to missing extensions
Configure options used:
  --prefix=/home/yuichiro-n/.rbenv/versions/2.3.1
  CFLAGS= -O3 -Wno-error=shorten-64-to-32 
  LDFLAGS=-L/home/yuichiro-n/.rbenv/versions/2.3.1/lib 
  CPPFLAGS=-I/home/yuichiro-n/.rbenv/versions/2.3.1/include 
```

The reason of this error,
FreeBSD 11-RELEASE has changed not to export readline shared library.
Application should use readline library in Ports Collection.

c.f.
  https://www.freebsd.org/releases/11.0R/relnotes.html

In FreeBSD Ports Collection,
ruby interpreter compiled with libedit by default.

To follow this configuration,
this patch prefers to link libedit first, readline next.
