### PR TITLE
Add definition for Ruby 2.5.6 and 2.4.7

### DIFF
--- a/share/ruby-build/2.4.7
+++ b/share/ruby-build/2.4.7
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.6
+++ b/share/ruby-build/2.5.6
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
These Rubies has been released.

- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-5-6-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-4-7-released/