### PR TITLE
Add definition for Ruby 2.6.0-preview2

### DIFF
--- a/share/ruby-build/2.6.0-preview2
+++ b/share/ruby-build/2.6.0-preview2
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0h" "https://www.openssl.org/source/openssl-1.1.0h.tar.gz#5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517"  mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.6.0-preview2 has been released!

https://www.ruby-lang.org/ja/news/2018/05/31/ruby-2-6-0-preview2-released/