### PR TITLE
End to support old rbx versions.

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -879,20 +879,6 @@ require_llvm() {
   fi
 }
 
-locate_llvm() {
-  local llvm_version="$1"
-  local package llvm_config
-  shopt -s nullglob
-  for package in `brew list 2>/dev/null | grep "^llvm"`; do
-    llvm_config="$(echo "$(brew --prefix "$package")/bin/llvm-config"*)"
-    if [ -n "$llvm_config" ] && [[ "$("$llvm_config" --version)" = "$llvm_version"* ]]; then
-      echo "$llvm_config"
-      break
-    fi
-  done
-  shopt -u nullglob
-}
-
 needs_yaml() {
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-libyaml-dir=* ]] &&
   ! use_homebrew_yaml

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -864,28 +864,15 @@ require_llvm() {
   if is_mac -ge 1010; then
     if [[ "$RUBY_CONFIGURE_OPTS" != *--llvm-* ]]; then
       case "$llvm_version" in
-      3.2 )
-        package_option ruby configure --prebuilt-name="llvm-3.2-x86_64-apple-darwin13.tar.bz2"
-        ;;
-      3.[56] )
-        local llvm_config="$(locate_llvm "$llvm_version")"
-        if [ -n "$llvm_config" ]; then
-          package_option ruby configure --llvm-config="$llvm_config"
-        else
-          local homebrew_package="llvm@$llvm_version"
-          { echo
-            colorize 1 "ERROR"
-            echo ": Rubinius will not be able to compile using Apple's LLVM-based "
-            echo "build tools on OS X. You will need to install LLVM $llvm_version first."
-            echo
-            colorize 1 "TO FIX THE PROBLEM"
-            echo ": Install Homebrew's llvm package with this"
-            echo -n "command: "
-            colorize 4 "brew install $homebrew_package"
-            echo
-          } >&3
-          return 1
-        fi
+      3.[256] )
+        local homebrew_package="llvm@$llvm_version"
+        { echo
+          colorize 1 "ERROR"
+          echo ": Rubinius will not be able to compile using Apple's LLVM-based "
+          echo "build tools on OS X. You will need to install LLVM $llvm_version."
+          echo "Unfortunately ruby-build is not support to build under rbx-3.66."
+        } >&3
+        return 1
         ;;
       esac
     fi

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -875,6 +875,18 @@ require_llvm() {
         return 1
         ;;
       esac
+
+      local llvm_config="$(echo "$(brew --prefix llvm)/bin/llvm-config"*)"
+      if [ ! -f "$llvm_config" ]; then
+        { echo ": Rubinius will not be able to compile using Apple's LLVM-based "
+          echo "build tools on OS X. You will need to install LLVM via Homebrew"
+          echo
+          echo -n "command: "
+          colorize 4 "brew install llvm"
+          echo
+        } >&3
+        return 1
+      fi
     fi
   fi
 }

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -870,7 +870,7 @@ require_llvm() {
           colorize 1 "ERROR"
           echo ": Rubinius will not be able to compile using Apple's LLVM-based "
           echo "build tools on OS X. You will need to install LLVM $llvm_version."
-          echo "Unfortunately ruby-build is not support to build under rbx-3.66."
+          echo "Unfortunately, ruby-build is not support to build under the rbx-3.66."
         } >&3
         return 1
         ;;

--- a/share/ruby-build/rbx-3.66
+++ b/share/ruby-build/rbx-3.66
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.66" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.66.tar.bz2#4bb237a1da1d52bc830bbe704bd4b995bbc07e50b558e460aff54d6bc309975e" rbx

--- a/share/ruby-build/rbx-3.66
+++ b/share/ruby-build/rbx-3.66
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.66" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.66.tar.bz2#4bb237a1da1d52bc830bbe704bd4b995bbc07e50b558e460aff54d6bc309975e" rbx

--- a/share/ruby-build/rbx-3.67
+++ b/share/ruby-build/rbx-3.67
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.67" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.67.tar.bz2#a5eedd6169f80df528ac73cf2ed9183e2f5a82a57ca0b2ae3962c26238427b87" rbx

--- a/share/ruby-build/rbx-3.67
+++ b/share/ruby-build/rbx-3.67
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.67" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.67.tar.bz2#a5eedd6169f80df528ac73cf2ed9183e2f5a82a57ca0b2ae3962c26238427b87" rbx

--- a/share/ruby-build/rbx-3.68
+++ b/share/ruby-build/rbx-3.68
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.68" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.68.tar.bz2#44f423a8557aa8fa383573638a94faaf3f9c587a771be267c60ed0c78784f567" rbx

