### PR TITLE
Handle non-git patches

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1151,7 +1151,7 @@ apply_ruby_patch() {
     cat "${2:--}" >"$patchfile"
 
     local striplevel=0
-    grep -q '^diff --git a/' "$patchfile" && striplevel=1
+    grep -q '^--- a/' "$patchfile" && striplevel=1
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac


### PR DESCRIPTION
Detecting `$striplevel` relies on a git-specific line, so it is now made
to not depend on a git-specific match that is reliably present in all
patch formats.

Fixes #1159