### PR TITLE
Remove early check for LLVM when installing TruffleRuby

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -729,14 +729,6 @@ fix_jruby_shebangs() {
 }
 
 build_package_truffleruby() {
-  if ! opt --version &>/dev/null; then
-    echo ""
-    echo "TruffleRuby requires LLVM to be installed to run native extensions."
-    echo "For more details and for setup instructions for your system, please see:"
-    echo "https://github.com/oracle/truffleruby/blob/master/doc/user/installing-llvm.md"
-    exit 1
-  fi
-
   build_package_copy
 
   cd "${PREFIX_PATH}"

--- a/test/build.bats
+++ b/test/build.bats
@@ -639,27 +639,12 @@ DEF
 echo Running post-install hook
 OUT
   cached_tarball "truffleruby-test" bin/truffleruby
-  stub opt true
 
   run_inline_definition <<DEF
 install_package "truffleruby-test" "URL" truffleruby
 DEF
   assert_success
   assert_output_contains "Running post-install hook"
-}
-
-@test "TruffleRuby LLVM missing" {
-  executable "${RUBY_BUILD_CACHE_PATH}/truffleruby-test/lib/truffle/post_install_hook.sh" <<OUT
-echo Running post-install hook
-OUT
-  cached_tarball "truffleruby-test" bin/truffleruby
-  stub opt false
-
-  run_inline_definition <<DEF
-install_package "truffleruby-test" "URL" truffleruby
-DEF
-  assert_failure
-  assert_output_contains "TruffleRuby requires LLVM to be installed to run native extensions."
 }
 
 @test "non-writable TMPDIR aborts build" {


### PR DESCRIPTION
* TruffleRuby already checks for LLVM itself when it needs it and looks up more paths to find the LLVM executables `clang` and `opt` (TruffleRuby also looks up in Homebrew and MacPorts directories on macOS).
* It's also needlessly restrictive for Homebrew and MacPorts (forcing the LLVM executables to be in `PATH`), so it should be removed.
* See https://github.com/oracle/truffleruby/issues/1386.

A similar PR was merged to RVM (https://github.com/rvm/rvm/pull/4427).

cc @hsbt 