### PR TITLE
Add definition for JRuby 9.2.4.1

### DIFF
--- a/share/ruby-build/jruby-9.2.4.1
+++ b/share/ruby-build/jruby-9.2.4.1
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.2.4.1" "https://s3.amazonaws.com/jruby.org/downloads/9.2.4.1/jruby-bin-9.2.4.1.tar.gz#c89821120d74f17f90c9bc346cc7bd1278df623fc1fe60ea3b5c0a8a01360d5b" jruby


### PR DESCRIPTION
JRuby 9.2.4.1 has been released.
https://www.jruby.org/2018/11/28/jruby-9-2-4-1