### PR TITLE
Add definition for Ruby 2.6.0

### DIFF
--- a/share/ruby-build/2.6.0
+++ b/share/ruby-build/2.6.0
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.6.0 has been released.
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/