### PR TITLE
Update so Ruby 1.9.3 thru 2.3, and rbx can be built with OpenSSL 1.0.2u

### DIFF
--- a/share/ruby-build/1.9.3-dev
+++ b/share/ruby-build/1.9.3-dev
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_git "ruby-1.9.3-dev" "https://github.com/ruby/ruby.git" "ruby_1_9_3" warn_eol autoconf standard

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,5 +1,5 @@
 require_gcc
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.bz2#ca8ba4e564fc5f98b210a5784e43dfffef9471222849e46f8e848b37e9f38acf" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p105
+++ b/share/ruby-build/1.9.3-p105
@@ -1,5 +1,5 @@
 [ -n "$CC" ] || export CC=cc
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p105" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p105.tar.bz2#8a149dee6498553fe5d25618ccce8002ca076affca57c857503235d00a35f9d1" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,5 +1,5 @@
 [ -n "$CC" ] || export CC=cc
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.bz2#c67a59443052b5a9219eb4cee3892bdfbc6f250f0c8e214e02256a4cc7ef5526" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p194
+++ b/share/ruby-build/1.9.3-p194
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.bz2#a9d1ea9eaea075c60048369a63b35b3b5a06a30aa214a3d990e0bb71212db8fa" warn_eol standard

--- a/share/ruby-build/1.9.3-p286
+++ b/share/ruby-build/1.9.3-p286
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.bz2#5281656c7a0ae48b64f28d845a96b4dfa16ba1357a911265752787585fb5ea64" warn_eol standard

--- a/share/ruby-build/1.9.3-p327
+++ b/share/ruby-build/1.9.3-p327
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.bz2#d989465242f9b11a8a3aa8cbd2c75a9b3a8c0ec2f14a087a0c7b51abf164e488" warn_eol standard

--- a/share/ruby-build/1.9.3-p362
+++ b/share/ruby-build/1.9.3-p362
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.bz2#9ed456711a4c0fb2969d9144a81a706d2d506070a35a6d5bc98bb5c8407f9985" warn_eol standard

--- a/share/ruby-build/1.9.3-p374
+++ b/share/ruby-build/1.9.3-p374
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.bz2#712944f691b79f22f655547826400c26b13bc8c9e7bdc73a4abea45d5e766d85" warn_eol standard

--- a/share/ruby-build/1.9.3-p385
+++ b/share/ruby-build/1.9.3-p385
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.bz2#f991ee50414dc795696bad0fc5c7b0b94d93b9b38fed943326d20ce4e9dda42b" warn_eol standard

--- a/share/ruby-build/1.9.3-p392
+++ b/share/ruby-build/1.9.3-p392
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.bz2#5a7334dfdf62966879bf539b8a9f0b889df6f3b3824fb52a9303c3c3d3a58391" warn_eol standard

--- a/share/ruby-build/1.9.3-p426
+++ b/share/ruby-build/1.9.3-p426
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p426" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p426.tar.bz2#54ac09a5579562ce6d3ba04413d24b5486d3bd3c0632968c7bd49cb76725186a" warn_eol standard

--- a/share/ruby-build/1.9.3-p429
+++ b/share/ruby-build/1.9.3-p429
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.bz2#9d8949c24cf6fe810b65fb466076708b842a3b0bac7799f79b7b6a8791dc2a70" warn_eol standard

--- a/share/ruby-build/1.9.3-p448
+++ b/share/ruby-build/1.9.3-p448
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.bz2#a7372230357bfff8e4525fb8019046da521561fe66b02c25d8efc10c9877bc91" warn_eol standard

--- a/share/ruby-build/1.9.3-p484
+++ b/share/ruby-build/1.9.3-p484
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.bz2#0fdc6e860d0023ba7b94c7a0cf1f7d32908b65b526246de9dfd5bb39d0d7922b" warn_eol standard

--- a/share/ruby-build/1.9.3-p545
+++ b/share/ruby-build/1.9.3-p545
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.bz2#2533de9f56d62f11c06a02dd32b5ab6d22a8f268c94b8e1e1ade6536adfd1aab" warn_eol standard

--- a/share/ruby-build/1.9.3-p547
+++ b/share/ruby-build/1.9.3-p547
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.bz2#ef588ed3ff53009b4c1833c83187ae252dd6c20db45e21a326cd4a16a102ef4c" warn_eol standard

--- a/share/ruby-build/1.9.3-p550
+++ b/share/ruby-build/1.9.3-p550
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p550" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p550.tar.bz2#d3da003896db47fb10ba4d2e0285eea7fe8cdc785b86c02ebad5bc9cdeaa4748" warn_eol standard

--- a/share/ruby-build/1.9.3-p551
+++ b/share/ruby-build/1.9.3-p551
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2#b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e" warn_eol standard

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,5 +1,5 @@
 require_gcc
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2#a15d7924d74a45ffe48d5421c5fc4ff83b7009676054fa5952b890711afef6fc" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,4 +1,4 @@
 require_gcc
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.bz2#951a8810086abca0e200f81767a518ee2730d6dc9b0cc2c7e3587dcfc3bf5fc8" warn_eol standard

