### PR TITLE
Add definition for Ruby 2.6.4

### DIFF
--- a/share/ruby-build/2.6.4
+++ b/share/ruby-build/2.6.4
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1c" "https://www.openssl.org/source/openssl-1.1.1c.tar.gz#f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.6.4 has been released.
https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/