### PR TITLE
Use master branch of ruby.git for 2.7.0-dev

### DIFF
--- a/share/ruby-build/2.7.0-dev
+++ b/share/ruby-build/2.7.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-trunk" "https://github.com/ruby/ruby.git" "trunk" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
## Description
Today we switched ruby.git's default branch from "trunk" to "master":
https://bugs.ruby-lang.org/issues/15843

And the former "Ruby trunk" redmine project was renamed to ["Ruby master"](https://bugs.ruby-lang.org/projects/ruby-trunk) as well.

As trunk branch will be terminated on Jan 1st, 2020, we should use master branch for building 2.7.0-dev.

## Test
On my local environment, this branch worked like:

```
$ rbenv install 2.7.0-dev
Cloning https://github.com/ruby/ruby.git...
Installing ruby-master...
Installed ruby-master to /home/k0kubun/.rbenv/versions/2.7.0-dev

$ rbenv shell 2.7.0-dev
$ ruby -v
ruby 2.7.0dev (2019-06-30T16:05:29Z master dbe834ab5a) [x86_64-linux]
```