--- a/share/ruby-build/2.0.0-dev
+++ b/share/ruby-build/2.0.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_0_0" warn_eol autoconf standard verify_openssl

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.bz2#c680d392ccc4901c32067576f5b474ee186def2fcd3fcbfa485739168093295f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.bz2#0be32aef7a7ab6e3708cc1d65cd3e0a99fa801597194bbedd5799c11d652eb5b" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.bz2#08e3d4b85b8a1118a8e81261f59dd8b4ddcfd70b6ae554e0ec5ceb99c3185e8a" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p353
+++ b/share/ruby-build/2.0.0-p353
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.bz2#3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p451
+++ b/share/ruby-build/2.0.0-p451
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2#5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p481
+++ b/share/ruby-build/2.0.0-p481
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.bz2#0762dad7e96d8091bdf33b3e3176c2066fbf3dc09dfe85fbf40e74e83c63d8e2" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p576
+++ b/share/ruby-build/2.0.0-p576
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2#8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p594
+++ b/share/ruby-build/2.0.0-p594
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2#e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p598
+++ b/share/ruby-build/2.0.0-p598
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2#67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p643
+++ b/share/ruby-build/2.0.0-p643
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.bz2#1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p645
+++ b/share/ruby-build/2.0.0-p645
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.bz2#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p647
+++ b/share/ruby-build/2.0.0-p647
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.bz2#3c3782e313d1ec3ed06c104eafd133cc54ff5183b991786ece9e957fd6cf1cb9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p648
+++ b/share/ruby-build/2.0.0-p648
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2#087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.bz2#79e5605003bf6766fbd123ce00a0027df716ba6d28494c35185909f7e61a5bdf" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.bz2#cea98c000a113f10cb7d55753c759da1f1baa7ca9b3edf75fc19fa5f44bf71a0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.bz2#4033ddadd0b44eecfcb7686231ebd109ee6f22bf09797a7e15882b9df0b1ee81" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2#d55f897bb04283c5fa80223d96d990fe8ecb598508dd59443b356cbba1f66145" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.0-dev
+++ b/share/ruby-build/2.1.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_1" warn_eol ldflags_dirs autoconf standard verify_openssl

--- a/share/ruby-build/2.1.0-preview1
+++ b/share/ruby-build/2.1.0-preview1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.bz2#860b90d28b214393fd9d77ac2ad65b384d8249cd59b658c668cf0c7bad1db341" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.bz2#780fddf0e3c8a219057d578e83367ecfac5e945054b9f132b3b93ded4802d1ce" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.bz2#af828bc0fe6aee5ffad0f8f10b48ee25964f54d5118570937ac7cf1c1df0edd3" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.10
+++ b/share/ruby-build/2.1.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.10" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2#a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.3
+++ b/share/ruby-build/2.1.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.4
+++ b/share/ruby-build/2.1.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.5
+++ b/share/ruby-build/2.1.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.8
+++ b/share/ruby-build/2.1.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.9
+++ b/share/ruby-build/2.1.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0
+++ b/share/ruby-build/2.2.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2#1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0-dev
+++ b/share/ruby-build/2.2.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" warn_eol ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.2.0-preview1
+++ b/share/ruby-build/2.2.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview1.tar.bz2#a3614c389de06b1636d8b919f2cd07e85311486bda2cb226a5549657a3610af5" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0-preview2
+++ b/share/ruby-build/2.2.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.bz2#9e49583f3fad3888fefc85b719fdb210a88ef54d80f9eac439b7ca4232fa7f0b" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0-rc1
+++ b/share/ruby-build/2.2.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-rc1.tar.bz2#e6a1f8d45ea749bdc92eb1269b77ec475bc600b66039ff90d77db8f50820a896" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.1
+++ b/share/ruby-build/2.2.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.bz2#4e5676073246b7ade207be3e80a930567a88100513591a0f19fc38e247370065" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.10
+++ b/share/ruby-build/2.2.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.10" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.bz2#a54204d2728283c9eff0cf81d654f245fa5b3447d0824f1a6bc3b2c5c827381e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.2
+++ b/share/ruby-build/2.2.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.bz2#f3b8ffa6089820ee5bdc289567d365e5748d4170e8aa246d2ea6576f24796535" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.3
+++ b/share/ruby-build/2.2.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.bz2#c745cb98b29127d7f19f1bf9e0a63c384736f4d303b83c4f4bda3c2ee3c5e41f" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.4
+++ b/share/ruby-build/2.2.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.4" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2#31203696adbfdda6f2874a2de31f7c5a1f3bcb6628f4d1a241de21b158cd5c76" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.5
+++ b/share/ruby-build/2.2.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.5" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2#22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.6
+++ b/share/ruby-build/2.2.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.6" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.bz2#e845ba41ea3525aafaa4094212f1eadc57392732232b67b4394a7e0f046dddf7" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.7
+++ b/share/ruby-build/2.2.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.7" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.bz2#80486c5991783185afeceeb315060a3dafc3889a2912e145b1a8457d7b005c5b" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.8
+++ b/share/ruby-build/2.2.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.8" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2#b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.9
+++ b/share/ruby-build/2.2.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.2.9" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2#5e3cfcc3b69638e165f72f67b1321fa05aff62b0f9e9b32042a5a79614e7c70a" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0
+++ b/share/ruby-build/2.3.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0-dev
+++ b/share/ruby-build/2.3.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.3.0-preview1
+++ b/share/ruby-build/2.3.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.bz2#42b9c9e1740a5abe2855d11803524370bd95744c8dcb0068572ed5c969ac7f0f" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0-preview2
+++ b/share/ruby-build/2.3.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.bz2#e9b0464e50b2e5c31546e6b8ca8cad71fe2d2146ccf88b7419bbe9626af741cb" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.1
+++ b/share/ruby-build/2.3.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.2
+++ b/share/ruby-build/2.3.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.3
+++ b/share/ruby-build/2.3.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.4
+++ b/share/ruby-build/2.3.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.5
+++ b/share/ruby-build/2.3.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.6
+++ b/share/ruby-build/2.3.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.7
+++ b/share/ruby-build/2.3.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.8
+++ b/share/ruby-build/2.3.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/rbx-2.10
+++ b/share/ruby-build/rbx-2.10
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.10.tar.bz2#c8047557a3d8513e4b10c661014e22901a24ec0aad71f0f1ffd3a8b31d58e694" warn_eol rbx

