### PR TITLE
Add definition for JRuby 9.2.0.0 and JRuby 9.2.1.0-dev

### DIFF
--- a/share/ruby-build/jruby-9.2.0.0
+++ b/share/ruby-build/jruby-9.2.0.0
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.2.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.0.0/jruby-bin-9.2.0.0.tar.gz#42718dea5fc90b7696cb3fccf8e8d546729173963ad0bc477d66545677d00684" jruby

--- a/share/ruby-build/jruby-9.2.1.0-dev
+++ b/share/ruby-build/jruby-9.2.1.0-dev
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.2.1.0-SNAPSHOT" "https://projectodd.ci.cloudbees.com/view/JRuby/job/jruby-development-dist/lastSuccessfulBuild/artifact/release/jruby-bin-9.2.1.0-SNAPSHOT.tar.gz" jruby


### PR DESCRIPTION
JRuby 9.2.0.0 has been released.
http://jruby.org/2018/05/24/jruby-9-2-0-0