### PR TITLE
Use --depth=1 for Git cloning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ $ brew install ruby-build
 
 # As an rbenv plugin
 $ mkdir -p "$(rbenv root)"/plugins
-$ git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+$ git clone --depth=1 https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
 
 # As a standalone program
-$ git clone https://github.com/rbenv/ruby-build.git
+$ git clone --depth=1 https://github.com/rbenv/ruby-build.git
 $ PREFIX=/usr/local ./ruby-build/install.sh
 ```
 


### PR DESCRIPTION
People don't need to clone the whole Git history of **ruby-build** when they want to use it. This is can be done by adding `--depth=1` parameter at Git clone command. By not cloning the whole Git history, clone time and space occupied will be reduced.

### Benchmarking

#### Clone all history

```
$ time git clone https://github.com/rbenv/ruby-build.git ruby-build-no-depth 
Cloning into 'ruby-build-no-depth'...
remote: Enumerating objects: 81, done.
remote: Counting objects: 100% (81/81), done.
remote: Compressing objects: 100% (38/38), done.
remote: Total 9872 (delta 37), reused 70 (delta 31), pack-reused 9791
Receiving objects: 100% (9872/9872), 2.11 MiB | 1.38 MiB/s, done.
Resolving deltas: 100% (6402/6402), done.
git clone https://github.com/rbenv/ruby-build.git ruby-build-no-depth  0.48s user 0.19s system 16% cpu 4.051 total
$ du -s ruby-build-no-depth
4600    ruby-build-no-depth
```

**Clone time:** 4.05 s
**Disc usage:** 4600

#### Clone using `--depth=1`
```
$ time git clone --depth=1 https://github.com/rbenv/ruby-build.git ruby-build-depth-1
Cloning into 'ruby-build-depth-1'...
remote: Enumerating objects: 501, done.
remote: Counting objects: 100% (501/501), done.
remote: Compressing objects: 100% (289/289), done.
remote: Total 501 (delta 266), reused 312 (delta 207), pack-reused 0
Receiving objects: 100% (501/501), 114.22 KiB | 248.00 KiB/s, done.
Resolving deltas: 100% (266/266), done.
git clone --depth=1 https://github.com/rbenv/ruby-build.git ruby-build-depth-  0.10s user 0.09s system 5% cpu 3.738 total
$ du -s ruby-build-depth-1
2296    ruby-build-depth-1

```

**Clone time:** 3.74 s
**Disc usage:** 2296

### Summary

**Clone time improvement:** 7.65% faster.
**Disc usage shrinkage:** 50.09% smaller.

And these numbers will be increasing as this repository grows.