### PR TITLE
Add definition for Ruby 2.7.0

### DIFF
--- a/share/ruby-build/2.7.0
+++ b/share/ruby-build/2.7.0
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 2.7.0 has been released.
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/