### PR TITLE
Add definition for Ruby 2.6.0-preview1

### DIFF
--- a/share/ruby-build/2.6.0-preview1
+++ b/share/ruby-build/2.6.0-preview1
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0g.tar.gz#de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"  mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.6.0-preview1 has been released.
https://www.ruby-lang.org/en/news/2018/02/24/ruby-2-6-0-preview1-released/