### PR TITLE
Add JRuby 9.1.15.0

### DIFF
--- a/share/ruby-build/jruby-9.1.15.0
+++ b/share/ruby-build/jruby-9.1.15.0
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.1.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.15.0/jruby-dist-9.1.15.0-bin.tar.gz#4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e" jruby


### PR DESCRIPTION
This pull request adds JRuby 9.1.15.0

http://jruby.org/2017/12/07/jruby-9-1-15-0.html

```ruby
$ rbenv install jruby-9.1.15.0
Downloading jruby-dist-9.1.15.0-bin.tar.gz...
-> https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.15.0/jruby-dist-9.1.15.0-bin.tar.gz
Installing jruby-9.1.15.0...
/home/yahonda/.rbenv/plugins/ruby-build/bin/ruby-build: line 718: warning: command substitution: ignored null byte in input
/home/yahonda/.rbenv/plugins/ruby-build/bin/ruby-build: line 718: warning: command substitution: ignored null byte in input
Installed jruby-9.1.15.0 to /home/yahonda/.rbenv/versions/jruby-9.1.15.0

[yahonda@li1273-210 ruby-build (jruby91150)]$ rbenv global jruby-9.1.15.0
[yahonda@li1273-210 ruby-build (jruby91150)]$ ruby -v
jruby 9.1.15.0 (2.3.3) 2017-12-07 929fde8 OpenJDK 64-Bit Server VM 25.151-b12 on 1.8.0_151-b12 [linux-x86_64]
$
```