### PR TITLE
Use openssl from Homebrew for TruffleRuby on macOS

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1029,6 +1029,7 @@ use_homebrew_openssl() {
     echo "ruby-build: using openssl from homebrew"
     package_option ruby configure --with-openssl-dir="$ssldir"
   else
+    colorize 1 "ERROR openssl@1.1 from Homebrew is required, run 'brew install openssl@1.1'"
     return 1
   fi
 }

--- a/script/update-truffleruby
+++ b/script/update-truffleruby
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 if [ $# -ne 2 ]; then
   echo "usage: $0 VERSION RELEASE_DIRECTORY"
@@ -19,15 +20,24 @@ add_platform() {
 
   cat >> "$file" <<EOS
   install_package "truffleruby-${version}" "${url}#${sha256}" truffleruby
+  ;;
 EOS
 }
 
 cat > "$file" <<EOS
-install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
+case \$(uname -s) in
+Linux)
+EOS
+add_platform "linux-amd64"
+cat >> "$file" <<EOS
+Darwin)
+  use_homebrew_openssl
 EOS
 add_platform "macos-amd64"
-echo "else" >> "$file"
-add_platform "linux-amd64"
-echo "fi" >> "$file"
+cat >> "$file" <<EOS
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac
+EOS

--- a/share/ruby-build/truffleruby-1.0.0-rc10
+++ b/share/ruby-build/truffleruby-1.0.0-rc10
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc10" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc10/truffleruby-1.0.0-rc10-macos-amd64.tar.gz#b5a467ef7562b8806829dc7ea3fab6135e533350fe4f076c6c5fe5c8d0bd1283" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc10" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc10/truffleruby-1.0.0-rc10-linux-amd64.tar.gz#a3271572f202edf4d3d67ffd49508ccf80597a98219e2d3c217df43cbdfded2d" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc10" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc10/truffleruby-1.0.0-rc10-macos-amd64.tar.gz#b5a467ef7562b8806829dc7ea3fab6135e533350fe4f076c6c5fe5c8d0bd1283" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc11
+++ b/share/ruby-build/truffleruby-1.0.0-rc11
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc11" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc11/truffleruby-1.0.0-rc11-macos-amd64.tar.gz#c8c86fe7a77cacd690ddb64c66fbd92ff1f08788e40494cb4662b3d4731b02a6" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc11" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc11/truffleruby-1.0.0-rc11-linux-amd64.tar.gz#268c38f01331db4cbeae584aea4e9336b6a01aa1fcc621dda1232dcaac89da45" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc11" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc11/truffleruby-1.0.0-rc11-macos-amd64.tar.gz#c8c86fe7a77cacd690ddb64c66fbd92ff1f08788e40494cb4662b3d4731b02a6" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc12
+++ b/share/ruby-build/truffleruby-1.0.0-rc12
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc12" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc12/truffleruby-1.0.0-rc12-macos-amd64.tar.gz#3796e42978408826360464234809c71a84e1017227fef688c865b3e636ff3402" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc12" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc12/truffleruby-1.0.0-rc12-linux-amd64.tar.gz#f84b7fe9e2376962889dbc92c17997954e4e8b8db3e64b07e4220102f47f4aa5" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc12" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc12/truffleruby-1.0.0-rc12-macos-amd64.tar.gz#3796e42978408826360464234809c71a84e1017227fef688c865b3e636ff3402" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc13
+++ b/share/ruby-build/truffleruby-1.0.0-rc13
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc13" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc13/truffleruby-1.0.0-rc13-macos-amd64.tar.gz#c3dd003ee97c69da2697e2c09e538e13252f2c409b07b4bde4e5acbdbbf5314c" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc13" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc13/truffleruby-1.0.0-rc13-linux-amd64.tar.gz#26936811d08eed742b3ccf04ae7cc894abc0ba4e5c2cbfd3d43163d620f446e4" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc13" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc13/truffleruby-1.0.0-rc13-macos-amd64.tar.gz#c3dd003ee97c69da2697e2c09e538e13252f2c409b07b4bde4e5acbdbbf5314c" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc14
+++ b/share/ruby-build/truffleruby-1.0.0-rc14
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc14" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc14/truffleruby-1.0.0-rc14-macos-amd64.tar.gz#344ae35a57de1439be451d37066b678ed884bdd1fee0e5e685f00de24ff5d9dc" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc14" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc14/truffleruby-1.0.0-rc14-linux-amd64.tar.gz#e944421c3057e9fdc1d9c00cb53b4e1abe7d88fd922a2124f6b9eb49a85bfb6f" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc14" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc14/truffleruby-1.0.0-rc14-macos-amd64.tar.gz#344ae35a57de1439be451d37066b678ed884bdd1fee0e5e685f00de24ff5d9dc" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc15
+++ b/share/ruby-build/truffleruby-1.0.0-rc15
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc15" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc15/truffleruby-1.0.0-rc15-macos-amd64.tar.gz#8b664a836ec080ddee043ae78de4d2c362ae840706dc045ede6c40af8533a6f2" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc15" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc15/truffleruby-1.0.0-rc15-linux-amd64.tar.gz#cad2538bda6230d290d67f9ee0c6ef06cb9d149e6f84f1b847e94da7d33ca99f" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc15" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc15/truffleruby-1.0.0-rc15-macos-amd64.tar.gz#8b664a836ec080ddee043ae78de4d2c362ae840706dc045ede6c40af8533a6f2" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc16
+++ b/share/ruby-build/truffleruby-1.0.0-rc16
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc16" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc16/truffleruby-1.0.0-rc16-macos-amd64.tar.gz#86d385feab785abb8e9f84ac76900eec69082f15918c4d9edb478c00dcd8330b" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc16" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc16/truffleruby-1.0.0-rc16-linux-amd64.tar.gz#58fee4266b68cfe4e90f46a005693955370a760ccaf28224c9fcbd59241ff4b5" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc16" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc16/truffleruby-1.0.0-rc16-macos-amd64.tar.gz#86d385feab785abb8e9f84ac76900eec69082f15918c4d9edb478c00dcd8330b" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc2
+++ b/share/ruby-build/truffleruby-1.0.0-rc2
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-macos-amd64.tar.gz#308a5bf727914803cc0f794fd1aea89fd5f80ce00a97120372be9c58a930b82c" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-linux-amd64.tar.gz#2b7d999646dcfb895e49a41606a0b53ca055f291fb0cc33002944655fc3e2acb" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-macos-amd64.tar.gz#308a5bf727914803cc0f794fd1aea89fd5f80ce00a97120372be9c58a930b82c" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc3
+++ b/share/ruby-build/truffleruby-1.0.0-rc3
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-macos-amd64.tar.gz#8b6805df62e6e11982d1ec035269a51c325626c5d38ac8e10d28ae17eefee041" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-linux-amd64.tar.gz#d54bf05866d50e4fe589a7e8f30935062245292eb338098d143cbd67f33c823a" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-macos-amd64.tar.gz#8b6805df62e6e11982d1ec035269a51c325626c5d38ac8e10d28ae17eefee041" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc5
+++ b/share/ruby-build/truffleruby-1.0.0-rc5
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-macos-amd64.tar.gz#d05798f9bd302eb6e03daa608e2a65fc01abc9cddcd6f60150e625fb84c1199c" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-linux-amd64.tar.gz#c40cf6f8b2d664aa22a2b230af0e5889a9bf7ec07de9fb84454f5ab05d43c90c" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-macos-amd64.tar.gz#d05798f9bd302eb6e03daa608e2a65fc01abc9cddcd6f60150e625fb84c1199c" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc6
+++ b/share/ruby-build/truffleruby-1.0.0-rc6
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc6" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc6/truffleruby-1.0.0-rc6-macos-amd64.tar.gz#de2af4e1115fa96245d143fa323234cc78cd6ab3e29d68cee4bb74064c97a124" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc6" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc6/truffleruby-1.0.0-rc6-linux-amd64.tar.gz#a2514b1f992d9359de86a7e4faa5c14ad6b418e88fd7cf6e67cd9b2fdb1ae85d" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc6" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc6/truffleruby-1.0.0-rc6-macos-amd64.tar.gz#de2af4e1115fa96245d143fa323234cc78cd6ab3e29d68cee4bb74064c97a124" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc7
+++ b/share/ruby-build/truffleruby-1.0.0-rc7
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc7" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc7/truffleruby-1.0.0-rc7-macos-amd64.tar.gz#a189793967c4eac9cd114c613ed3aeb8d5060685035ceba2ab99c3de39bb97a3" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc7" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc7/truffleruby-1.0.0-rc7-linux-amd64.tar.gz#be83d50f6c60c5ebe5800d9d326a44af13b934fd9cc2def6614cc0558176543f" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc7" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc7/truffleruby-1.0.0-rc7-macos-amd64.tar.gz#a189793967c4eac9cd114c613ed3aeb8d5060685035ceba2ab99c3de39bb97a3" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc8
+++ b/share/ruby-build/truffleruby-1.0.0-rc8
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc8" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc8/truffleruby-1.0.0-rc8-macos-amd64.tar.gz#e627b43cdd5e8f1711704c6a2f5a1503957df7b226fd722771c54ea6c217457a" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc8" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc8/truffleruby-1.0.0-rc8-linux-amd64.tar.gz#080e066272184a72dc8019841ad0bca015cfa4ab979c6605c30346fcc0604597" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc8" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc8/truffleruby-1.0.0-rc8-macos-amd64.tar.gz#e627b43cdd5e8f1711704c6a2f5a1503957df7b226fd722771c54ea6c217457a" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-1.0.0-rc9
+++ b/share/ruby-build/truffleruby-1.0.0-rc9
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-1.0.0-rc9" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc9/truffleruby-1.0.0-rc9-macos-amd64.tar.gz#7cf61d001e0d3e5b3f053ecc8e5923adc30af3e580df7cc3625ad0cd95db0b85" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-1.0.0-rc9" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc9/truffleruby-1.0.0-rc9-linux-amd64.tar.gz#cccbe87360385f99f14eca94e834599caf89b93eaaa3934f1e63b403cc7a63e5" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-1.0.0-rc9" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc9/truffleruby-1.0.0-rc9-macos-amd64.tar.gz#7cf61d001e0d3e5b3f053ecc8e5923adc30af3e580df7cc3625ad0cd95db0b85" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-19.0.0
+++ b/share/ruby-build/truffleruby-19.0.0
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-19.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.0.0/truffleruby-19.0.0-macos-amd64.tar.gz#962003deaae6eff3150a9682287636445088bedf667bf62c635646659878ec49" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-19.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.0.0/truffleruby-19.0.0-linux-amd64.tar.gz#42b37f6e36a04bdd7319f7ad46f9790e7f8234a910c12229625afb0931b1d2d9" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-19.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.0.0/truffleruby-19.0.0-macos-amd64.tar.gz#962003deaae6eff3150a9682287636445088bedf667bf62c635646659878ec49" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-19.1.0
+++ b/share/ruby-build/truffleruby-19.1.0
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-19.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.1.0/truffleruby-19.1.0-macos-amd64.tar.gz#9cb8e8374dd21928bf822394810988e37f1a7c804cf407fb2b2a0a50e9302f3b" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-19.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.1.0/truffleruby-19.1.0-linux-amd64.tar.gz#5fc68b22ee95259f62edaf3d80af9073461ced0931b61e50e2147a42724a9ada" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-19.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.1.0/truffleruby-19.1.0-macos-amd64.tar.gz#9cb8e8374dd21928bf822394810988e37f1a7c804cf407fb2b2a0a50e9302f3b" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-19.2.0
+++ b/share/ruby-build/truffleruby-19.2.0
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-19.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0/truffleruby-19.2.0-macos-amd64.tar.gz#7f717cb86bd93e0c191f7a7ec39aaa66bad0b9e76348efc4c9104983290c1ffb" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-19.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0/truffleruby-19.2.0-linux-amd64.tar.gz#9dd36f703b862cb5d6ffb93be7b5f9ad92992fa93664fdadfd487af0c9c3f40a" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-19.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0/truffleruby-19.2.0-macos-amd64.tar.gz#7f717cb86bd93e0c191f7a7ec39aaa66bad0b9e76348efc4c9104983290c1ffb" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-19.2.0.1
+++ b/share/ruby-build/truffleruby-19.2.0.1
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-19.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0.1/truffleruby-19.2.0.1-macos-amd64.tar.gz#3a1bef2706ea9dc430f45ec0d7bf798ef09526f39d5102d88ef6a1b74bea3c12" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-19.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0.1/truffleruby-19.2.0.1-linux-amd64.tar.gz#38facb48768340efe638579b67a5e3f4cd8fa091006f7e098a654ddf3ec1bbac" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-19.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0.1/truffleruby-19.2.0.1-macos-amd64.tar.gz#3a1bef2706ea9dc430f45ec0d7bf798ef09526f39d5102d88ef6a1b74bea3c12" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-19.3.0
+++ b/share/ruby-build/truffleruby-19.3.0
@@ -1,7 +1,13 @@
-install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-
-if is_mac; then
-  install_package "truffleruby-19.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.0/truffleruby-19.3.0-macos-amd64.tar.gz#b2958301dbe0d2ed6dd430ccfb4c06f414a575e2fa6dbd38f6cf7ef63f679550" truffleruby
-else
+case $(uname -s) in
+Linux)
   install_package "truffleruby-19.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.0/truffleruby-19.3.0-linux-amd64.tar.gz#1fe9100a5272c5f82990a6ad4da08422f8a25d1b8d028fa89d32affa8d7e376f" truffleruby
-fi
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-19.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.0/truffleruby-19.3.0-macos-amd64.tar.gz#b2958301dbe0d2ed6dd430ccfb4c06f414a575e2fa6dbd38f6cf7ef63f679550" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: Linux"
+  return 1
+  ;;
+esac

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -92,7 +92,9 @@ jruby-1.7.9
 jruby-1.7.10
 jruby-9000-dev
 jruby-9000
-truffleruby-1.0.0-rc2"
+truffleruby-1.0.0-rc2
+truffleruby-19.0.0
+truffleruby-19.3.0"
   for ver in $expected; do
     touch "${RUBY_BUILD_ROOT}/share/ruby-build/$ver"
   done


### PR DESCRIPTION
Fixes https://github.com/oracle/truffleruby/issues/1818

* The openssl built by ruby-build was not used by TruffleRuby,
  and causes https://github.com/oracle/truffleruby/issues/1818
* Improve error message when openssl from Homebrew is not available.
* Change the definition code so it checks the operating system too.

cc @hsbt 