### PR TITLE
Add support for ruby 2.5.4 and 2.6.2

### DIFF
--- a/share/ruby-build/2.5.4
+++ b/share/ruby-build/2.5.4
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.2
+++ b/share/ruby-build/2.6.2
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby [2.5.4](https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-5-4-released/) and [2.6.2](https://www.ruby-lang.org/en/news/2019/03/13/ruby-2-6-2-released/) have been released.