### PR TITLE
Add definition for Ruby 2.7.0-preview3

### DIFF
--- a/share/ruby-build/2.7.0-preview3
+++ b/share/ruby-build/2.7.0-preview3
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.7.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2#df2ddee659873e6fc30a8590ecffa49cf3a4ef81fa922b0d09f821b69ee88bc3" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 2.7.0-preview3 has been released.
https://www.ruby-lang.org/en/news/2019/11/23/ruby-2-7-0-preview3-released/

And this PR has been verified using a modified checksum.
https://github.com/ruby/www.ruby-lang.org/pull/2284