### PR TITLE
Quote JRuby check on FreeBSD to avoid "unary operator" syntax issue.

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1281,7 +1281,7 @@ fi
 
 if [ -z "$MAKE" ]; then
   if [ "FreeBSD" = "$(uname -s)" ]; then
-    if [ $(echo $1 | sed 's/-.*$//') = "jruby" ]; then
+    if [ "$(echo $1 | sed 's/-.*$//')" = "jruby" ]; then
       export MAKE="gmake"
     else
       if [ "$(uname -r | sed 's/[^[:digit:]].*//')" -lt 10 ]; then


### PR DESCRIPTION
Currently, if you pass an argument like '-v' or '-k' to ruby-build on a FreeBSD system, you get a shell syntax warning about '=' being used as a unary operator.

This is happening because of some missing quotes, and no longer complains once they are added.