### PR TITLE
Add definition for mruby 2.1.0

### DIFF
--- a/share/ruby-build/mruby-2.1.0
+++ b/share/ruby-build/mruby-2.1.0
@@ -1,0 +1,1 @@
+install_package "mruby-2.1.0" "https://github.com/mruby/mruby/archive/2.1.0.tar.gz#d6733742a07e553c52ab71df08b0604b3b571768bbc0c2729fbf0389d1bb5d13" mruby


### PR DESCRIPTION
mruby 2.1.0 was released on November 19, 2019:
http://mruby.org/releases/2019/11/19/mruby-2.1.0-released.html
https://github.com/mruby/mruby/releases/tag/2.1.0