### PR TITLE
Add JRuby 9.1.9.0 snapshot

### DIFF
--- a/share/ruby-build/jruby-9.1.9.0-dev
+++ b/share/ruby-build/jruby-9.1.9.0-dev
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.1.9.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-bin-9.1.9.0-SNAPSHOT.tar.gz" jruby


### PR DESCRIPTION
This pull request adds JRuby 9.1.9.0 snapshot installation.

```
$ rbenv install jruby-9.1.9.0-dev
Downloading jruby-bin-9.1.9.0-SNAPSHOT.tar.gz...
-> http://ci.jruby.org/snapshots/master/jruby-bin-9.1.9.0-SNAPSHOT.tar.gz
Installing jruby-9.1.9.0-SNAPSHOT...
Installed jruby-9.1.9.0-SNAPSHOT to /home/yahonda/.rbenv/versions/jruby-9.1.9.0-dev
$ ruby -v
jruby 9.1.9.0-SNAPSHOT (2.3.3) 2017-04-03 e7bcde5 OpenJDK 64-Bit Server VM 25.121-b14 on 1.8.0_121-b14 +jit [linux-x86_64]
```
