### PR TITLE
Add definition for Ruby 2.4.9.

### DIFF
--- a/share/ruby-build/2.4.9
+++ b/share/ruby-build/2.4.9
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/

Definition updated from the 2.4.8 one.