### PR TITLE
Add definition for JRuby 9.2.4.0

### DIFF
--- a/share/ruby-build/jruby-9.2.4.0
+++ b/share/ruby-build/jruby-9.2.4.0
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.2.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.4.0/jruby-bin-9.2.4.0.tar.gz#b9638c82c85d89f6e8b2da1b876ac235bb9ed47f2163b3c851f0496c9bd58a0c" jruby


### PR DESCRIPTION
JRuby 9.2.4.0 has been released.
https://www.jruby.org/2018/11/13/jruby-9-2-4-0.html