### PR TITLE
Bump version to 20181019

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -13,7 +13,7 @@
 #   --version        Show version of ruby-build
 #
 
-RUBY_BUILD_VERSION="20181018"
+RUBY_BUILD_VERSION="20181019"
 
 OLDIFS="$IFS"
 


### PR DESCRIPTION
This will allow other package managers that rely on ruby-build (i.e. https://github.com/asdf-vm/asdf-ruby) to update to the latest version so users can download Ruby 2.5.3

Fixes #1243 