### PR TITLE
ruby-build 20170322

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -13,7 +13,7 @@
 #   --version        Show version of ruby-build
 #
 
-RUBY_BUILD_VERSION="20170201"
+RUBY_BUILD_VERSION="20170322"
 
 OLDIFS="$IFS"
 


### PR DESCRIPTION
Hi,
it seems to me that `RUBY_BUILD_VERSION` should be bumped according to recent release, shouldn't it?
