### PR TITLE
Add definition for Ruby 2.5.1, 2.4.4, 2.3.7 and 2.2.10

### DIFF
--- a/share/ruby-build/2.2.10
+++ b/share/ruby-build/2.2.10
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.2n" "https://www.openssl.org/source/openssl-1.0.2n.tar.gz#370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.2.10" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.bz2#a54204d2728283c9eff0cf81d654f245fa5b3447d0824f1a6bc3b2c5c827381e" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.7
+++ b/share/ruby-build/2.3.7
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.2n" "https://www.openssl.org/source/openssl-1.0.2n.tar.gz#370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0g.tar.gz#de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"  mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.1
+++ b/share/ruby-build/2.5.1
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0g" "https://www.openssl.org/source/openssl-1.1.0g.tar.gz#de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"  mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
These Rubies has been released.

- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/
- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/
- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-3-7-released/
- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/