### PR TITLE
Make building of jruby-launcher gem optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The build process may be configured through the following environment variables:
 | `RUBY_CONFIGURE_OPTS`    | Additional `./configure` options (applies only to Ruby source).                                  |
 | `RUBY_MAKE_OPTS`         | Additional `make` options (applies only to Ruby source).                                         |
 | `RUBY_MAKE_INSTALL_OPTS` | Additional `make install` options (applies only to Ruby source).                                 |
+| `JRUBY_DISABLE_LAUNCHER` | Do not install the jruby-launcher gem when installing JRuby                                      |
 
 #### Applying Patches
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -727,9 +727,13 @@ build_package_jruby() {
   cd "${PREFIX_PATH}/bin"
   ln -fs jruby ruby
   chmod +x ruby
-  install_jruby_launcher
+  [ -z "${JRUBY_LAUNCHER_DISABLED}" ] && install_jruby_launcher
   remove_windows_files
   fix_jruby_shebangs
+}
+
+build_package_disable_launcher() {
+  JRUBY_LAUNCHER_DISABLED=true
 }
 
 install_jruby_launcher() {

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -737,6 +737,7 @@ build_package_disable_launcher() {
 }
 
 install_jruby_launcher() {
+  echo "Installing the jruby-launcher gem"
   cd "${PREFIX_PATH}/bin"
   { ./ruby gem install jruby-launcher
   } >&4 2>&1

--- a/share/ruby-build/jruby-1.6.8
+++ b/share/ruby-build/jruby-1.6.8
@@ -1,1 +1,1 @@
-install_package "jruby-1.6.8" "https://s3.amazonaws.com/jruby-org/downloads/1.6.8/jruby-bin-1.6.8.tar.gz#e3b05f9cf0ba9b02e6cba75d5b62e2abf8ac7a4483c3713dc4eb83e3b8b162d4" warn_eol jruby
+install_package "jruby-1.6.8" "https://s3.amazonaws.com/jruby-org/downloads/1.6.8/jruby-bin-1.6.8.tar.gz#e3b05f9cf0ba9b02e6cba75d5b62e2abf8ac7a4483c3713dc4eb83e3b8b162d4" warn_eol disable_launcher jruby


### PR DESCRIPTION
The Jruby-launcher gem is not compatible with all versions of jruby. As well it may not always be desirable to have this gem automatically installed by ruby-build. Updated jruby-1.6.8 as it requires this per #1292.

 It may be preferable to have the jruby-launcher separated out from the build_package_jruby function along the lines of other platforms. This patch tries to follow current code patterns (but I may have misjudged) and to be of minimal impact.

Took the liberty of modifying the code. Was unsure about the test suite.
