### PR TITLE
Ignore LibreSSL bundled with macOS 10.13

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -959,7 +959,10 @@ use_homebrew_readline() {
 
 has_broken_mac_openssl() {
   is_mac &&
-  [[ "$(/usr/bin/openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ]] &&
+  [[
+    "$(/usr/bin/openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ||
+    "$(/usr/bin/openssl version 2>/dev/null || true)" = "LibreSSL 2.2.7"
+  ]] &&
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]] &&
   ! use_homebrew_openssl
 }


### PR DESCRIPTION
macOS 10.13 High Sierra has replaced OpenSSL 0.9.8 with LibreSSL 2.2.7. Even though, the header files (`ssl.h` etc.) aren't included, so we can't use this to build Ruby.

This pull request changes `has_broken_mac_openssl()` to ignore LibreSSL bundled with macOS 10.13.