### PR TITLE
Add definition for Ruby 2.6.3

### DIFF
--- a/share/ruby-build/2.6.3
+++ b/share/ruby-build/2.6.3
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.6.3 has been released.
https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released