### PR TITLE
Allow overriding HTTP client type based on environment variable of `RUBY_BUILD_HTTP_CLIENT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The build process may be configured through the following environment variables:
 | `TMPDIR`                 | Where temporary files are stored.                                                                |
 | `RUBY_BUILD_BUILD_PATH`  | Where sources are downloaded and built. (Default: a timestamped subdirectory of `TMPDIR`)        |
 | `RUBY_BUILD_CACHE_PATH`  | Where to cache downloaded package files. (Default: `~/.rbenv/cache` if invoked as rbenv plugin)  |
+| `RUBY_BUILD_HTTP_CLIENT` | One of `aria2c`, `curl`, or `wget` to use for downloading. (Default: first one found in PATH)    |
+| `RUBY_BUILD_ARIA2_OPTS`  | Additional options to pass to `aria2c` for downloading.                                          |
+| `RUBY_BUILD_CURL_OPTS`   | Additional options to pass to `curl` for downloading.                                            |
+| `RUBY_BUILD_WGET_OPTS`   | Additional options to pass to `wget` for downloading.                                            |
 | `RUBY_BUILD_MIRROR_URL`  | Custom mirror URL root.                                                                          |
 | `RUBY_BUILD_SKIP_MIRROR` | Always download from official sources, not mirrors. (Default: unset)                             |
 | `RUBY_BUILD_ROOT`        | Custom build definition directory. (Default: `share/ruby-build`)                                 |

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -300,26 +300,25 @@ verify_checksum() {
 
 http() {
   local method="$1"
-  local url="$2"
-  local file="$3"
-  [ -n "$url" ] || return 1
+  [ -n "$2" ] || return 1
+  shift 1
 
-  local http_client
-  if [ -n "${RUBY_BUILD_HTTP_CLIENT}" ]; then
-    http_client="http_${method}_${RUBY_BUILD_HTTP_CLIENT}"
-  else
-    if type aria2c &>/dev/null; then
-      http_client="http_${method}_aria2c"
-    elif type curl &>/dev/null; then
-      http_client="http_${method}_curl"
-    elif type wget &>/dev/null; then
-      http_client="http_${method}_wget"
-    else
-      echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
-      exit 1
+  RUBY_BUILD_HTTP_CLIENT="${RUBY_BUILD_HTTP_CLIENT:-$(detect_http_client)}"
+  [ -n "$RUBY_BUILD_HTTP_CLIENT" ] || return 1
+
+  "http_${method}_${RUBY_BUILD_HTTP_CLIENT}" "$@"
+}
+
+detect_http_client() {
+  local client
+  for client in aria2c curl wget; do
+    if type "$client" &>/dev/null; then
+      echo "$client"
+      return
     fi
-  fi
-  "${http_client}" "$url" "$file"
+  done
+  echo "error: please install \`aria2c\`, \`curl\`, or \`wget\` and try again" >&2
+  return 1
 }
 
 http_head_aria2c() {

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -304,16 +304,22 @@ http() {
   local file="$3"
   [ -n "$url" ] || return 1
 
-  if type aria2c &>/dev/null; then
-    "http_${method}_aria2c" "$url" "$file"
-  elif type curl &>/dev/null; then
-    "http_${method}_curl" "$url" "$file"
-  elif type wget &>/dev/null; then
-    "http_${method}_wget" "$url" "$file"
+  local http_client
+  if [ -n "${RUBY_BUILD_HTTP_CLIENT}" ]; then
+    http_client="http_${method}_${RUBY_BUILD_HTTP_CLIENT}"
   else
-    echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
-    exit 1
+    if type aria2c &>/dev/null; then
+      http_client="http_${method}_aria2c"
+    elif type curl &>/dev/null; then
+      http_client="http_${method}_curl"
+    elif type wget &>/dev/null; then
+      http_client="http_${method}_wget"
+    else
+      echo "error: please install \`aria2c\`, \`curl\` or \`wget\` and try again" >&2
+      exit 1
+    fi
   fi
+  "${http_client}" "$url" "$file"
 }
 
 http_head_aria2c() {

--- a/test/build.bats
+++ b/test/build.bats
@@ -8,7 +8,6 @@ export CC=cc
 export -n RUBY_CONFIGURE_OPTS
 
 setup() {
-  ensure_not_found_in_path aria2c
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
   stub curl false

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -3,10 +3,8 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH="$TMP/cache"
-export RUBY_BUILD_CURL_OPTS=
 
 setup() {
-  ensure_not_found_in_path aria2c
   mkdir "$RUBY_BUILD_CACHE_PATH"
 }
 

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -3,11 +3,6 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
-export RUBY_BUILD_CURL_OPTS=
-
-setup() {
-  ensure_not_found_in_path aria2c
-}
 
 
 @test "package URL without checksum" {

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -3,10 +3,8 @@
 load test_helper
 export RUBY_BUILD_SKIP_MIRROR=1
 export RUBY_BUILD_CACHE_PATH=
-export RUBY_BUILD_ARIA2_OPTS=
 
 setup() {
-  ensure_not_found_in_path aria2c
   export RUBY_BUILD_BUILD_PATH="${TMP}/source"
   mkdir -p "${RUBY_BUILD_BUILD_PATH}"
 }
@@ -21,6 +19,8 @@ setup() {
 }
 
 @test "using aria2c if available" {
+  export RUBY_BUILD_ARIA2_OPTS=
+  export RUBY_BUILD_HTTP_CLIENT="aria2c"
   stub aria2c "--allow-overwrite=true --no-conf=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
 
   install_fixture definitions/without-checksum

--- a/test/fetch.bats
+++ b/test/fetch.bats
@@ -20,7 +20,7 @@ setup() {
 
 @test "using aria2c if available" {
   export RUBY_BUILD_ARIA2_OPTS=
-  export RUBY_BUILD_HTTP_CLIENT="aria2c"
+  export -n RUBY_BUILD_HTTP_CLIENT
   stub aria2c "--allow-overwrite=true --no-conf=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$4"
 
   install_fixture definitions/without-checksum

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -4,11 +4,6 @@ load test_helper
 export RUBY_BUILD_SKIP_MIRROR=
 export RUBY_BUILD_CACHE_PATH=
 export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
-export RUBY_BUILD_CURL_OPTS=
-
-setup() {
-  ensure_not_found_in_path aria2c
-}
 
 
 @test "package URL without checksum bypasses mirror" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,4 +1,6 @@
 export TMP="$BATS_TEST_DIRNAME/tmp"
+export RUBY_BUILD_CURL_OPTS=
+export RUBY_BUILD_HTTP_CLIENT="curl"
 
 if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures"
@@ -8,35 +10,6 @@ if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   PATH="$TMP/bin:$PATH"
   export PATH
 fi
-
-remove_command_from_path() {
-  OLDIFS="${IFS}"
-  local cmd="$1"
-  local path
-  local paths=()
-  IFS=:
-  for path in ${PATH}; do
-    if [ -e "${path}/${cmd}" ]; then
-      local tmp_path="$(mktemp -d "${TMP}/path.XXXXX")"
-      ln -fs "${path}"/* "${tmp_path}"
-      rm -f "${tmp_path}/${cmd}"
-      paths["${#paths[@]}"]="${tmp_path}"
-    else
-      paths["${#paths[@]}"]="${path}"
-    fi
-  done
-  export PATH="${paths[*]}"
-  IFS="${OLDIFS}"
-}
-
-ensure_not_found_in_path() {
-  local cmd
-  for cmd; do
-    if command -v "${cmd}" 1>/dev/null 2>&1; then
-      remove_command_from_path "${cmd}"
-    fi
-  done
-}
 
 teardown() {
   rm -fr "${TMP:?}"/*


### PR DESCRIPTION
This allows users to choose appropriate HTTP client for ruby-build based on environment variable of `RUBY_BUILD_HTTP_CLIENT`. Since rbenv is based on shim script architecture, checking some command's availability based on the visibility in `$PATH` (e.g. `type aria2c`) is not actually appropriate way to do so.

The issue was originally reported as pyenv/pyenv#1126 that there was some problem in `aria2c` package of FreeBSD and `python-build` was always preferred to use it since it was on the top of the list. I think similar issue can happen with `ruby-build` too. This provides users to prepare some workaround for situations like that.