### PR TITLE
Upgrade to OpenSSL 1.1.1 (LTS)

### DIFF
--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.4.1
+++ b/share/ruby-build/2.4.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.2
+++ b/share/ruby-build/2.4.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.0
+++ b/share/ruby-build/2.5.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.5.0-preview1
+++ b/share/ruby-build/2.5.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2#1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.0-rc1
+++ b/share/ruby-build/2.5.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.1
+++ b/share/ruby-build/2.5.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-dev
+++ b/share/ruby-build/2.6.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-trunk" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.6.0-preview1
+++ b/share/ruby-build/2.6.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-preview2
+++ b/share/ruby-build/2.6.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/truffleruby-1.0.0-rc2
+++ b/share/ruby-build/truffleruby-1.0.0-rc2
@@ -1,4 +1,4 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 
 if is_mac; then
   install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-macos-amd64.tar.gz#308a5bf727914803cc0f794fd1aea89fd5f80ce00a97120372be9c58a930b82c" truffleruby

--- a/share/ruby-build/truffleruby-1.0.0-rc3
+++ b/share/ruby-build/truffleruby-1.0.0-rc3
@@ -1,4 +1,4 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 
 if is_mac; then
   install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-macos-amd64.tar.gz#8b6805df62e6e11982d1ec035269a51c325626c5d38ac8e10d28ae17eefee041" truffleruby

--- a/share/ruby-build/truffleruby-1.0.0-rc5
+++ b/share/ruby-build/truffleruby-1.0.0-rc5
@@ -1,4 +1,4 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 
 if is_mac; then
   install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-macos-amd64.tar.gz#d05798f9bd302eb6e03daa608e2a65fc01abc9cddcd6f60150e625fb84c1199c" truffleruby

--- a/share/ruby-build/truffleruby-1.0.0-rc6
+++ b/share/ruby-build/truffleruby-1.0.0-rc6
@@ -1,4 +1,4 @@
-install_package "openssl-1.1.0i" "https://www.openssl.org/source/openssl-1.1.0i.tar.gz#ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1" "https://www.openssl.org/source/openssl-1.1.1.tar.gz#2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" mac_openssl --if has_broken_mac_openssl
 
 if is_mac; then
   install_package "truffleruby-1.0.0-rc6" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc6/truffleruby-1.0.0-rc6-macos-amd64.tar.gz#de2af4e1115fa96245d143fa323234cc78cd6ab3e29d68cee4bb74064c97a124" truffleruby


### PR DESCRIPTION
I upgraded all rubies depended on OpenSSL 1.1.0x to OpenSSL 1.1.1 (LTS). I tried to compile several rubies, and no problem occurred.