### PR TITLE
Don’t look for Homebrew openssl

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1023,6 +1023,16 @@ has_broken_mac_openssl() {
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]]
 }
 
+use_homebrew_openssl() {
+  local ssldir="$(brew --prefix openssl@1.1 2>/dev/null || true)"
+  if [ -d "$ssldir" ]; then
+    echo "ruby-build: using openssl from homebrew"
+    package_option ruby configure --with-openssl-dir="$ssldir"
+  else
+    return 1
+  fi
+}
+
 build_package_mac_openssl() {
   # Install to a subdirectory since we don't want shims for bin/openssl.
   OPENSSL_PREFIX_PATH="${PREFIX_PATH}/openssl"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1020,18 +1020,7 @@ has_broken_mac_openssl() {
   is_mac || return 1
   local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
   [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]] &&
-  [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]] &&
-  ! use_homebrew_openssl
-}
-
-use_homebrew_openssl() {
-  local ssldir="$(brew --prefix openssl@1.1 2>/dev/null || true)"
-  if [ -d "$ssldir" ]; then
-    echo "ruby-build: using openssl from homebrew"
-    package_option ruby configure --with-openssl-dir="$ssldir"
-  else
-    return 1
-  fi
+  [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]]
 }
 
 build_package_mac_openssl() {


### PR DESCRIPTION
`ruby-build` already does a lot of work to make sure that the version of ruby you're installing has the correct version of openssl also installed. Looking for any version of openssl installed by Homebrew is problematic for a few reasons:
- The user may have an incompatible version installed
- The user may not know that a particular version of openssl has been installed by Homebrew
- The openssl version split now makes this logic more difficult to maintain for all versions of ruby that `ruby-build` can install

Let's stop looking for any version of Homebrew's openssl by default so that the user always gets a working version of the ruby they're installing. Advanced users can use the `RUBY_CONFIGURE_OPTS="--with-openssl-dir=/my-openssl-directory"` option if they don't want to install the `ruby-build` defined compatible version of openssl.

#1353 #1360 #1347 