### PR TITLE
fix ordering for versions with different length patch number

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1136,7 +1136,7 @@ list_definitions() {
 }
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -68,7 +68,10 @@ NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
 @test "sorting Ruby versions" {
   export RUBY_BUILD_ROOT="$TMP"
   mkdir -p "${RUBY_BUILD_ROOT}/share/ruby-build"
-  expected="1.9.3-dev
+  expected="1.8.7
+1.8.7-p72
+1.8.7-p375
+1.9.3-dev
 1.9.3-preview1
 1.9.3-rc1
 1.9.3-p0

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -88,7 +88,7 @@ jruby-1.7.9
 jruby-1.7.10
 jruby-9000-dev
 jruby-9000"
-  for ver in "$expected"; do
+  for ver in $expected; do
     touch "${RUBY_BUILD_ROOT}/share/ruby-build/$ver"
   done
   run ruby-build --definitions


### PR DESCRIPTION
It should be:
```
1.8.7
1.8.7-p72
1.8.7-p374
1.8.7-p375
```
It was:
```
1.8.7-p374
1.8.7-p375
1.8.7-p72
1.8.7
```
