### PR TITLE
Turn on `--enable-shared` by default for all supported MRI Rubies

### DIFF
--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.1
+++ b/share/ruby-build/2.4.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.2
+++ b/share/ruby-build/2.4.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.5
+++ b/share/ruby-build/2.4.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.6
+++ b/share/ruby-build/2.4.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.7
+++ b/share/ruby-build/2.4.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.8
+++ b/share/ruby-build/2.4.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.9
+++ b/share/ruby-build/2.4.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.0
+++ b/share/ruby-build/2.5.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.1
+++ b/share/ruby-build/2.5.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.2
+++ b/share/ruby-build/2.5.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.3
+++ b/share/ruby-build/2.5.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.4
+++ b/share/ruby-build/2.5.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.5
+++ b/share/ruby-build/2.5.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.6
+++ b/share/ruby-build/2.5.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.7
+++ b/share/ruby-build/2.5.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.0
+++ b/share/ruby-build/2.6.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.1
+++ b/share/ruby-build/2.6.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.2
+++ b/share/ruby-build/2.6.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.3
+++ b/share/ruby-build/2.6.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1b" "https://www.openssl.org/source/openssl-1.1.1b.tar.gz#5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.4
+++ b/share/ruby-build/2.6.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1c" "https://www.openssl.org/source/openssl-1.1.1c.tar.gz#f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.5
+++ b/share/ruby-build/2.6.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview1
+++ b/share/ruby-build/2.7.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1c" "https://www.openssl.org/source/openssl-1.1.1c.tar.gz#f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" ldflags_dirs standard verify_openssl
+install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview2
+++ b/share/ruby-build/2.7.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" ldflags_dirs standard verify_openssl
+install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Some gems need the host ruby to have shared library enabled. Currently, we're not aware of any potential downsides to having this enabled by default.

Fixes https://github.com/rbenv/ruby-build/issues/35

Should we support a flag to disable shared, i.e. to override the default?