--- a/share/ruby-build/rbx-3.68
+++ b/share/ruby-build/rbx-3.68
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.68" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.68.tar.bz2#44f423a8557aa8fa383573638a94faaf3f9c587a771be267c60ed0c78784f567" rbx

--- a/share/ruby-build/rbx-3.69
+++ b/share/ruby-build/rbx-3.69
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.69" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.69.tar.bz2#2dcde5cb7ba1e1664f6bf902cd866d2564985536a0908caeac2e4099b6b255b2" rbx

--- a/share/ruby-build/rbx-3.69
+++ b/share/ruby-build/rbx-3.69
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.69" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.69.tar.bz2#2dcde5cb7ba1e1664f6bf902cd866d2564985536a0908caeac2e4099b6b255b2" rbx

--- a/share/ruby-build/rbx-3.70
+++ b/share/ruby-build/rbx-3.70
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.70" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.70.tar.bz2#e5b22ff6f19d7ac75d94e7503ae74c0bf9a3d249ce0e80480402cf7cbd2fea19" rbx

--- a/share/ruby-build/rbx-3.70
+++ b/share/ruby-build/rbx-3.70
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.70" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.70.tar.bz2#e5b22ff6f19d7ac75d94e7503ae74c0bf9a3d249ce0e80480402cf7cbd2fea19" rbx

--- a/share/ruby-build/rbx-3.71
+++ b/share/ruby-build/rbx-3.71
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.71" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.71.tar.bz2#77bfac38feea0f7d1ebecd7be5b6fac9cefe44d00ee5932ee7ba9d1f078080b8" rbx

--- a/share/ruby-build/rbx-3.71
+++ b/share/ruby-build/rbx-3.71
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.71" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.71.tar.bz2#77bfac38feea0f7d1ebecd7be5b6fac9cefe44d00ee5932ee7ba9d1f078080b8" rbx

--- a/share/ruby-build/rbx-3.72
+++ b/share/ruby-build/rbx-3.72
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.72" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.72.tar.bz2#7dfd678536d49947e08a327eb3b96a00c49f6b4a3ee5d4b548f4840efef0726c" rbx

--- a/share/ruby-build/rbx-3.72
+++ b/share/ruby-build/rbx-3.72
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.72" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.72.tar.bz2#7dfd678536d49947e08a327eb3b96a00c49f6b4a3ee5d4b548f4840efef0726c" rbx

--- a/share/ruby-build/rbx-3.73
+++ b/share/ruby-build/rbx-3.73
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.73" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.73.tar.bz2#4fea98d26df5a00185d5d92684ec04cf6a22ca8cf6e9b47c3895ba5e6f14ea1a" rbx

--- a/share/ruby-build/rbx-3.73
+++ b/share/ruby-build/rbx-3.73
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.73" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.73.tar.bz2#4fea98d26df5a00185d5d92684ec04cf6a22ca8cf6e9b47c3895ba5e6f14ea1a" rbx

--- a/share/ruby-build/rbx-3.74
+++ b/share/ruby-build/rbx-3.74
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.74" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.74.tar.bz2#8dae2c4e4b2361cdeafb39035f8b1b1bfe6387104f43ae6026cae3234793b8e5" rbx

--- a/share/ruby-build/rbx-3.74
+++ b/share/ruby-build/rbx-3.74
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.74" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.74.tar.bz2#8dae2c4e4b2361cdeafb39035f8b1b1bfe6387104f43ae6026cae3234793b8e5" rbx

--- a/share/ruby-build/rbx-3.75
+++ b/share/ruby-build/rbx-3.75
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.75" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.75.tar.bz2#04cd1bc8fa021d569aac38cf98aeeb97f8324815f82d7ea1a0c963898c79e137" rbx

--- a/share/ruby-build/rbx-3.75
+++ b/share/ruby-build/rbx-3.75
@@ -1,2 +1,3 @@
+require_llvm
 install_package "openssl-1.0.2k" "https://www.openssl.org/source/openssl-1.0.2k.tar.gz#6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.75" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.75.tar.bz2#04cd1bc8fa021d569aac38cf98aeeb97f8324815f82d7ea1a0c963898c79e137" rbx


### PR DESCRIPTION
Related with https://github.com/rbenv/ruby-build/issues/1079

homebrew stopped to distribute llvm-3.5 and 3.6. Unfortunately, We will not support old rbx versions that are required llvm-3.5 and 3.6. Also, we will not support version required llvm-3.2.

