### PR TITLE
Relax java version regexp

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -773,7 +773,7 @@ fix_rbx_irb() {
 
 require_java7() {
   local version="$(java -version 2>&1 | grep '\(java\|openjdk\) version' | head -1)"
-  if [[ $version != *1.[789]* ]]; then
+  if [[ $version != *[789]* ]]; then
     colorize 1 "ERROR" >&3
     echo ": Java 7 required. Please install a 1.7-compatible JRE." >&3
     return 1

--- a/test/build.bats
+++ b/test/build.bats
@@ -622,6 +622,18 @@ DEF
   assert_success
 }
 
+@test "JRuby Java 9 version string" {
+  cached_tarball "jruby-9000.dev" bin/jruby
+
+  stub java '-version : echo java version "9" >&2'
+
+  run_inline_definition <<DEF
+require_java7
+install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+DEF
+  assert_success
+}
+
 @test "non-writable TMPDIR aborts build" {
   export TMPDIR="${TMP}/build"
   mkdir -p "$TMPDIR"


### PR DESCRIPTION
This allows the java version to be specified as "9", instead of "1.9".

Closes #1135