### PR TITLE
Add definition for JRuby 9.1.14.0

### DIFF
--- a/share/ruby-build/jruby-9.1.14.0
+++ b/share/ruby-build/jruby-9.1.14.0
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.1.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.14.0/jruby-dist-9.1.14.0-bin.tar.gz#074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651" jruby


### PR DESCRIPTION
## Summary

JRuby 9.1.14.0 has been released.
http://jruby.org/2017/11/08/jruby-9-1-14-0.html

## Other Information

JRuby 9.1.14.0+ download URL has changed.
https://github.com/rbenv/ruby-build/issues/1148