### PR TITLE
Add definition for mruby 2.0.1

### DIFF
--- a/share/ruby-build/mruby-2.0.1
+++ b/share/ruby-build/mruby-2.0.1
@@ -1,0 +1,1 @@
+install_package "mruby-2.0.1" "https://github.com/mruby/mruby/archive/2.0.1.tar.gz#fe0c50a25b4dc7692fd7f6a7dfc1d58ba73f53fedda5762845b853692cfac810" mruby


### PR DESCRIPTION
mruby 2.0.1 was released on April 4th, 2019.

https://github.com/mruby/mruby/releases/tag/2.0.1