### PR TITLE
More portable rename after tarball extraction

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -381,10 +381,7 @@ fetch_tarball() {
     download_tarball "$package_url" "$package_filename" "$checksum"
   fi
 
-  mkdir "$package_name"
-
-  { if tar $tar_args "$package_filename" -C "$package_name" --strip-components=1; then
-  ls >&2
+  { if tar $tar_args "$package_filename"; then
       if [ -z "$KEEP_BUILD_PATH" ]; then
         rm -f "$package_filename"
       else

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -350,6 +350,7 @@ fetch_tarball() {
   local package_url="$2"
   local mirror_url
   local checksum
+  local extracted_dir
 
   if [ "$package_url" != "${package_url/\#}" ]; then
     checksum="${package_url#*#}"
@@ -382,6 +383,11 @@ fetch_tarball() {
   fi
 
   { if tar $tar_args "$package_filename"; then
+      if [ ! -d "$package_name" ]; then
+        extracted_dir=$(find_extracted_directory)
+        mv "$extracted_dir" "$package_name"
+      fi
+
       if [ -z "$KEEP_BUILD_PATH" ]; then
         rm -f "$package_filename"
       else
@@ -389,6 +395,17 @@ fetch_tarball() {
       fi
     fi
   } >&4 2>&1
+}
+
+find_extracted_directory() {
+  for f in *; do
+    if [ -d "$f" ]; then
+      echo "$f"
+      return
+    fi
+  done
+  echo "Extracted directory not found" >&2
+  return 1
 }
 
 reuse_existing_tarball() {

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -375,7 +375,7 @@ fetch_tarball() {
   fi
 
   if ! reuse_existing_tarball "$package_filename" "$checksum"; then
-    local tarball_filename=$(basename $package_url)
+    local tarball_filename="$(basename "$package_url")"
     echo "Downloading ${tarball_filename}..." >&2
     http head "$mirror_url" &&
     download_tarball "$mirror_url" "$package_filename" "$checksum" ||
@@ -384,7 +384,7 @@ fetch_tarball() {
 
   { if tar $tar_args "$package_filename"; then
       if [ ! -d "$package_name" ]; then
-        extracted_dir=$(find_extracted_directory)
+        extracted_dir="$(find_extracted_directory)"
         mv "$extracted_dir" "$package_name"
       fi
 


### PR DESCRIPTION
This should solve https://github.com/rbenv/ruby-build/commit/d155b41e#commitcomment-30215955.

Renaming is needed for TruffleRuby, so just reverting the commit is not enough.
Specifically, https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-linux-amd64.tar.gz contains a toplevel directory `truffleruby-1.0.0-rc5-linux-amd64` which is not the same as `$package_name` which is `truffleruby-1.0.0-rc5`

So in this PR, I rename the extracted directory if it is not the same as `$package_name`
* make_package() assumes the archive was extracted to $package_name.
* fetch_tarball() does not check the name of the toplevel directory in
  the archive, so rename after if it's not exactly "$package_name".

@mislav @xaque208 Please review this PR.