### PR TITLE
Add definition for JRuby 9.2.8.0

### DIFF
--- a/share/ruby-build/jruby-9.2.8.0
+++ b/share/ruby-build/jruby-9.2.8.0
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.2.8.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.8.0/jruby-bin-9.2.8.0.tar.gz#b7c58688093f54acd89d732a8bf40e3ae0ac4c92488d6f5b424c33e4fb09c7bb" jruby


### PR DESCRIPTION
Closes #1335.

JRuby 9.2.8.0 has been released.
https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html