### PR TITLE
Add snapshot and stable-snapshot

### DIFF
--- a/share/ruby-build/snapshot
+++ b/share/ruby-build/snapshot
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0g.tar.gz#de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"  mac_openssl --if has_broken_mac_openssl
+install_package "snapshot" "https://cache.ruby-lang.org/pub/ruby/snapshot.tar.bz2" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/stable-snapshot
+++ b/share/ruby-build/stable-snapshot
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0g.tar.gz#de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"  mac_openssl --if has_broken_mac_openssl
+install_package "stable-snapshot" "https://cache.ruby-lang.org/pub/ruby/stable-snapshot.tar.bz2" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
They are useful on environments without autoconf etc.
Based on share/ruby-build/2.5.0.
When autoconf is old (for example CentOS 6), 2.5.0-dev can not install.