### PR TITLE
output errors when curl/wget/aria2c are absent

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -299,12 +299,18 @@ verify_checksum() {
 }
 
 http() {
+  RUBY_BUILD_HTTP_CLIENT="${RUBY_BUILD_HTTP_CLIENT:-$(detect_http_client)}"
+  if [ -z "$RUBY_BUILD_HTTP_CLIENT" ]; then
+    { echo
+      echo "error: please install \`aria2c\`, \`curl\`, or \`wget\` and try again"
+      echo
+    } >&2
+    exit 1
+  fi
+
   local method="$1"
   [ -n "$2" ] || return 1
   shift 1
-
-  RUBY_BUILD_HTTP_CLIENT="${RUBY_BUILD_HTTP_CLIENT:-$(detect_http_client)}"
-  [ -n "$RUBY_BUILD_HTTP_CLIENT" ] || return 1
 
   "http_${method}_${RUBY_BUILD_HTTP_CLIENT}" "$@"
 }
@@ -317,7 +323,6 @@ detect_http_client() {
       return
     fi
   done
-  echo "error: please install \`aria2c\`, \`curl\`, or \`wget\` and try again" >&2
   return 1
 }
 


### PR DESCRIPTION
#### What's this PR do?

output errors to terminal correctly when curl/wget/aria2c are absent before downloading

#### How should this be manually tested?

when clients are absent 

```

# which aria2c
/usr/bin/which: no aria2c in (/root/.rbenv/shims:/root/.rbenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin)
# which curl
/usr/bin/which: no curl in (/root/.rbenv/shims:/root/.rbenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin)
# which wget
/usr/bin/which: no wget in (/root/.rbenv/shims:/root/.rbenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin)

# rbenv install 2.2.0
Downloading ruby-2.2.0.tar.bz2...

error: please install `aria2c`, `curl`, or `wget` and try again
```

when wget exists 

```
# rbenv install 2.4.0 --verbose
Downloading ruby-2.4.0.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2
2018-09-16 22:31:36 URL:https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2 [12572424/12572424] -> "ruby-2.4.0.tar.bz2" [1]
(...)
Installed ruby-2.4.0 to /root/.rbenv/versions/2.4.0

/tmp/ruby-build.20180916222501.12441 ~/.rbenv/plugins/ruby-build
~/.rbenv/plugins/ruby-build
```

#### What are the relevant tickets?

https://github.com/rbenv/ruby-build/issues/1058