--- a/share/ruby-build/rbx-2.11
+++ b/share/ruby-build/rbx-2.11
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.11.tar.bz2#5a9ce5c86a4a566a088f379cf2889aa14d8fcd8b2295d5571f61bf43a9548b97" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.8
+++ b/share/ruby-build/rbx-2.5.8
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.5.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.5.8.tar.bz2#d6b411732aa035865f2855845abe5405119560f0979062672d576601de89e59a" warn_eol rbx

--- a/share/ruby-build/rbx-2.6
+++ b/share/ruby-build/rbx-2.6
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.6.tar.bz2#f63bbcca7d1bc71b4c20a3bd5748430be001f3a39b14a903d3d4ca39a657cfe0" warn_eol rbx

--- a/share/ruby-build/rbx-2.7
+++ b/share/ruby-build/rbx-2.7
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.7.tar.bz2#6f121cccbbd5ad0183024bf2405ca627982d1890307c059c754a1847e19eadd1" warn_eol rbx

--- a/share/ruby-build/rbx-2.71828182
+++ b/share/ruby-build/rbx-2.71828182
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.71828182" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.71828182.tar.bz2" warn_eol rbx

--- a/share/ruby-build/rbx-2.8
+++ b/share/ruby-build/rbx-2.8
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.8.tar.bz2#93e798b4c79800d0543d8d78aa1066b4285af209ed9908c35e54260c13bc7e9d" warn_eol rbx

--- a/share/ruby-build/rbx-2.9
+++ b/share/ruby-build/rbx-2.9
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-2.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.9.tar.bz2#9f8ad067ce494d201dae359d132ddac275d0bd13315dc8fdd094c9aa661ce8b1" warn_eol rbx

--- a/share/ruby-build/rbx-3.0
+++ b/share/ruby-build/rbx-3.0
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.0.tar.bz2#fd4c9687af6e29939100610a231f13951ed763a9028c85878505f313857c43ca" rbx

--- a/share/ruby-build/rbx-3.1
+++ b/share/ruby-build/rbx-3.1
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.1" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.1.tar.bz2#33e1b3b8e489a86f94de819fc478640150a4b1794c6a6ffe93d717fda6b610d8" rbx

--- a/share/ruby-build/rbx-3.10
+++ b/share/ruby-build/rbx-3.10
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.10.tar.bz2#a5980628edf318c4142cd3f7c6b01d3b07b50387533056ea67d75a63af3a5054" rbx

--- a/share/ruby-build/rbx-3.100
+++ b/share/ruby-build/rbx-3.100
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.100" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.100.tar.bz2#95f434cb034e732ecd075bc0b99540b54a5adfd0d8b8da7d5a0d4566bdcd8cce" rbx

--- a/share/ruby-build/rbx-3.101
+++ b/share/ruby-build/rbx-3.101
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.101" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.101.tar.bz2#ce9861e569807c8db5de3dcbe093441a61de623d9df7c52de78891962c3f66e8" rbx

--- a/share/ruby-build/rbx-3.102
+++ b/share/ruby-build/rbx-3.102
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.102" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.102.tar.bz2#82ecb66158d0a61dc2ed84fee8923c9fdb24d9c0ac0b6e6639e8e5e35ef82005" rbx

--- a/share/ruby-build/rbx-3.103
+++ b/share/ruby-build/rbx-3.103
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.103" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.103.tar.bz2#5cc15e89005b1824bf6c4d62d66e4cbadafe8af29baf4cfd5a1c1ecc8df2d67a" rbx

--- a/share/ruby-build/rbx-3.104
+++ b/share/ruby-build/rbx-3.104
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.104" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.104.tar.bz2#9ba016ce50e055d94345bb81a471408adb5b9dd04117e962bfa4ff2651af6461" rbx

--- a/share/ruby-build/rbx-3.105
+++ b/share/ruby-build/rbx-3.105
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.105" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.105.tar.bz2#38261e40f9e1008c38ef3c0be968994430fc5ef31ecf411e4dd04fa9e2e009b3" rbx

