### PR TITLE
SI-740: reverse curl and wget preference

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -302,10 +302,10 @@ http() {
 
   if type aria2c &>/dev/null; then
     "http_${method}_aria2c" "$url" "$file"
-  elif type curl &>/dev/null; then
-    "http_${method}_curl" "$url" "$file"
   elif type wget &>/dev/null; then
     "http_${method}_wget" "$url" "$file"
+  elif type curl &>/dev/null; then
+    "http_${method}_curl" "$url" "$file"
   else
     echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
     exit 1


### PR DESCRIPTION
curl does not work on the Altiscale CentOS platform (through at least Prometheus 6.7.9), probably due to an old version of the openssl RPM.  Putting wget in front of curl allows the code to work on Altiscale CentOS without any degradation in functionality.
