### PR TITLE
Fix to build Rubinius on FreeBSD

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -601,6 +601,45 @@ build_package_ree_installer() {
   } >&4 2>&1
 }
 
+post_configure_hook_rbx() {
+    if [ "FreeBSD" = "$(uname -s)" ]; then
+	cat > build-tool.c <<_EOS_
+/* LLVM wrapper script invokes the actual binary based on the argv[0]
+ * which rubinius messes up, by calling clang39 as cc, and thus breaking
+ * the LLVM wrapper. This hack workarounds this limitation, by invoking
+ * LLVM wrapper script with expected argv[0]
+ */
+
+#include <string.h>
+#include <unistd.h>
+
+#define PATH_CC "${CLANG_BIN}"
+#define PATH_CXX "${CLANGCPP_BIN}"
+
+int
+main(int argc, char** argv)
+{
+	char* basename = strrchr(argv[0] , '/');
+
+	if(NULL == basename)
+		basename = argv[0];
+	else
+		basename++;
+
+	if( !strcmp(basename, "cc"))
+		execv(PATH_CC, argv);
+	else if( !strcmp(basename, "c++"))
+		execv(PATH_CXX, argv);
+	else
+		return 0;
+}
+_EOS_
+	cc -O -o ./build/bin/build-tool build-tool.c
+	ln -sf ./build/bin/build-tool ./build/bin/cc
+	ln -sf ./build/bin/build-tool ./build/bin/c++
+    fi
+}
+
 build_package_rbx() {
   local package_name="$1"
 
@@ -623,6 +662,7 @@ build_package_rbx() {
     done
 
     RUBYOPT="-rubygems $RUBYOPT" ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS "${configure_opts[@]}"
+    post_configure_hook_rbx
     rake install
     fix_rbx_gem_binstubs "$PREFIX_PATH"
     fix_rbx_irb "$PREFIX_PATH"
@@ -889,6 +929,26 @@ require_llvm() {
         ;;
       esac
     fi
+  elif [ "FreeBSD" = "$(uname -s)" ]; then
+      ver="$(pkg info -x llvm[0-9] | sort | tail -1 | cut -c 5-6)"
+      if [ X$ver != X ]; then
+          package_option ruby configure --cc="clang${ver}"
+          package_option ruby configure --cxx="clang++${ver}"
+          package_option ruby configure --no-bin-links
+          package_option ruby configure --llvm-config="llvm-config${ver}"
+	  CLANG_BIN="/usr/local/bin/clang${ver}"
+	  CLANGCPP_BIN="/usr/local/bin/clang++${ver}"
+      elif pkg info -e llvm-devel > /dev/null; then
+          package_option ruby configure --cc="clang-devel"
+          package_option ruby configure --cxx="clang++-devel"
+          package_option ruby configure --no-bin-links
+          package_option ruby configure --llvm-config="llvm-config-devel"
+	  CLANG_BIN="/usr/local/bin/clang-devel"
+	  CLANGCPP_BIN="/usr/local/bin/clang++-devel"
+      else
+	  echo "error: please install 'llvm' and try again" >&2
+      fi
+      package_option ruby configure --with-opt-dir=/usr/local
   fi
 }
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -443,6 +443,7 @@ DEF
 @test "rbx uses bundle then rake" {
   cached_tarball "rubinius-2.0.0" "Gemfile"
 
+  stub uname "-s: Linux"
   stub gem false
   stub rake false
   stub bundle \
@@ -476,6 +477,7 @@ print '>>'
 OUT
   cached_tarball "rubinius-2.0.0" bin/ruby
 
+  stub uname "-s: Linux"
   stub bundle false
   stub rake \
     '--version : echo 1' \


### PR DESCRIPTION
ruby-build fails to build Rubinius on FreeBSD-11.
The reasons of this problem are following 3 issues.

1. llvm package

FreeBSD llvm packages are named like following.

  llvm37
  llvm38
  llvm39
  llvm-devel

For each package,
clang and llvm-config are renamed to be installed as following.

  clang37     llvm-config37
  clang38     llvm-config38
  clang39     llvm-config39
  clang-devel llvm-config-devel

I fixed that ruby-build checks which package is installed
and then make configure options by the result.

2. readline package

readline package is installed in '/usr/local',
I fixed to add configure option '--with-opt-dir=/usr/local'.

3. cc & c++ wrapper

It's complicated to explain.

Rubinius build tool makes symbolic links for cc and c++ compiler.
If the configure options specifies to use clang37,
cc is linked to '/usr/local/bin/clang37' and
c++ is linked to '/usr/local/bin/clang++37'.

Unfortunately '/usr/local/bin/clang37' is a wrapper script on FreeBSD.
The wrapper script makes the clang compiler path
like "/usr/local/llvm37/bin/$0".

As the result of these,
cc is executed as "/usr/local/llvm37/bin/cc".
No compiler is found in the path.

Same things happens in FreeBSD ports.
I fixed to use the wrapper (written in C) as same as FreeBSD ports.
