### PR TITLE
Add JRuby 9.1.7.0 snapshot

### DIFF
--- a/share/ruby-build/jruby-9.1.7.0-dev
+++ b/share/ruby-build/jruby-9.1.7.0-dev
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.1.7.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-bin-9.1.7.0-SNAPSHOT.tar.gz" jruby


### PR DESCRIPTION
This pull request enables to install JRuby 9.1.7.0 snapshot.

```
$ rbenv install jruby-9.1.7.0-dev
Downloading jruby-bin-9.1.7.0-SNAPSHOT.tar.gz...
-> http://ci.jruby.org/snapshots/master/jruby-bin-9.1.7.0-SNAPSHOT.tar.gz
Installing jruby-9.1.7.0-SNAPSHOT...
Installed jruby-9.1.7.0-SNAPSHOT to /home/yahonda/.rbenv/versions/jruby-9.1.7.0-dev
$ rbenv global jruby-9.1.7.0-dev
$ ruby -v
jruby 9.1.7.0-SNAPSHOT (2.3.1) 2016-11-28 40a90b1 OpenJDK 64-Bit Server VM 25.111-b16 on 1.8.0_111-b16 +jit [linux-x86_64]
$
```
