### PR TITLE
invoke make update-gems before make install with ruby-trunk

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -531,7 +531,7 @@ build_package_warn_unsupported() {
   } >&3
 }
 
-build_package_standard() {
+build_package_standard_build() {
   local package_name="$1"
 
   if [ "${MAKEOPTS+defined}" ]; then
@@ -548,8 +548,6 @@ build_package_standard() {
   local PACKAGE_CONFIGURE_OPTS_ARRAY="${package_var_name}_CONFIGURE_OPTS_ARRAY[@]"
   local PACKAGE_MAKE_OPTS="${package_var_name}_MAKE_OPTS"
   local PACKAGE_MAKE_OPTS_ARRAY="${package_var_name}_MAKE_OPTS_ARRAY[@]"
-  local PACKAGE_MAKE_INSTALL_OPTS="${package_var_name}_MAKE_INSTALL_OPTS"
-  local PACKAGE_MAKE_INSTALL_OPTS_ARRAY="${package_var_name}_MAKE_INSTALL_OPTS_ARRAY[@]"
   local PACKAGE_CFLAGS="${package_var_name}_CFLAGS"
 
   if [ "$package_var_name" = "RUBY" ]; then
@@ -566,18 +564,33 @@ build_package_standard() {
       $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" || return 1
   ) >&4 2>&1
 
-
   { "$MAKE" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} "${!PACKAGE_MAKE_OPTS_ARRAY}"
   } >&4 2>&1
+}
 
-  if [ "$package_name" == "ruby-trunk" ]; then
-    { "$MAKE" update-gems
-      "$MAKE" extract-gems
-    } >&4 2>&1
-  fi
+build_package_standard_install() {
+  local package_name="$1"
+  local package_var_name="$(capitalize "${package_name%%-*}")"
+
+  local PACKAGE_MAKE_INSTALL_OPTS="${package_var_name}_MAKE_INSTALL_OPTS"
+  local PACKAGE_MAKE_INSTALL_OPTS_ARRAY="${package_var_name}_MAKE_INSTALL_OPTS_ARRAY[@]"
 
   { "$MAKE" install $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}"
   } >&4 2>&1
+}
+
+build_package_standard_install_with_bundled_gems() {
+  { "$MAKE" update-gems
+    "$MAKE" extract-gems
+  } >&4 2>&1
+
+  build_package_standard_install
+}
+
+# Backword Compatibility for standard function
+build_package_standard() {
+  build_package_standard_build
+  build_package_standard_install
 }
 
 build_package_autoconf() {

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -566,8 +566,16 @@ build_package_standard() {
       $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS} "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" || return 1
   ) >&4 2>&1
 
+
   { "$MAKE" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} "${!PACKAGE_MAKE_OPTS_ARRAY}"
-    "$MAKE" install $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}"
+  } >&4 2>&1
+
+  if [ "$package_name" == "ruby-trunk" ]; then
+    { "$MAKE" update-gems
+    } >&4 2>&1
+  fi
+
+  { "$MAKE" install $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}"
   } >&4 2>&1
 }
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -584,13 +584,13 @@ build_package_standard_install_with_bundled_gems() {
     "$MAKE" extract-gems
   } >&4 2>&1
 
-  build_package_standard_install
+  build_package_standard_install "$@"
 }
 
 # Backword Compatibility for standard function
 build_package_standard() {
-  build_package_standard_build
-  build_package_standard_install
+  build_package_standard_build "$@"
+  build_package_standard_install "$@"
 }
 
 build_package_autoconf() {

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -572,6 +572,7 @@ build_package_standard() {
 
   if [ "$package_name" == "ruby-trunk" ]; then
     { "$MAKE" update-gems
+      "$MAKE" extract-gems
     } >&4 2>&1
   fi
 

--- a/share/ruby-build/2.2.0-dev
+++ b/share/ruby-build/2.2.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2l" "https://www.openssl.org/source/openssl-1.0.2l.tar.gz#ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" ldflags_dirs autoconf standard verify_openssl
+install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.3.0-dev
+++ b/share/ruby-build/2.3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2l" "https://www.openssl.org/source/openssl-1.0.2l.tar.gz#ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" ldflags_dirs autoconf standard verify_openssl
+install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0f" "https://www.openssl.org/source/openssl-1.1.0f.tar.gz#12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765"  mac_openssl --if has_broken_mac_openssl 
-install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" ldflags_dirs autoconf standard verify_openssl
+install_package "openssl-1.1.0f" "https://www.openssl.org/source/openssl-1.1.0f.tar.gz#12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765"  mac_openssl --if has_broken_mac_openssl
+install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0f" "https://www.openssl.org/source/openssl-1.1.0f.tar.gz#12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765"  mac_openssl --if has_broken_mac_openssl 
-install_git "ruby-trunk" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard verify_openssl
+install_package "openssl-1.1.0f" "https://www.openssl.org/source/openssl-1.1.0f.tar.gz#12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765"  mac_openssl --if has_broken_mac_openssl
+install_git "ruby-trunk" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
Fixes #1093 

Added `make update-gems` command before `make install` when installing to 2.5.0-dev named "ruby-trunk"

/cc @k0kubun

I'm not a familiar with shell script. Can I handle ruby-trunk, ruby-2.4.0-dev and ruby-2.3.0-dev smartly?