### PR TITLE
Fix installing error on macOS 10.13

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -957,9 +957,18 @@ use_homebrew_readline() {
   fi
 }
 
+is_broken_openssl() {
+  openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
+  if [[ "$openssl_version" = "OpenSSL 0.9.8"?* ]] || [[ "$openssl_version" = "LibreSSL 2.2"? ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 has_broken_mac_openssl() {
   is_mac &&
-  [[ "$(/usr/bin/openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ]] &&
+  is_broken_openssl &&
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]] &&
   ! use_homebrew_openssl
 }


### PR DESCRIPTION
Now, `rbenv install` fails on macOS 10.13.

![](https://pbs.twimg.com/media/DBpJHj1UMAExqMz.jpg:large)

macOS 10.13 beta has bundled LibreSSL 2.2.7 as OpenSSL library.
```
$ sw_vers -productVersion
10.13
$ /usr/bin/openssl version
LibreSSL 2.2.7
```

However, seems that Ruby has supported LibreSSL 2.3+, not support 2.2.7
 (https://github.com/ruby/ruby/blob/aab0d67a1ff5190ff7a951e40cee742210302aed/ext/openssl/History.md#supported-platforms)

So, if system bundled older LibreSSL, this patch will use OpenSSL installed by homebrew to fix installing error.