### PR TITLE
add ruby 2.6.0-rc2

### DIFF
--- a/share/ruby-build/2.6.0-rc2
+++ b/share/ruby-build/2.6.0-rc2
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2#b3d03e471e3136f43bb948013d4f4974abb63d478e8ff7ec2741b22750a3ec50" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/12/15/ruby-2-6-0-rc2-released/

Successfully installed on macOS Mojave:

```
rbenv install 2.6.0-rc2
ruby-build: use openssl from homebrew
Downloading ruby-2.6.0-rc2.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2
Installing ruby-2.6.0-rc2...
ruby-build: use readline from homebrew
Installed ruby-2.6.0-rc2 to /Users/frank/.rbenv/versions/2.6.0-rc2
```