### PR TITLE
Add JRuby 9.1.13.0

### DIFF
--- a/share/ruby-build/jruby-9.1.13.0
+++ b/share/ruby-build/jruby-9.1.13.0
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.1.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.tar.gz#9d156646623ac2f27174721035b52572a4b05690db7c1293295aa2c04aad3908" jruby


### PR DESCRIPTION
This pull request enables to install JRuby 9.1.13.0

http://jruby.org/2017/09/06/jruby-9-1-13-0

```ruby
$ rbenv install jruby-9.1.13.0
Downloading jruby-bin-9.1.13.0.tar.gz...
-> https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.tar.gz
Installing jruby-9.1.13.0...
/home/yahonda/.rbenv/plugins/ruby-build/bin/ruby-build: line 717: warning: command substitution: ignored null byte in input
/home/yahonda/.rbenv/plugins/ruby-build/bin/ruby-build: line 717: warning: command substitution: ignored null byte in input
Installed jruby-9.1.13.0 to /home/yahonda/.rbenv/versions/jruby-9.1.13.0
$ rbenv global jruby-9.1.13.0
$ ruby -v
jruby 9.1.13.0 (2.3.3) 2017-09-06 8e1c115 OpenJDK 64-Bit Server VM 25.141-b16 on 1.8.0_141-b16 +jit [linux-x86_64]
$
```
