### PR TITLE
pass arguments of --list to definitions()

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -78,7 +78,7 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "l" | "list" )
     echo "Available versions:"
-    definitions ${ARGUMENTS[0]} | indent
+    definitions "${ARGUMENTS[0]}" | indent
     exit
     ;;
   "f" | "force" )

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -78,7 +78,7 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "l" | "list" )
     echo "Available versions:"
-    definitions | indent
+    definitions ${ARGUMENTS[0]} | indent
     exit
     ;;
   "f" | "force" )


### PR DESCRIPTION
this is just a quick hack but it pains me there's no built-in filter method for `rbenv-install --list` even though internally it exists. this patch just exposes it.

```
$ rbenv install -l 2.6
Available versions:
  2.2.6
  2.6.0-dev
  2.6.0-preview1
  2.6.0-preview2
  rbx-2.2.6
  rbx-2.6
```
