### PR TITLE
Add JRuby 9.2.0.0 snapshot

### DIFF
--- a/share/ruby-build/jruby-9.2.0.0-dev
+++ b/share/ruby-build/jruby-9.2.0.0-dev
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.2.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-bin-9.2.0.0-SNAPSHOT.tar.gz" jruby


### PR DESCRIPTION
```ruby
$ rbenv install jruby-9.2.0.0-dev
Downloading jruby-bin-9.2.0.0-SNAPSHOT.tar.gz...
-> http://ci.jruby.org/snapshots/master/jruby-bin-9.2.0.0-SNAPSHOT.tar.gz
Installing jruby-9.2.0.0-SNAPSHOT...
/home/yahonda/.rbenv/plugins/ruby-build/bin/ruby-build: line 717: warning: command substitution: ignored null byte in input
/home/yahonda/.rbenv/plugins/ruby-build/bin/ruby-build: line 717: warning: command substitution: ignored null byte in input
Installed jruby-9.2.0.0-SNAPSHOT to /home/yahonda/.rbenv/versions/jruby-9.2.0.0-dev

$ rbenv global jruby-9.2.0.0-dev
$ ruby -v
jruby 9.2.0.0-SNAPSHOT (2.4.1) 2017-08-15 ef6da47 OpenJDK 64-Bit Server VM 25.141-b16 on 1.8.0_141-b16 +jit [linux-x86_64]
```