### PR TITLE
`--quiet` option isn't sensible sha256sum(1) of GNU coreutils

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -224,7 +224,7 @@ compute_sha2() {
     output="$("$openssl" dgst -sha256 2>/dev/null)" || return 1
     echo "${output##* }"
   elif type sha256sum &>/dev/null; then
-    output="$(sha256sum --quiet)" || return 1
+    output="$(sha256sum -b)" || return 1
     echo "${output%% *}"
   else
     return 1


### PR DESCRIPTION
The option is available only if verifying digest, not available when computing digest.

>       --quiet
>              don't print OK for each successfully verified file