### PR TITLE
Add example of mirrored URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ install_package "ruby-2.6.5" "https://ruby-lang.org/ruby-2.6.5.tgz#<SHA2>"
 ```
 
 ruby-build will first try to fetch this package from `$RUBY_BUILD_MIRROR_URL/<SHA2>`
-(note: this is the complete URL). It will fall back to downloading the package from
-the original location if:
+(note: this is the complete URL), where `<SHA2>` is the checksum for the file. It
+will fall back to downloading the package from the original location if:
 - the package was not found on the mirror;
 - the mirror is down;
 - the download is corrupt, i.e. the file's checksum doesn't match;

--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ URL specified in the definition file.
 You can point ruby-build to another mirror by specifying the
 `RUBY_BUILD_MIRROR_URL` environment variable--useful if you'd like to run your
 own local mirror, for example. Package mirror URLs are constructed by joining
-this variable with the SHA2 checksum of the package file.
+this variable with the SHA2 checksum of the package file. For example, the default
+URL for `ruby-2.3.0.tar.bz2` is http://cache.ruby-lang.org/pub/ruby/ruby-2.3.0.tar.bz2.
+That package would be mirrored at `$RUBY_BUILD_MIRROR_URL/ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e`,
+where the SHA2 sum is the package to be downloaded.
 
 If you don't have an SHA2 program installed, ruby-build will skip the download
 mirror and use official URLs instead. You can force ruby-build to bypass the


### PR DESCRIPTION
I found the documentation on how to install ruby from a mirrored URL extremely unclear and found issues from folks who had also had that problem. This PR adds an example of a package downloaded from cache.ruby-lang.org and its corresponding download url on a mirror.