### PR TITLE
Homebrew upgrade for HEAD package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Or, if you would like to install the latest development release:
 
     brew install --HEAD ruby-build
 
-Note, that if you chose to install the HEAD package, you need to reinstall it for every update:
+To upgrade the HEAD package use `--fetch-HEAD` option:
 
-    brew reinstall --HEAD ruby-build
+    brew upgrade --fetch-HEAD ruby-build
 
 ## Usage
 


### PR DESCRIPTION
From `brew upgrade --help`:

>     If --fetch-HEAD is passed, fetch the upstream repository to detect if
>     the HEAD installation of the formula is outdated. Otherwise, the
>     repository's HEAD will be checked for updates when a new stable or devel
>     version has been released.