--- a/share/ruby-build/rbx-3.106
+++ b/share/ruby-build/rbx-3.106
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.106" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.106.tar.bz2#0c98afdc68c7ceecdc882674a1ee32aee75d76ca69aca44836ffa84a1b33afbd" rbx

--- a/share/ruby-build/rbx-3.107
+++ b/share/ruby-build/rbx-3.107
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.107" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.107.tar.bz2#46d68cb26ce83fb503b25776770abad6a55ef03a14cd4fd05f44e17becb71589" rbx

--- a/share/ruby-build/rbx-3.11
+++ b/share/ruby-build/rbx-3.11
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.11.tar.bz2#2e8bf15313440ec7c0315e5d3a387bf88c95518040073d78fcb7a044eaef162b" rbx

--- a/share/ruby-build/rbx-3.12
+++ b/share/ruby-build/rbx-3.12
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.12" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.12.tar.bz2#bc955346e2dfface41c87adf432034b591eb81350905d5b503b501f36ee773c9" rbx

--- a/share/ruby-build/rbx-3.13
+++ b/share/ruby-build/rbx-3.13
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.13" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.13.tar.bz2#a286b91150970a0116c843de5929c1e3c7a399943bd9f22f5fde25e67fa74368" rbx

--- a/share/ruby-build/rbx-3.14
+++ b/share/ruby-build/rbx-3.14
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.14" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.14.tar.bz2#19043116e885c428041677f672f54480bba171da9d43f369d1c854cb794c8426" rbx

--- a/share/ruby-build/rbx-3.15
+++ b/share/ruby-build/rbx-3.15
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.15" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.15.tar.bz2#86ce6c330843f1a4fa1217e37d8898e10b90673838b7a2867e4e4d6d65599cef" rbx

--- a/share/ruby-build/rbx-3.16
+++ b/share/ruby-build/rbx-3.16
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.16" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.16.tar.bz2#1c34db3254e8304988b3c10591c11af058f371bee80fe3b559e6c16d84f4fa03" rbx

--- a/share/ruby-build/rbx-3.17
+++ b/share/ruby-build/rbx-3.17
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.17" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.17.tar.bz2#bb76bc9613064f48d50f8323c2727002bb7dcb0ccf8813e69a366c603b7bc689" rbx

--- a/share/ruby-build/rbx-3.18
+++ b/share/ruby-build/rbx-3.18
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.18" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.18.tar.bz2#c552a539f3f6b8f240a02cbe9926540a0c3ad95e0e341179963a43c64208ce3e" rbx

--- a/share/ruby-build/rbx-3.19
+++ b/share/ruby-build/rbx-3.19
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.19" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.19.tar.bz2#cee948256bf288595b4ce53034f0dcd4ae2bc257acb2d43a63364dfc8e5db47c" rbx

--- a/share/ruby-build/rbx-3.2
+++ b/share/ruby-build/rbx-3.2
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.2" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.2.tar.bz2#e9e906492900755425d29cbb650b0b5a39d1163fa692d6a33958e98a2e8ea156" rbx

--- a/share/ruby-build/rbx-3.20
+++ b/share/ruby-build/rbx-3.20
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.20" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.20.tar.bz2#caf95bf55e5483e288b40c315ad7f2d4091823e33dcd57e9c6364c66c29a7ff2" rbx

--- a/share/ruby-build/rbx-3.21
+++ b/share/ruby-build/rbx-3.21
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.21" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.21.tar.bz2#281195af772ef05f789404f0fb95838c5942591762191962bab22860022650ee" rbx

--- a/share/ruby-build/rbx-3.22
+++ b/share/ruby-build/rbx-3.22
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.22" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.22.tar.bz2#90b9a69ab71cffdc4a0dd68aafebce5df1fcd79c2bc60ef78b44fccd160d341a" rbx

--- a/share/ruby-build/rbx-3.23
+++ b/share/ruby-build/rbx-3.23
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.23" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.23.tar.bz2#bed25ca7c27629115768eb666adfcbb95d6f625e8666980e837ead5e13848b64" rbx

--- a/share/ruby-build/rbx-3.24
+++ b/share/ruby-build/rbx-3.24
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.25" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.25.tar.bz2#9a1d1219acf34bab516e07a1b5ada3b54afd51ec25e87908fc0b6801db0c5d57" rbx

--- a/share/ruby-build/rbx-3.25
+++ b/share/ruby-build/rbx-3.25
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.24" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.24.tar.bz2#7edf189283255d68b2a1d69e011cfebad0397743229fd50b08e21774ec8dab63" rbx

--- a/share/ruby-build/rbx-3.26
+++ b/share/ruby-build/rbx-3.26
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.26" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.26.tar.bz2#10341c880eef73dda89cf8bcf5ae066b04683e40a3b1721d4d2733f32778819a" rbx

--- a/share/ruby-build/rbx-3.27
+++ b/share/ruby-build/rbx-3.27
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.27" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.27.tar.bz2#4ede3d0adcfab77eb9ffb43eec1b6cbe63c32f326630b488e9c2382fa3a6db98" rbx

