### PR TITLE
Added definitions for Rubinius 3.61–3.69

### DIFF
--- a/share/ruby-build/rbx-3.61
+++ b/share/ruby-build/rbx-3.61
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.61" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.61.tar.bz2#38623cf198b1b0047b4c3404070252903b4da33c091be8708c205815d1516636" rbx

--- a/share/ruby-build/rbx-3.62
+++ b/share/ruby-build/rbx-3.62
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.62" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.62.tar.bz2#1cc468a7967687a062c11e21bf6787cc60f6894590eabe3fc9be5e9af36a022f" rbx

--- a/share/ruby-build/rbx-3.63
+++ b/share/ruby-build/rbx-3.63
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.63" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.63.tar.bz2#3003298b9d53620ad84d71a63be2a37b53dfdfe6c2fced9280a7f3b219f365d4" rbx

--- a/share/ruby-build/rbx-3.64
+++ b/share/ruby-build/rbx-3.64
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.64" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.64.tar.bz2#43e2efd91074b52dc1d691e1424dbbb2e91bc9406b595dbb4753e9dd6001eedb" rbx

--- a/share/ruby-build/rbx-3.65
+++ b/share/ruby-build/rbx-3.65
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.65" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.65.tar.bz2#a4290b6cd1f332c90405bd421163658a2d91abf27c83ad3afe7dbbbd3628829a" rbx

--- a/share/ruby-build/rbx-3.66
+++ b/share/ruby-build/rbx-3.66
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.66" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.66.tar.bz2#4bb237a1da1d52bc830bbe704bd4b995bbc07e50b558e460aff54d6bc309975e" rbx

--- a/share/ruby-build/rbx-3.67
+++ b/share/ruby-build/rbx-3.67
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.67" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.67.tar.bz2#a5eedd6169f80df528ac73cf2ed9183e2f5a82a57ca0b2ae3962c26238427b87" rbx

--- a/share/ruby-build/rbx-3.68
+++ b/share/ruby-build/rbx-3.68
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.68" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.68.tar.bz2#44f423a8557aa8fa383573638a94faaf3f9c587a771be267c60ed0c78784f567" rbx

--- a/share/ruby-build/rbx-3.69
+++ b/share/ruby-build/rbx-3.69
@@ -1,0 +1,3 @@
+require_llvm 3.6
+install_package "openssl-1.0.2j" "https://www.openssl.org/source/openssl-1.0.2j.tar.gz#e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" mac_openssl --if has_broken_mac_openssl
+install_package "rubinius-3.69" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.69.tar.bz2#2dcde5cb7ba1e1664f6bf902cd866d2564985536a0908caeac2e4099b6b255b2" rbx


### PR DESCRIPTION
In the other definitions — for example —

```
install_package "rubinius-3.60" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.60.tar.bz2#39f83fc74216391af56ea1ad13372878c0ed41fae49ee6a8cf8b0369a54c3b57" rbx
```

is `39f83fc74216391af56ea1ad13372878c0ed41fae49ee6a8cf8b0369a54c3b57` the checksum?

How do I find or generate that?