### PR TITLE
Fix tests on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
+os:
+  - osx
+  - linux
 install: git clone --depth 1 https://github.com/sstephenson/bats.git
 script: PATH="./bats/bin:$PATH" script/test
 language: c

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -5,7 +5,10 @@ export RUBY_BUILD_HTTP_CLIENT="curl"
 if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures"
   export INSTALL_ROOT="$TMP/install"
-  PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+  if [ "FreeBSD" = "$(uname -s)" ]; then
+    PATH="/usr/local/bin:$PATH"
+  fi
   PATH="$BATS_TEST_DIRNAME/../bin:$PATH"
   PATH="$TMP/bin:$PATH"
   export PATH


### PR DESCRIPTION
Fixes #1056

PR #1038, specifically https://github.com/rbenv/ruby-build/pull/1038/files#diff-2b060f35496217f5f6b474e5552c11e2L6
broke the test suite on macOS.

This is because including `/usr/local/bin` in `PATH` makes
homebrew packages available to the tests, in particular readline.

Since ruby-build will prefer homebrew readline if available, making it
available in the tests will break any assertions that assume it _won't_
be available.

This PR also enables the test suite to run on macOS on Travis to prevent
regressions. The enabling of travis is the first commit, such that the
build can be seen to fail before the fix in the second commit.