--- a/share/ruby-build/rbx-3.28
+++ b/share/ruby-build/rbx-3.28
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.28" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.28.tar.bz2#7954146ee9284e038b3c524613478e2884d8a7a9df85de6c17e43177e41d842c" rbx

--- a/share/ruby-build/rbx-3.29
+++ b/share/ruby-build/rbx-3.29
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.29" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.29.tar.bz2#6a8bf87ce26a6a05a80dd2ae40ac8c4e2c5153d4d2d913549a85d9aa32aaeee2" rbx

--- a/share/ruby-build/rbx-3.3
+++ b/share/ruby-build/rbx-3.3
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.3" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.3.tar.bz2#3f592b1f5580f7075c7fdc72eee7c959dd4791d96d04de6a8d467529dcff72be" rbx

--- a/share/ruby-build/rbx-3.30
+++ b/share/ruby-build/rbx-3.30
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.30" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.30.tar.bz2#5294f406679d41160abe46ec1ff14b76c4353a75756227cc691108bb57f4bd16" rbx

--- a/share/ruby-build/rbx-3.31
+++ b/share/ruby-build/rbx-3.31
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.31" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.31.tar.bz2#1c7a7763ab7cf36ad6b2e328ff1d78fb6587721b8667f8598d15354d0704de72" rbx

--- a/share/ruby-build/rbx-3.32
+++ b/share/ruby-build/rbx-3.32
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.32" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.32.tar.bz2#f88d6d277efe1f9774da1201ce4c8a8fd7cb2ea29620c1727a4471e3a0eed1dc" rbx

--- a/share/ruby-build/rbx-3.33
+++ b/share/ruby-build/rbx-3.33
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.33" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.33.tar.bz2#1455940fc3a17b6efbb787c9316ff86a260187ebbaba6b32746dd27cebe14907" rbx

--- a/share/ruby-build/rbx-3.34
+++ b/share/ruby-build/rbx-3.34
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.34" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.34.tar.bz2#90f5d5b53dbc6494b8a81ecd3569950b1d85d0c463dd537cab677fab82e2b300" rbx

--- a/share/ruby-build/rbx-3.35
+++ b/share/ruby-build/rbx-3.35
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.35" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.35.tar.bz2#d72c8ec1a1cd6e1c77381e6d1e1d21811d71948a08f108d8a064884c379d2465" rbx

--- a/share/ruby-build/rbx-3.36
+++ b/share/ruby-build/rbx-3.36
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.36" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.36.tar.bz2#660c6eaad9ab0ef3813942e906b14d1f02d071c6e25f60b9d6c8dfbab278b754" rbx

--- a/share/ruby-build/rbx-3.37
+++ b/share/ruby-build/rbx-3.37
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.37" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.37.tar.bz2#85d855a0734c315d67b592675481458ddddac075426dbf6dc39a8ad34b8cb2d1" rbx

--- a/share/ruby-build/rbx-3.38
+++ b/share/ruby-build/rbx-3.38
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.38" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.38.tar.bz2#2e038ee1e1dcee5b0d574cc446ad7bf2d98ea70ced35090f1680a90c6b9d6333" rbx

--- a/share/ruby-build/rbx-3.39
+++ b/share/ruby-build/rbx-3.39
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.39" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.39.tar.bz2#f6f8132b44eadb4c07f8b26af16ce0a5470309ada33ef6f20ab76770a44193e0" rbx

--- a/share/ruby-build/rbx-3.4
+++ b/share/ruby-build/rbx-3.4
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.4" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.4.tar.bz2#480a4f536bfdc7208b06bb40bef39944de7e1c770e9962f87c6900dec30155f8" rbx

--- a/share/ruby-build/rbx-3.40
+++ b/share/ruby-build/rbx-3.40
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.40" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.40.tar.bz2#09f6590515bf6180427544fb217a34330a689784ea05b03f0a98db2a197bb20f" rbx

--- a/share/ruby-build/rbx-3.41
+++ b/share/ruby-build/rbx-3.41
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.41" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.41.tar.bz2#b06966230e647aa0e5b64da14ba213256074c34f3bb8614be1ce81ef1434c41f" rbx

--- a/share/ruby-build/rbx-3.42
+++ b/share/ruby-build/rbx-3.42
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.42" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.42.tar.bz2#4fc4413101100f6393894632eef522c2667a821856ac32eb99ccecab2aeeae85" rbx

--- a/share/ruby-build/rbx-3.43
+++ b/share/ruby-build/rbx-3.43
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.43" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.43.tar.bz2#2c573257518774e464036515cc7283bc934a41566599afe94612c605844481ad" rbx

--- a/share/ruby-build/rbx-3.44
+++ b/share/ruby-build/rbx-3.44
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.44" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.44.tar.bz2#c9e08b2e1d745798a0b32bef773e287361769c07a0eb9512377020661e2e4236" rbx

--- a/share/ruby-build/rbx-3.45
+++ b/share/ruby-build/rbx-3.45
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.45" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.45.tar.bz2#5cadc3842c9c6d574bf5897354c384d8d688d9fa285b0d6083bdcc386bd6de96" rbx

--- a/share/ruby-build/rbx-3.46
+++ b/share/ruby-build/rbx-3.46
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.46" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.46.tar.bz2#6bf24221ebd2c4d69e2388be1a3fa06d41009eeee00bfcdd86de8d57892d3fb2" rbx

