### PR TITLE
Add definition for TruffleRuby 1.0.0 RC3

### DIFF
--- a/share/ruby-build/truffleruby-1.0.0-rc3
+++ b/share/ruby-build/truffleruby-1.0.0-rc3
@@ -1,0 +1,7 @@
+install_package "openssl-1.1.0h" "https://www.openssl.org/source/openssl-1.1.0h.tar.gz#5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" mac_openssl --if has_broken_mac_openssl
+
+if is_mac; then
+  install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-macos-amd64.tar.gz#8b6805df62e6e11982d1ec035269a51c325626c5d38ac8e10d28ae17eefee041" truffleruby
+else
+  install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-linux-amd64.tar.gz#d54bf05866d50e4fe589a7e8f30935062245292eb338098d143cbd67f33c823a" truffleruby
+fi


### PR DESCRIPTION
TruffleRuby 1.0.0-rc3 [has been released](https://github.com/oracle/truffleruby/releases).
In general, we have a release about once a month.

cc @hsbt 