### PR TITLE
Improve check for openssl on macOS

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -958,11 +958,9 @@ use_homebrew_readline() {
 }
 
 has_broken_mac_openssl() {
-  is_mac &&
-  [[
-    "$(/usr/bin/openssl version 2>/dev/null || true)" = "OpenSSL 0.9.8"?* ||
-    "$(/usr/bin/openssl version 2>/dev/null || true)" = "LibreSSL 2.2.7"
-  ]] &&
+  is_mac || return 1
+  local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
+  [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]] &&
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]] &&
   ! use_homebrew_openssl
 }


### PR DESCRIPTION
- Only call `openssl version` once;

- Make the check work with future version of LibreSSL after 2.2.7. This assumes that Apple might keep updating LibreSSL shipping with macOS, but that they will never provide header files.

Followup to https://github.com/rbenv/ruby-build/pull/1095

/cc @hsbt @osyoyu