--- a/share/ruby-build/rbx-3.47
+++ b/share/ruby-build/rbx-3.47
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.47" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.47.tar.bz2#be734298ccad4dcadaa1f566d9655a971a4f12abc7629db045fd5c63e1685d16" rbx

--- a/share/ruby-build/rbx-3.48
+++ b/share/ruby-build/rbx-3.48
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.48" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.48.tar.bz2#1180ea6a3de81bcd99c25b394fb05c010411bf4d3b48ee9881539b8043aeb561" rbx

--- a/share/ruby-build/rbx-3.49
+++ b/share/ruby-build/rbx-3.49
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.49" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.49.tar.bz2#9a92d2cfede087e89f13f40e85e6c9cc9849041a0260144f44cd75aae67e3198" rbx

--- a/share/ruby-build/rbx-3.5
+++ b/share/ruby-build/rbx-3.5
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.5" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.5.tar.bz2#13b0ce02d597f80c48ecc942b807368883e5cf3003bba2bc4957b3f1b368669e" rbx

--- a/share/ruby-build/rbx-3.50
+++ b/share/ruby-build/rbx-3.50
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.50" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.50.tar.bz2#8da87cae447fe6bacd3417943bb1af603c2b4800bef0fc50ddd512ec89252ea8" rbx

--- a/share/ruby-build/rbx-3.51
+++ b/share/ruby-build/rbx-3.51
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.51" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.51.tar.bz2#ded54018c6090dd0e051f7c3ffbb458ebdb5bcf77306a8b63d1bdeb73fb8c6f4" rbx

--- a/share/ruby-build/rbx-3.52
+++ b/share/ruby-build/rbx-3.52
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.52" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.52.tar.bz2#657ed568ddc4a3155d05bc56ca6d327f960ec6098d03e1480b5c28936c70b5c5" rbx

--- a/share/ruby-build/rbx-3.53
+++ b/share/ruby-build/rbx-3.53
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.53" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.53.tar.bz2#ec2efb7d026a41ef97cb9812961bf37803f3928f978e38f504cd2c09eae34f54" rbx

--- a/share/ruby-build/rbx-3.54
+++ b/share/ruby-build/rbx-3.54
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.54" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.54.tar.bz2#2498a4c04feafba72d14c12e33ef881ae4bd8d3ccaa9bddcc8aec8acbad780fb" rbx

--- a/share/ruby-build/rbx-3.55
+++ b/share/ruby-build/rbx-3.55
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.55" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.55.tar.bz2#fe7671beb3f36b987e02933afb392123b4c0a8ac15909a7b774d26101fec1ac1" rbx

--- a/share/ruby-build/rbx-3.56
+++ b/share/ruby-build/rbx-3.56
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.56" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.56.tar.bz2#fa8170bc0eca01ebd83eb3a04240a0c7bd079ddf6ddc8b002167cff987db93b8" rbx

--- a/share/ruby-build/rbx-3.57
+++ b/share/ruby-build/rbx-3.57
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.57" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.57.tar.bz2#c2bc550129ad306188458880240348892893d08af8e74e2dbdb5318f313762bd" rbx

--- a/share/ruby-build/rbx-3.58
+++ b/share/ruby-build/rbx-3.58
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.58" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.58.tar.bz2#28875f1b9cb9b722323fa4217d9f3472e57a9ea6bd1fbc43a67eb47f81967cee" rbx

--- a/share/ruby-build/rbx-3.59
+++ b/share/ruby-build/rbx-3.59
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.59" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.59.tar.bz2#feb65af7ff97ef44cab86790e3a67881cc0bc7389f01bfa10a9c2d62e9aadae7" rbx

--- a/share/ruby-build/rbx-3.6
+++ b/share/ruby-build/rbx-3.6
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.6.tar.bz2#25b5913bba06511170e365643579ccfc193c1c4e74dbe6ea4b37dcabdcd8f6ad" rbx

--- a/share/ruby-build/rbx-3.60
+++ b/share/ruby-build/rbx-3.60
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.60" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.60.tar.bz2#39f83fc74216391af56ea1ad13372878c0ed41fae49ee6a8cf8b0369a54c3b57" rbx

--- a/share/ruby-build/rbx-3.61
+++ b/share/ruby-build/rbx-3.61
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.61" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.61.tar.bz2#38623cf198b1b0047b4c3404070252903b4da33c091be8708c205815d1516636" rbx

--- a/share/ruby-build/rbx-3.62
+++ b/share/ruby-build/rbx-3.62
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.62" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.62.tar.bz2#1cc468a7967687a062c11e21bf6787cc60f6894590eabe3fc9be5e9af36a022f" rbx

--- a/share/ruby-build/rbx-3.63
+++ b/share/ruby-build/rbx-3.63
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.63" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.63.tar.bz2#3003298b9d53620ad84d71a63be2a37b53dfdfe6c2fced9280a7f3b219f365d4" rbx

--- a/share/ruby-build/rbx-3.64
+++ b/share/ruby-build/rbx-3.64
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.64" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.64.tar.bz2#43e2efd91074b52dc1d691e1424dbbb2e91bc9406b595dbb4753e9dd6001eedb" rbx

