### PR TITLE
[Proposal] Use OpenSSL 1.1.0 for Ruby 2.4+

### DIFF
--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0d" "https://www.openssl.org/source/openssl-1.1.0d.tar.gz#7d5ebb9e89756545c156ff9c13cf2aa6214193b010a468a3bc789c3c28fe60df" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0d" "https://www.openssl.org/source/openssl-1.1.0d.tar.gz#7d5ebb9e89756545c156ff9c13cf2aa6214193b010a468a3bc789c3c28fe60df" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" ldflags_dirs autoconf standard verify_openssl

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.0d" "https://www.openssl.org/source/openssl-1.1.0d.tar.gz#7d5ebb9e89756545c156ff9c13cf2aa6214193b010a468a3bc789c3c28fe60df" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-trunk" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard verify_openssl


### PR DESCRIPTION
This is just proposal to use OpenSSL for Ruby 2.4 and later versions.

If I remember correctly, OpenSSL 1.1.0 is only supported since Ruby 2.4 (https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/) and it's unsupported in Ruby 2.3 and in earlier versions (@hsbt could you please to confirm it)?