### PR TITLE
Ignore everything after whitespace in the output from sha256sum

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -225,7 +225,7 @@ compute_sha2() {
     echo "${output##* }"
   elif type sha256sum &>/dev/null; then
     output="$(sha256sum --quiet)" || return 1
-    echo "${output% *}"
+    echo "${output%% *}"
   else
     return 1
   fi
@@ -240,7 +240,7 @@ compute_md5() {
     echo "${output##* }"
   elif type md5sum &>/dev/null; then
     output="$(md5sum -b)" || return 1
-    echo "${output% *}"
+    echo "${output%% *}"
   else
     return 1
   fi


### PR DESCRIPTION
The issue has originarily reported as pyenv/pyenv#902.

Unlike sha256sum of GNU coreutils, BusyBox one doesn't print '*' and prints extra whitespaces, when computing digest from stdin.

sha256sum (GNU coreutils 8.26)

```
% cat /sbin/init | sha256sum -b
ef753e9504ada221155b86e7e6b7b4ff2499d64e27bcd959f0542bcac589feb1 *-
```

sha256sum (BusyBox v1.26.2)

```
/ # cat /sbin/init | sha256sum -b
4cd6d1a4028772fabc9166bb52b5826aec4e91874c107fce33dc515c04cb754f  -
```

I also confirmed that md5sum behaves just similarly.

Actually sha256sum feature won't work correctly even with this unless merging #1059.