--- a/share/ruby-build/rbx-3.65
+++ b/share/ruby-build/rbx-3.65
@@ -1,3 +1,3 @@
 require_llvm 3.6
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.65" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.65.tar.bz2#a4290b6cd1f332c90405bd421163658a2d91abf27c83ad3afe7dbbbd3628829a" rbx

--- a/share/ruby-build/rbx-3.66
+++ b/share/ruby-build/rbx-3.66
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.66" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.66.tar.bz2#4bb237a1da1d52bc830bbe704bd4b995bbc07e50b558e460aff54d6bc309975e" rbx

--- a/share/ruby-build/rbx-3.67
+++ b/share/ruby-build/rbx-3.67
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.67" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.67.tar.bz2#a5eedd6169f80df528ac73cf2ed9183e2f5a82a57ca0b2ae3962c26238427b87" rbx

--- a/share/ruby-build/rbx-3.68
+++ b/share/ruby-build/rbx-3.68
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.68" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.68.tar.bz2#44f423a8557aa8fa383573638a94faaf3f9c587a771be267c60ed0c78784f567" rbx

--- a/share/ruby-build/rbx-3.69
+++ b/share/ruby-build/rbx-3.69
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.69" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.69.tar.bz2#2dcde5cb7ba1e1664f6bf902cd866d2564985536a0908caeac2e4099b6b255b2" rbx

--- a/share/ruby-build/rbx-3.7
+++ b/share/ruby-build/rbx-3.7
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.7.tar.bz2#fafcdc518b5b2440960d023203bedca133be4af62e1ef8be9ff37a2842438257" rbx

--- a/share/ruby-build/rbx-3.70
+++ b/share/ruby-build/rbx-3.70
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.70" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.70.tar.bz2#e5b22ff6f19d7ac75d94e7503ae74c0bf9a3d249ce0e80480402cf7cbd2fea19" rbx

--- a/share/ruby-build/rbx-3.71
+++ b/share/ruby-build/rbx-3.71
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.71" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.71.tar.bz2#77bfac38feea0f7d1ebecd7be5b6fac9cefe44d00ee5932ee7ba9d1f078080b8" rbx

--- a/share/ruby-build/rbx-3.72
+++ b/share/ruby-build/rbx-3.72
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.72" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.72.tar.bz2#7dfd678536d49947e08a327eb3b96a00c49f6b4a3ee5d4b548f4840efef0726c" rbx

--- a/share/ruby-build/rbx-3.73
+++ b/share/ruby-build/rbx-3.73
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.73" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.73.tar.bz2#4fea98d26df5a00185d5d92684ec04cf6a22ca8cf6e9b47c3895ba5e6f14ea1a" rbx

--- a/share/ruby-build/rbx-3.74
+++ b/share/ruby-build/rbx-3.74
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.74" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.74.tar.bz2#8dae2c4e4b2361cdeafb39035f8b1b1bfe6387104f43ae6026cae3234793b8e5" rbx

--- a/share/ruby-build/rbx-3.75
+++ b/share/ruby-build/rbx-3.75
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.75" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.75.tar.bz2#04cd1bc8fa021d569aac38cf98aeeb97f8324815f82d7ea1a0c963898c79e137" rbx

--- a/share/ruby-build/rbx-3.76
+++ b/share/ruby-build/rbx-3.76
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.76" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.76.tar.bz2#1606d229ea611f3c271f0b579c839cea6a1b4b07ddea7b0c4d2d794146781589" rbx

--- a/share/ruby-build/rbx-3.77
+++ b/share/ruby-build/rbx-3.77
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.77" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.77.tar.bz2#badaeb4129c64979fb37322cc1913effde17010db5f57398ab7409f3fb84360e" rbx

--- a/share/ruby-build/rbx-3.78
+++ b/share/ruby-build/rbx-3.78
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.78" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.78.tar.bz2#d285d798226fa6d80db7fd5afc2ceb2860546378772beccab154b8b7612446c9" rbx

--- a/share/ruby-build/rbx-3.79
+++ b/share/ruby-build/rbx-3.79
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.79" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.79.tar.bz2#514c5032a23bfc1ca2defce646cc3a740aa053dab37e0cb4fbba1d4f11a9c33a" rbx

--- a/share/ruby-build/rbx-3.8
+++ b/share/ruby-build/rbx-3.8
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.8.tar.bz2#9a74316b1adf7535c4529741bd3b7e660b7fbdb01ab1c5e6deeed0fae09b811d" rbx

--- a/share/ruby-build/rbx-3.80
+++ b/share/ruby-build/rbx-3.80
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.80" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.80.tar.bz2#8cda9123efac9c2bbe374368c4767ada7e28299a7c4c706c562b3d133f96c19e" rbx

--- a/share/ruby-build/rbx-3.81
+++ b/share/ruby-build/rbx-3.81
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.81" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.81.tar.bz2#d8fffa145f1132bc2d1f17d9194f1b8fc6dffa0f3ff6c29b44e99378daeea807" rbx

