### PR TITLE
Add definition for Ruby 2.7.0-preview2

### DIFF
--- a/share/ruby-build/2.7.0-preview2
+++ b/share/ruby-build/2.7.0-preview2
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Ruby 2.7.0-preview2 has been released.
https://www.ruby-lang.org/en/news/2019/10/22/ruby-2-7-0-preview2-released/