### PR TITLE
gcc is installed on FreeBSD

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1236,7 +1236,7 @@ if [ -n "$noexec" ]; then
   exit 1
 fi
 
-# Apply following work around, if gcc is not available.
+# Apply following work around, if gcc is not installed.
 if [ -z "$(locate_gcc)" ]; then
   # Work around warnings building Ruby 2.0 on Clang 2.x:
   # pass -Wno-error=shorten-64-to-32 if the compiler accepts it.

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1236,14 +1236,17 @@ if [ -n "$noexec" ]; then
   exit 1
 fi
 
-# Work around warnings building Ruby 2.0 on Clang 2.x:
-# pass -Wno-error=shorten-64-to-32 if the compiler accepts it.
-#
-# When we set CFLAGS, Ruby won't apply its default flags, though. Since clang
-# builds 1.9.x and 2.x only, where -O3 is default, we can safely set that flag.
-# Ensure it's the first flag since later flags take precedence.
-if "${CC:-cc}" -x c /dev/null -E -Wno-error=shorten-64-to-32 &>/dev/null; then
-  RUBY_CFLAGS="-O3 -Wno-error=shorten-64-to-32 $RUBY_CFLAGS"
+# Apply following work around, if gcc is not available.
+if [ -z "$(locate_gcc)" ]; then
+  # Work around warnings building Ruby 2.0 on Clang 2.x:
+  # pass -Wno-error=shorten-64-to-32 if the compiler accepts it.
+  #
+  # When we set CFLAGS, Ruby won't apply its default flags, though. Since clang
+  # builds 1.9.x and 2.x only, where -O3 is default, we can safely set that flag.
+  # Ensure it's the first flag since later flags take precedence.
+  if "${CC:-cc}" -x c /dev/null -E -Wno-error=shorten-64-to-32 &>/dev/null; then
+    RUBY_CFLAGS="-O3 -Wno-error=shorten-64-to-32 $RUBY_CFLAGS"
+  fi
 fi
 
 if [ -z "$MAKE" ]; then

--- a/test/compiler.bats
+++ b/test/compiler.bats
@@ -10,7 +10,7 @@ export -n RUBY_CONFIGURE_OPTS
 @test "require_gcc on OS X 10.9" {
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.9.5'
-  stub gcc '--version : echo 4.2.1'
+  stub gcc '--version : echo 4.2.1' '--version : echo 4.2.1'
 
   run_inline_definition <<DEF
 require_gcc
@@ -27,7 +27,7 @@ OUT
 @test "require_gcc on OS X 10.10" {
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
-  stub gcc '--version : echo 4.2.1'
+  stub gcc '--version : echo 4.2.1' '--version : echo 4.2.1'
 
   run_inline_definition <<DEF
 require_gcc
@@ -42,7 +42,7 @@ OUT
 }
 
 @test "require_gcc silences warnings" {
-  stub gcc '--version : echo warning >&2; echo 4.2.1'
+  stub gcc '--version : echo warning >&2; echo 4.2.1' '--version : echo warning >&2; echo 4.2.1'
 
   run_inline_definition <<DEF
 require_gcc


### PR DESCRIPTION
I fixed a problem about gcc is installed on FreeBSD-11.

The problem is simple.
When I install gcc on my FreeBSD,
ruby-build fails to compile for all ruby versions.

ruby-build adds "-Wno-error=shorten-64-to-32" option to CFLAGS,
when cc is clang. (clang is the default compiler of FreeBSD-11)
But if the configure script of ruby detects gcc,
ruby is compiled with "gcc -Wno-error=shorten-64-to-32",
it will fail because gcc doesn't supports "-Wno-error=shorten-64-to-32" option.

My patch checks if gcc is not installed,
and then adds "-Wno-error=shorten-64-to-32" option to CFLAGS.

Will you merge this Pull Request?