### PR TITLE
Fix rbenv install on Solaris / Illumos

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -153,6 +153,9 @@ num_cpu_cores() {
   Darwin | *BSD )
     num="$(sysctl -n hw.ncpu 2>/dev/null || true)"
     ;;
+  SunOS )
+    num="$(getconf NPROCESSORS_ONLN 2>/dev/null || true)"
+    ;;
   * )
     num="$({ getconf _NPROCESSORS_ONLN ||
              grep -c ^processor /proc/cpuinfo; } 2>/dev/null)"


### PR DESCRIPTION
rbenv install crashes on Solaris with an empty log file. Adding support
for the proper Solaris getconf call in num_cpu_cores fixed it. Tested
and working under OmniOS CE r151024.