--- a/share/ruby-build/rbx-3.82
+++ b/share/ruby-build/rbx-3.82
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.82" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.82.tar.bz2#53abb85219980d7307a762660e1d509cd74beccbcf4d46979ddd0749e77a1401" rbx

--- a/share/ruby-build/rbx-3.83
+++ b/share/ruby-build/rbx-3.83
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.83" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.83.tar.bz2#323d44321478aca7ccb8c5a76addc00df4aa90ec89a69a764e92fe77896669aa" rbx

--- a/share/ruby-build/rbx-3.84
+++ b/share/ruby-build/rbx-3.84
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.84" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.84.tar.bz2#87eeaf24efd64bb06c4409814410a9154287dd889a976b70c474ef88992b279d" rbx

--- a/share/ruby-build/rbx-3.85
+++ b/share/ruby-build/rbx-3.85
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.85" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.85.tar.bz2#18a55be0de6323847f946af43cedcc44277e62124c8140523b34776265a5c6e1" rbx

--- a/share/ruby-build/rbx-3.86
+++ b/share/ruby-build/rbx-3.86
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.86" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.86.tar.bz2#cfb0650b937d109cf52c982f185ef247cc7a184dbb5f16c625d4827cef11f6fb" rbx

--- a/share/ruby-build/rbx-3.87
+++ b/share/ruby-build/rbx-3.87
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.87" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.87.tar.bz2#53eb602a8635aef334142832ba3b81ee7ca58706643f5136f019cdae6f4431c2" rbx

--- a/share/ruby-build/rbx-3.88
+++ b/share/ruby-build/rbx-3.88
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.88" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.88.tar.bz2#e1c11578256b072870cfe929edfcb5965f076ef7543a92c7d0e6cf4c22787fae" rbx

--- a/share/ruby-build/rbx-3.89
+++ b/share/ruby-build/rbx-3.89
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.89" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.89.tar.bz2#6e48ecd3253137c9d958e762fe9f5e512b597ffbd7f44ddabc716f8d33ea7d71" rbx

--- a/share/ruby-build/rbx-3.9
+++ b/share/ruby-build/rbx-3.9
@@ -1,3 +1,3 @@
 require_llvm 3.5
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.9.tar.bz2#de5a2238d90387143b8b63a52b7f036d408d7a84387347e56099d811c423bdf6" rbx

--- a/share/ruby-build/rbx-3.90
+++ b/share/ruby-build/rbx-3.90
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.90" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.90.tar.bz2#f888910670ff2a9f913a66b18447ee3fab6a4ee424015e46e8c9e0dbb9c600d8" rbx

--- a/share/ruby-build/rbx-3.91
+++ b/share/ruby-build/rbx-3.91
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.91" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.91.tar.bz2#9be8f94a322cd27c84f51e8075635ee7193e407ea0b37d6e297bea01dd2aa0a6" rbx

--- a/share/ruby-build/rbx-3.92
+++ b/share/ruby-build/rbx-3.92
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.92" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.92.tar.bz2#a15196a33c3628aa5baff0613102973fe0e489583b2614f9dacc02ad33efe87b" rbx

--- a/share/ruby-build/rbx-3.93
+++ b/share/ruby-build/rbx-3.93
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.93" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.93.tar.bz2#851a93d68727f41603dbafa498ffe37bcdf2e6c697ba07c7804062f6a07200a9" rbx

--- a/share/ruby-build/rbx-3.94
+++ b/share/ruby-build/rbx-3.94
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.94" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.94.tar.bz2#bf82ab49248f0011ba89a36e1d6f45d37703398d03b0c379184e3276130f0861" rbx

--- a/share/ruby-build/rbx-3.95
+++ b/share/ruby-build/rbx-3.95
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.95" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.95.tar.bz2#cb2f42645e5408c8017fe80975179ddc38357192193f16070120ee38a2891801" rbx

--- a/share/ruby-build/rbx-3.96
+++ b/share/ruby-build/rbx-3.96
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.96" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.96.tar.bz2#78e077f9faa115da58c616f6f660875f85f44f6a3708560b61c294c53aec8f5c" rbx

--- a/share/ruby-build/rbx-3.97
+++ b/share/ruby-build/rbx-3.97
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.97" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.97.tar.bz2#a47549474734cd64fb6d122966cfeb8bf46adba5cde2d1b85a9fa753f2668118" rbx

--- a/share/ruby-build/rbx-3.98
+++ b/share/ruby-build/rbx-3.98
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.98" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.98.tar.bz2#e8230eed22818893ba4771f0c409104ccccf5b4b4102c9289d3c85a000d13f36" rbx

--- a/share/ruby-build/rbx-3.99
+++ b/share/ruby-build/rbx-3.99
@@ -1,3 +1,3 @@
 require_llvm 3.7
-install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
 install_package "rubinius-3.99" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.99.tar.bz2#56ed8edf91add5f497a68e5b11165db6640eb2d4effbb6453ab4b5e6b847b178" rbx


### PR DESCRIPTION
1. Change all `share/ruby-build/2.3.x` files to use OpenSSL 1.0.2u
2. Update cert code for Ubuntu & macOS

This is for use in generating Rubies for use on GitHub Actions.  A build run is here:

https://github.com/MSP-Greg/ruby-install-builder/runs/384299585