### PR TITLE
Remove overzealous permission change post-install

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -214,7 +214,6 @@ make_package() {
   before_install_package "$package_name"
   build_package "$package_name" $*
   after_install_package "$package_name"
-  fix_directory_permissions
   popd >&4
 }
 
@@ -770,11 +769,6 @@ before_install_package() {
 
 after_install_package() {
   local stub=1
-}
-
-fix_directory_permissions() {
-  # Ensure installed directories are not world-writable to avoid Bundler warnings
-  find "$PREFIX_PATH" -type d \( -perm -020 -o -perm -002 \) -exec chmod go-w {} \;
 }
 
 fix_rbx_gem_binstubs() {


### PR DESCRIPTION
Allows group-writeable Ruby installations

Reverts e1b50e68e339fef4172d000c8d5541a3ec8af14b

Fix #400, close #903