### PR TITLE
Add definition for TruffleRuby 1.0.0-rc5

### DIFF
--- a/share/ruby-build/truffleruby-1.0.0-rc5
+++ b/share/ruby-build/truffleruby-1.0.0-rc5
@@ -1,0 +1,7 @@
+install_package "openssl-1.1.0h" "https://www.openssl.org/source/openssl-1.1.0h.tar.gz#5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" mac_openssl --if has_broken_mac_openssl
+
+if is_mac; then
+  install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-macos-amd64.tar.gz#d05798f9bd302eb6e03daa608e2a65fc01abc9cddcd6f60150e625fb84c1199c" truffleruby
+else
+  install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-linux-amd64.tar.gz#c40cf6f8b2d664aa22a2b230af0e5889a9bf7ec07de9fb84454f5ab05d43c90c" truffleruby
+fi


### PR DESCRIPTION
* No 1.0.0-rc4 as that was a Graal JavaScript-only release.

cc @hsbt 