### PR TITLE
Update EOL Ruby message for macOS > 10.9 Mavericks

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -838,9 +838,9 @@ require_gcc() {
 
         colorize 1 "TO FIX THE PROBLEM"
         if type brew &>/dev/null; then
-          echo ": Install Homebrew's apple-gcc42 package with this"
+          echo ": Install Homebrew's GCC package with this"
           echo -n "command: "
-          colorize 4 "brew tap homebrew/dupes ; brew install apple-gcc42"
+          colorize 4 "brew install gcc@4.9"
         else
           echo ": Install the official GCC compiler using these"
           echo -n "packages: "


### PR DESCRIPTION
_Please go easy on me, I'm a first time contributor to the xenv suite of tools_ 🙇

I was trying to install Ruby 1.8.7 on macOS Mojave today and found that this message was out of date. `brew/taps` complains it no longer exists and the `apple-gcc42` package complains it hasn't worked on the last 4 macOS releases. Installing this gcc package did make `rbenv instal 1.8.7-p375` work for me (though I can't speak for whether or not it will link SSL correctly, basic Ruby scripts seem to work)

