### PR TITLE
Add TruffleRuby to ruby-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ The build process may be configured through the following environment variables:
 #### Applying Patches
 
 Both `rbenv install` and `ruby-build` support the `--patch` (`-p`) flag to apply
-a patch to the Ruby (/JRuby/Rubinius) source code before building. Patches are
-read from `STDIN`:
+a patch to the Ruby (/JRuby/Rubinius/TruffleRuby) source code before building.
+Patches are read from `STDIN`:
 
 ```sh
 # applying a single patch

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -728,6 +728,21 @@ fix_jruby_shebangs() {
   done
 }
 
+build_package_truffleruby() {
+  if ! opt --version &>/dev/null; then
+    echo ""
+    echo "TruffleRuby requires LLVM to be installed to run native extensions."
+    echo "For more details and for setup instructions for your system, please see:"
+    echo "https://github.com/oracle/truffleruby/blob/master/doc/user/installing-llvm.md"
+    exit 1
+  fi
+
+  build_package_copy
+
+  cd "${PREFIX_PATH}"
+  ./lib/truffle/post_install_hook.sh
+}
+
 remove_windows_files() {
   cd "$PREFIX_PATH"
   rm -f bin/*.exe bin/*.dll bin/*.bat bin/jruby.sh

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -381,7 +381,10 @@ fetch_tarball() {
     download_tarball "$package_url" "$package_filename" "$checksum"
   fi
 
-  { if tar $tar_args "$package_filename"; then
+  mkdir "$package_name"
+
+  { if tar $tar_args "$package_filename" -C "$package_name" --strip-components=1; then
+  ls >&2
       if [ -z "$KEEP_BUILD_PATH" ]; then
         rm -f "$package_filename"
       else

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1154,7 +1154,7 @@ isolated_gem_install() {
 apply_ruby_patch() {
   local patchfile
   case "$1" in
-  ruby-* | jruby-* | rubinius-* )
+  ruby-* | jruby-* | rubinius-* | truffleruby-* )
     patchfile="$(mktemp "${TMP}/ruby-patch.XXXXXX")"
     cat "${2:--}" >"$patchfile"
 

--- a/share/ruby-build/truffleruby-1.0.0-rc2
+++ b/share/ruby-build/truffleruby-1.0.0-rc2
@@ -1,0 +1,7 @@
+install_package "openssl-1.1.0h" "https://www.openssl.org/source/openssl-1.1.0h.tar.gz#5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" mac_openssl --if has_broken_mac_openssl
+
+if is_mac; then
+  install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-macos-amd64.tar.gz#308a5bf727914803cc0f794fd1aea89fd5f80ce00a97120372be9c58a930b82c" truffleruby
+else
+  install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-linux-amd64.tar.gz#2b7d999646dcfb895e49a41606a0b53ca055f291fb0cc33002944655fc3e2acb" truffleruby
+fi

--- a/test/build.bats
+++ b/test/build.bats
@@ -634,6 +634,34 @@ DEF
   assert_success
 }
 
+@test "TruffleRuby post-install hook" {
+  executable "${RUBY_BUILD_CACHE_PATH}/truffleruby-test/lib/truffle/post_install_hook.sh" <<OUT
+echo Running post-install hook
+OUT
+  cached_tarball "truffleruby-test" bin/truffleruby
+  stub opt true
+
+  run_inline_definition <<DEF
+install_package "truffleruby-test" "URL" truffleruby
+DEF
+  assert_success
+  assert_output_contains "Running post-install hook"
+}
+
+@test "TruffleRuby LLVM missing" {
+  executable "${RUBY_BUILD_CACHE_PATH}/truffleruby-test/lib/truffle/post_install_hook.sh" <<OUT
+echo Running post-install hook
+OUT
+  cached_tarball "truffleruby-test" bin/truffleruby
+  stub opt false
+
+  run_inline_definition <<DEF
+install_package "truffleruby-test" "URL" truffleruby
+DEF
+  assert_failure
+  assert_output_contains "TruffleRuby requires LLVM to be installed to run native extensions."
+}
+
 @test "non-writable TMPDIR aborts build" {
   export TMPDIR="${TMP}/build"
   mkdir -p "$TMPDIR"

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -8,6 +8,7 @@ NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
   assert_success
   assert_output_contains "1.9.3-p194"
   assert_output_contains "jruby-1.7.9"
+  assert_output_contains "truffleruby-1.0.0-rc2"
   assert [ "${#lines[*]}" -eq "$NUM_DEFINITIONS" ]
 }
 
@@ -90,7 +91,8 @@ jruby-1.7.1
 jruby-1.7.9
 jruby-1.7.10
 jruby-9000-dev
-jruby-9000"
+jruby-9000
+truffleruby-1.0.0-rc2"
   for ver in $expected; do
     touch "${RUBY_BUILD_ROOT}/share/ruby-build/$ver"
   done


### PR DESCRIPTION
Hello,

Here is a PR to add [TruffleRuby](https://github.com/oracle/truffleruby) to ruby-build.
I tried to keep the logic as simple as possible, and to update all relevant places mentioning other implementations.

I tested it locally and it seems to work well.
I also added a couple tests for the new logic.

This is a fully open-source version of TruffleRuby, corresponding to a subset of the Community Edition of GraalVM (See http://www.graalvm.org/downloads/)
It includes the [`native` configuration](https://github.com/oracle/truffleruby#truffleruby-configurations) only, not the `JVM` configuration, so there is no JVM involved.