### PR TITLE
Add definition for Ruby 2.4.6

### DIFF
--- a/share/ruby-build/2.4.6
+++ b/share/ruby-build/2.4.6
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.4.6 has been released.
https://www.ruby-lang.org/en/news/2019/04/01/ruby-2-4-6-released/