### PR TITLE
Add 2.4.3, 2.3.6, 2.2.9, and 2.5.0-rc1

### DIFF
--- a/share/ruby-build/2.2.9
+++ b/share/ruby-build/2.2.9
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.2n" "https://www.openssl.org/source/openssl-1.0.2n.tar.gz#370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.2.9" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2#5e3cfcc3b69638e165f72f67b1321fa05aff62b0f9e9b32042a5a79614e7c70a" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.6
+++ b/share/ruby-build/2.3.6
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.2n" "https://www.openssl.org/source/openssl-1.0.2n.tar.gz#370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0g.tar.gz#de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"  mac_openssl --if has_broken_mac_openssl 
+install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.0-rc1
+++ b/share/ruby-build/2.5.0-rc1
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0g.tar.gz#de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"  mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
[CVE-2017-17405: Command injection vulnerability in Net::FTP](https://www.ruby-lang.org/en/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/)

- [Ruby 2.2.9 Released
](https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/)
- [Ruby 2.3.6 Released](https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-3-6-released/)
- [Ruby 2.4.3 Released](https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released/)
- [Ruby 2.5.0-rc1 Released](https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-5-0-rc1-released/)

