### PR TITLE
ruby 2.3 EOL

### DIFF
--- a/share/ruby-build/2.3.0
+++ b/share/ruby-build/2.3.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0-dev
+++ b/share/ruby-build/2.3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" warn_eol ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.3.0-preview1
+++ b/share/ruby-build/2.3.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.bz2#42b9c9e1740a5abe2855d11803524370bd95744c8dcb0068572ed5c969ac7f0f" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.bz2#42b9c9e1740a5abe2855d11803524370bd95744c8dcb0068572ed5c969ac7f0f" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0-preview2
+++ b/share/ruby-build/2.3.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.bz2#e9b0464e50b2e5c31546e6b8ca8cad71fe2d2146ccf88b7419bbe9626af741cb" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.bz2#e9b0464e50b2e5c31546e6b8ca8cad71fe2d2146ccf88b7419bbe9626af741cb" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.1
+++ b/share/ruby-build/2.3.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.2
+++ b/share/ruby-build/2.3.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.3
+++ b/share/ruby-build/2.3.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.4
+++ b/share/ruby-build/2.3.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.5
+++ b/share/ruby-build/2.3.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.6
+++ b/share/ruby-build/2.3.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.7
+++ b/share/ruby-build/2.3.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.8
+++ b/share/ruby-build/2.3.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" ldflags_dirs standard verify_openssl
+install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_unsupported ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.4.0-preview1
+++ b/share/ruby-build/2.4.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2#17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2#17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-preview2
+++ b/share/ruby-build/2.4.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2#2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2#2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-preview3
+++ b/share/ruby-build/2.4.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2#305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2#305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-rc1
+++ b/share/ruby-build/2.4.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-rc1.tar.bz2#3b156b20f9df0dd62cbeeb8e57e66ea872d2a5b55fabdef1889650122bcc2ea7" ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-rc1.tar.bz2#3b156b20f9df0dd62cbeeb8e57e66ea872d2a5b55fabdef1889650122bcc2ea7" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.1
+++ b/share/ruby-build/2.4.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.2
+++ b/share/ruby-build/2.4.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.5
+++ b/share/ruby-build/2.4.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.6
+++ b/share/ruby-build/2.4.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.7
+++ b/share/ruby-build/2.4.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.8
+++ b/share/ruby-build/2.4.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.9
+++ b/share/ruby-build/2.4.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/jruby-9.0.0.0
+++ b/share/ruby-build/jruby-9.0.0.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0/jruby-bin-9.0.0.0.tar.gz#655665db3a1dc0462cba99d45532ab57d8416b5f168d8a0081bde9b7a93a394e" jruby
+install_package "jruby-9.0.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0/jruby-bin-9.0.0.0.tar.gz#655665db3a1dc0462cba99d45532ab57d8416b5f168d8a0081bde9b7a93a394e" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.0.0
+++ b/share/ruby-build/jruby-9.0.0.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0/jruby-bin-9.0.0.0.tar.gz#655665db3a1dc0462cba99d45532ab57d8416b5f168d8a0081bde9b7a93a394e" eol_warn jruby
+install_package "jruby-9.0.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0/jruby-bin-9.0.0.0.tar.gz#655665db3a1dc0462cba99d45532ab57d8416b5f168d8a0081bde9b7a93a394e" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre1
+++ b/share/ruby-build/jruby-9.0.0.0.pre1
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.pre1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.pre1/jruby-dist-9.0.0.0.pre1-bin.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" jruby
+install_package "jruby-9.0.0.0.pre1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.pre1/jruby-dist-9.0.0.0.pre1-bin.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre1
+++ b/share/ruby-build/jruby-9.0.0.0.pre1
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.pre1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre1/jruby-bin-9.0.0.0.pre1.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" eol_warn jruby
+install_package "jruby-9.0.0.0.pre1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre1/jruby-bin-9.0.0.0.pre1.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre1
+++ b/share/ruby-build/jruby-9.0.0.0.pre1
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.0.0.0.pre1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.pre1/jruby-dist-9.0.0.0.pre1-bin.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre1
+++ b/share/ruby-build/jruby-9.0.0.0.pre1
@@ -1,2 +1,0 @@
-require_java7
-install_package "jruby-9.0.0.0.pre1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre1/jruby-bin-9.0.0.0.pre1.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre1
+++ b/share/ruby-build/jruby-9.0.0.0.pre1
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.pre1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre1/jruby-bin-9.0.0.0.pre1.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" jruby
+install_package "jruby-9.0.0.0.pre1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre1/jruby-bin-9.0.0.0.pre1.tar.gz#381da389b07c4692db5feeeeb6a21963cbdc86ee5172bd3f170bd081cc607354" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre2
+++ b/share/ruby-build/jruby-9.0.0.0.pre2
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.pre2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre2/jruby-bin-9.0.0.0.pre2.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" eol_warn jruby
+install_package "jruby-9.0.0.0.pre2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre2/jruby-bin-9.0.0.0.pre2.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre2
+++ b/share/ruby-build/jruby-9.0.0.0.pre2
@@ -1,2 +1,0 @@
-require_java7
-install_package "jruby-9.0.0.0.pre2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre2/jruby-bin-9.0.0.0.pre2.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre2
+++ b/share/ruby-build/jruby-9.0.0.0.pre2
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.pre2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre2/jruby-bin-9.0.0.0.pre2.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" jruby
+install_package "jruby-9.0.0.0.pre2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.pre2/jruby-bin-9.0.0.0.pre2.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre2
+++ b/share/ruby-build/jruby-9.0.0.0.pre2
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.0.0.0.pre2" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.pre2/jruby-dist-9.0.0.0.pre2-bin.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" jruby

--- a/share/ruby-build/jruby-9.0.0.0.pre2
+++ b/share/ruby-build/jruby-9.0.0.0.pre2
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.pre2" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.pre2/jruby-dist-9.0.0.0.pre2-bin.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" jruby
+install_package "jruby-9.0.0.0.pre2" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.pre2/jruby-dist-9.0.0.0.pre2-bin.tar.gz#6c9fd54c71bb64a04cea2af5938a67eab1ed951609fe999d6de88f6b98a6a1e4" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc1
+++ b/share/ruby-build/jruby-9.0.0.0.rc1
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.rc1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.rc1/jruby-dist-9.0.0.0.rc1-bin.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" jruby
+install_package "jruby-9.0.0.0.rc1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.rc1/jruby-dist-9.0.0.0.rc1-bin.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc1
+++ b/share/ruby-build/jruby-9.0.0.0.rc1
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.rc1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc1/jruby-bin-9.0.0.0.rc1.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" eol_warn jruby
+install_package "jruby-9.0.0.0.rc1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc1/jruby-bin-9.0.0.0.rc1.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc1
+++ b/share/ruby-build/jruby-9.0.0.0.rc1
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.0.0.0.rc1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.rc1/jruby-dist-9.0.0.0.rc1-bin.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc1
+++ b/share/ruby-build/jruby-9.0.0.0.rc1
@@ -1,2 +1,0 @@
-require_java7
-install_package "jruby-9.0.0.0.rc1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc1/jruby-bin-9.0.0.0.rc1.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc1
+++ b/share/ruby-build/jruby-9.0.0.0.rc1
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.rc1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc1/jruby-bin-9.0.0.0.rc1.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" jruby
+install_package "jruby-9.0.0.0.rc1" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc1/jruby-bin-9.0.0.0.rc1.tar.gz#b5c2bf5d4b22eba8ca62fe120aad682b8420454c12a426791a06f8efe6b90641" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc2
+++ b/share/ruby-build/jruby-9.0.0.0.rc2
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.rc2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc2/jruby-bin-9.0.0.0.rc2.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" eol_warn jruby
+install_package "jruby-9.0.0.0.rc2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc2/jruby-bin-9.0.0.0.rc2.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc2
+++ b/share/ruby-build/jruby-9.0.0.0.rc2
@@ -1,2 +1,0 @@
-require_java7
-install_package "jruby-9.0.0.0.rc2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc2/jruby-bin-9.0.0.0.rc2.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc2
+++ b/share/ruby-build/jruby-9.0.0.0.rc2
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.rc2" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.rc2/jruby-dist-9.0.0.0.rc2-bin.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" jruby
+install_package "jruby-9.0.0.0.rc2" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.rc2/jruby-dist-9.0.0.0.rc2-bin.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc2
+++ b/share/ruby-build/jruby-9.0.0.0.rc2
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0.rc2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc2/jruby-bin-9.0.0.0.rc2.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" jruby
+install_package "jruby-9.0.0.0.rc2" "https://s3.amazonaws.com/jruby.org/downloads/9.0.0.0.rc2/jruby-bin-9.0.0.0.rc2.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.0.0.rc2
+++ b/share/ruby-build/jruby-9.0.0.0.rc2
@@ -1,0 +1,2 @@
+require_java7
+install_package "jruby-9.0.0.0.rc2" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.0.0.0.rc2/jruby-dist-9.0.0.0.rc2-bin.tar.gz#f337adb43f4972ace8a04f77d889b35bc4fa4efec99e98cc7ca2aac50f393329" jruby

--- a/share/ruby-build/jruby-9.0.1.0
+++ b/share/ruby-build/jruby-9.0.1.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.1.0/jruby-bin-9.0.1.0.tar.gz#3cab8ead2f080eb9cdf16fc30cbc1974c36a4a4e6c9d321d5a3bbd973b64527f" jruby
+install_package "jruby-9.0.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.1.0/jruby-bin-9.0.1.0.tar.gz#3cab8ead2f080eb9cdf16fc30cbc1974c36a4a4e6c9d321d5a3bbd973b64527f" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.1.0
+++ b/share/ruby-build/jruby-9.0.1.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.1.0/jruby-bin-9.0.1.0.tar.gz#3cab8ead2f080eb9cdf16fc30cbc1974c36a4a4e6c9d321d5a3bbd973b64527f" eol_warn jruby
+install_package "jruby-9.0.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.1.0/jruby-bin-9.0.1.0.tar.gz#3cab8ead2f080eb9cdf16fc30cbc1974c36a4a4e6c9d321d5a3bbd973b64527f" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.3.0
+++ b/share/ruby-build/jruby-9.0.3.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.3.0/jruby-bin-9.0.3.0.tar.gz#e40c06d43cfbdd5b8447d07c0689183c70c4234da26621a177f426ebc5024cc1" eol_warn jruby
+install_package "jruby-9.0.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.3.0/jruby-bin-9.0.3.0.tar.gz#e40c06d43cfbdd5b8447d07c0689183c70c4234da26621a177f426ebc5024cc1" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.3.0
+++ b/share/ruby-build/jruby-9.0.3.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.3.0/jruby-bin-9.0.3.0.tar.gz#e40c06d43cfbdd5b8447d07c0689183c70c4234da26621a177f426ebc5024cc1" jruby
+install_package "jruby-9.0.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.3.0/jruby-bin-9.0.3.0.tar.gz#e40c06d43cfbdd5b8447d07c0689183c70c4234da26621a177f426ebc5024cc1" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.4.0
+++ b/share/ruby-build/jruby-9.0.4.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.4.0/jruby-bin-9.0.4.0.tar.gz#fcf828c4ad5b92430a349f1e873c067a15e0952d167d07368135c513fe0d18fb" eol_warn jruby
+install_package "jruby-9.0.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.4.0/jruby-bin-9.0.4.0.tar.gz#fcf828c4ad5b92430a349f1e873c067a15e0952d167d07368135c513fe0d18fb" warn_eol jruby

--- a/share/ruby-build/jruby-9.0.4.0
+++ b/share/ruby-build/jruby-9.0.4.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.4.0/jruby-bin-9.0.4.0.tar.gz#fcf828c4ad5b92430a349f1e873c067a15e0952d167d07368135c513fe0d18fb" jruby
+install_package "jruby-9.0.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.4.0/jruby-bin-9.0.4.0.tar.gz#fcf828c4ad5b92430a349f1e873c067a15e0952d167d07368135c513fe0d18fb" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.5.0
+++ b/share/ruby-build/jruby-9.0.5.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.5.0/jruby-bin-9.0.5.0.tar.gz#9ef392bd859690c9a838f6475040345e0c512f7fcc0b37c809a91cf671f5daf3" jruby
+install_package "jruby-9.0.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.5.0/jruby-bin-9.0.5.0.tar.gz#9ef392bd859690c9a838f6475040345e0c512f7fcc0b37c809a91cf671f5daf3" eol_warn jruby

--- a/share/ruby-build/jruby-9.0.5.0
+++ b/share/ruby-build/jruby-9.0.5.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.5.0/jruby-bin-9.0.5.0.tar.gz#9ef392bd859690c9a838f6475040345e0c512f7fcc0b37c809a91cf671f5daf3" eol_warn jruby
+install_package "jruby-9.0.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.0.5.0/jruby-bin-9.0.5.0.tar.gz#9ef392bd859690c9a838f6475040345e0c512f7fcc0b37c809a91cf671f5daf3" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.0.0
+++ b/share/ruby-build/jruby-9.1.0.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.0.0/jruby-bin-9.1.0.0.tar.gz#ff48c8eea61d0be93d807f56eda613350e91f598f6f4f71ef73ed53e7d0530ad" eol_warn jruby
+install_package "jruby-9.1.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.0.0/jruby-bin-9.1.0.0.tar.gz#ff48c8eea61d0be93d807f56eda613350e91f598f6f4f71ef73ed53e7d0530ad" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.0.0
+++ b/share/ruby-build/jruby-9.1.0.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.0.0/jruby-bin-9.1.0.0.tar.gz#ff48c8eea61d0be93d807f56eda613350e91f598f6f4f71ef73ed53e7d0530ad" jruby
+install_package "jruby-9.1.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.0.0/jruby-bin-9.1.0.0.tar.gz#ff48c8eea61d0be93d807f56eda613350e91f598f6f4f71ef73ed53e7d0530ad" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.0.0-dev
+++ b/share/ruby-build/jruby-9.1.0.0-dev
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-bin-9.1.0.0-SNAPSHOT.tar.gz" eol_warn jruby
+install_package "jruby-9.1.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-bin-9.1.0.0-SNAPSHOT.tar.gz" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.0.0-dev
+++ b/share/ruby-build/jruby-9.1.0.0-dev
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-bin-9.1.0.0-SNAPSHOT.tar.gz" jruby
+install_package "jruby-9.1.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-bin-9.1.0.0-SNAPSHOT.tar.gz" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.1.0
+++ b/share/ruby-build/jruby-9.1.1.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.1.0/jruby-bin-9.1.1.0.tar.gz#c5705b97569486fe52ca3754dea391c84d33d1702a48fcb8a4ac9838d18e6307" jruby
+install_package "jruby-9.1.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.1.0/jruby-bin-9.1.1.0.tar.gz#c5705b97569486fe52ca3754dea391c84d33d1702a48fcb8a4ac9838d18e6307" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.1.0
+++ b/share/ruby-build/jruby-9.1.1.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.1.0/jruby-bin-9.1.1.0.tar.gz#c5705b97569486fe52ca3754dea391c84d33d1702a48fcb8a4ac9838d18e6307" eol_warn jruby
+install_package "jruby-9.1.1.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.1.0/jruby-bin-9.1.1.0.tar.gz#c5705b97569486fe52ca3754dea391c84d33d1702a48fcb8a4ac9838d18e6307" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.10.0
+++ b/share/ruby-build/jruby-9.1.10.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.10.0/jruby-bin-9.1.10.0.tar.gz#93ec6b55fa0d5b37e9f8131f76adc01efa82bebcef8df3e0de49e83dad3ee958" jruby
+install_package "jruby-9.1.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.10.0/jruby-bin-9.1.10.0.tar.gz#93ec6b55fa0d5b37e9f8131f76adc01efa82bebcef8df3e0de49e83dad3ee958" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.10.0
+++ b/share/ruby-build/jruby-9.1.10.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.10.0/jruby-bin-9.1.10.0.tar.gz#93ec6b55fa0d5b37e9f8131f76adc01efa82bebcef8df3e0de49e83dad3ee958" eol_warn jruby
+install_package "jruby-9.1.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.10.0/jruby-bin-9.1.10.0.tar.gz#93ec6b55fa0d5b37e9f8131f76adc01efa82bebcef8df3e0de49e83dad3ee958" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.11.0
+++ b/share/ruby-build/jruby-9.1.11.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.11.0/jruby-bin-9.1.11.0.tar.gz#6773a164d0cd513ee22ee0c989095b368d0208a32f57f73c2c53ee2b58d05575" eol_warn jruby
+install_package "jruby-9.1.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.11.0/jruby-bin-9.1.11.0.tar.gz#6773a164d0cd513ee22ee0c989095b368d0208a32f57f73c2c53ee2b58d05575" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.11.0
+++ b/share/ruby-build/jruby-9.1.11.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.11.0/jruby-bin-9.1.11.0.tar.gz#6773a164d0cd513ee22ee0c989095b368d0208a32f57f73c2c53ee2b58d05575" jruby
+install_package "jruby-9.1.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.11.0/jruby-bin-9.1.11.0.tar.gz#6773a164d0cd513ee22ee0c989095b368d0208a32f57f73c2c53ee2b58d05575" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.12.0
+++ b/share/ruby-build/jruby-9.1.12.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.12.0/jruby-bin-9.1.12.0.tar.gz#ddb23c95f4b3cc3fc1cc57b81cb4ceee776496ede402b9a6eb0622cf15e1a597" eol_warn jruby
+install_package "jruby-9.1.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.12.0/jruby-bin-9.1.12.0.tar.gz#ddb23c95f4b3cc3fc1cc57b81cb4ceee776496ede402b9a6eb0622cf15e1a597" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.12.0
+++ b/share/ruby-build/jruby-9.1.12.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.12.0/jruby-bin-9.1.12.0.tar.gz#ddb23c95f4b3cc3fc1cc57b81cb4ceee776496ede402b9a6eb0622cf15e1a597" jruby
+install_package "jruby-9.1.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.12.0/jruby-bin-9.1.12.0.tar.gz#ddb23c95f4b3cc3fc1cc57b81cb4ceee776496ede402b9a6eb0622cf15e1a597" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.13.0
+++ b/share/ruby-build/jruby-9.1.13.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.tar.gz#9d156646623ac2f27174721035b52572a4b05690db7c1293295aa2c04aad3908" jruby
+install_package "jruby-9.1.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.tar.gz#9d156646623ac2f27174721035b52572a4b05690db7c1293295aa2c04aad3908" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.13.0
+++ b/share/ruby-build/jruby-9.1.13.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.tar.gz#9d156646623ac2f27174721035b52572a4b05690db7c1293295aa2c04aad3908" eol_warn jruby
+install_package "jruby-9.1.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.13.0/jruby-bin-9.1.13.0.tar.gz#9d156646623ac2f27174721035b52572a4b05690db7c1293295aa2c04aad3908" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.14.0
+++ b/share/ruby-build/jruby-9.1.14.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.14.0/jruby-dist-9.1.14.0-bin.tar.gz#074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651" eol_warn jruby
+install_package "jruby-9.1.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.14.0/jruby-dist-9.1.14.0-bin.tar.gz#074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.14.0
+++ b/share/ruby-build/jruby-9.1.14.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.14.0/jruby-dist-9.1.14.0-bin.tar.gz#074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651" jruby
+install_package "jruby-9.1.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.14.0/jruby-dist-9.1.14.0-bin.tar.gz#074057e672350a6652d92ccaaa5d517fc7d6b980bce8b947515fb64d114d1651" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.15.0
+++ b/share/ruby-build/jruby-9.1.15.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.15.0/jruby-dist-9.1.15.0-bin.tar.gz#4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e" eol_warn jruby
+install_package "jruby-9.1.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.15.0/jruby-dist-9.1.15.0-bin.tar.gz#4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.15.0
+++ b/share/ruby-build/jruby-9.1.15.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.15.0/jruby-dist-9.1.15.0-bin.tar.gz#4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e" jruby
+install_package "jruby-9.1.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.15.0/jruby-dist-9.1.15.0-bin.tar.gz#4a0d9305867ed327a8cf4f7ff8a65c7ff62094a495ec85463d0792656762469e" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.16.0
+++ b/share/ruby-build/jruby-9.1.16.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.16.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.16.0/jruby-dist-9.1.16.0-bin.tar.gz#d92c2b359e32a0afffef6982dc4730e4bdfcabd9c198e9c6075292c71ad9485a" eol_warn jruby
+install_package "jruby-9.1.16.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.16.0/jruby-dist-9.1.16.0-bin.tar.gz#d92c2b359e32a0afffef6982dc4730e4bdfcabd9c198e9c6075292c71ad9485a" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.16.0
+++ b/share/ruby-build/jruby-9.1.16.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.16.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.16.0/jruby-dist-9.1.16.0-bin.tar.gz#d92c2b359e32a0afffef6982dc4730e4bdfcabd9c198e9c6075292c71ad9485a" jruby
+install_package "jruby-9.1.16.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.16.0/jruby-dist-9.1.16.0-bin.tar.gz#d92c2b359e32a0afffef6982dc4730e4bdfcabd9c198e9c6075292c71ad9485a" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.17.0
+++ b/share/ruby-build/jruby-9.1.17.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.17.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.17.0/jruby-dist-9.1.17.0-bin.tar.gz#6a22f7bf8fef1a52530a9c9781a9d374ad07bbbef0d3d8e2af0ff5cbead0dfd5" jruby
+install_package "jruby-9.1.17.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.17.0/jruby-dist-9.1.17.0-bin.tar.gz#6a22f7bf8fef1a52530a9c9781a9d374ad07bbbef0d3d8e2af0ff5cbead0dfd5" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.17.0
+++ b/share/ruby-build/jruby-9.1.17.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.17.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.17.0/jruby-dist-9.1.17.0-bin.tar.gz#6a22f7bf8fef1a52530a9c9781a9d374ad07bbbef0d3d8e2af0ff5cbead0dfd5" eol_warn jruby
+install_package "jruby-9.1.17.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.17.0/jruby-dist-9.1.17.0-bin.tar.gz#6a22f7bf8fef1a52530a9c9781a9d374ad07bbbef0d3d8e2af0ff5cbead0dfd5" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.2.0
+++ b/share/ruby-build/jruby-9.1.2.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.2.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.2.0/jruby-bin-9.1.2.0.tar.gz#60598a465883ab4c933f805de4a7f280052bddc793b95735465619c03ca43f35" eol_warn jruby
+install_package "jruby-9.1.2.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.2.0/jruby-bin-9.1.2.0.tar.gz#60598a465883ab4c933f805de4a7f280052bddc793b95735465619c03ca43f35" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.2.0
+++ b/share/ruby-build/jruby-9.1.2.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.2.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.2.0/jruby-bin-9.1.2.0.tar.gz#60598a465883ab4c933f805de4a7f280052bddc793b95735465619c03ca43f35" jruby
+install_package "jruby-9.1.2.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.2.0/jruby-bin-9.1.2.0.tar.gz#60598a465883ab4c933f805de4a7f280052bddc793b95735465619c03ca43f35" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.3.0
+++ b/share/ruby-build/jruby-9.1.3.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.3.0/jruby-bin-9.1.3.0.tar.gz#3bf36ad72bfb49ba4424c5403df3b1da4f614186d82267f2481973f1fcaaeb20" jruby
+install_package "jruby-9.1.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.3.0/jruby-bin-9.1.3.0.tar.gz#3bf36ad72bfb49ba4424c5403df3b1da4f614186d82267f2481973f1fcaaeb20" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.3.0
+++ b/share/ruby-build/jruby-9.1.3.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.3.0/jruby-bin-9.1.3.0.tar.gz#3bf36ad72bfb49ba4424c5403df3b1da4f614186d82267f2481973f1fcaaeb20" eol_warn jruby
+install_package "jruby-9.1.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.3.0/jruby-bin-9.1.3.0.tar.gz#3bf36ad72bfb49ba4424c5403df3b1da4f614186d82267f2481973f1fcaaeb20" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.4.0
+++ b/share/ruby-build/jruby-9.1.4.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.4.0/jruby-bin-9.1.4.0.tar.gz#cde189a22f6b93a439873e4130fc2c73f07554d4f9c415adef2dd8429626be67" eol_warn jruby
+install_package "jruby-9.1.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.4.0/jruby-bin-9.1.4.0.tar.gz#cde189a22f6b93a439873e4130fc2c73f07554d4f9c415adef2dd8429626be67" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.4.0
+++ b/share/ruby-build/jruby-9.1.4.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.4.0/jruby-bin-9.1.4.0.tar.gz#cde189a22f6b93a439873e4130fc2c73f07554d4f9c415adef2dd8429626be67" jruby
+install_package "jruby-9.1.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.4.0/jruby-bin-9.1.4.0.tar.gz#cde189a22f6b93a439873e4130fc2c73f07554d4f9c415adef2dd8429626be67" eol_warn jruby

--- a/share/ruby-build/jruby-9.1.5.0
+++ b/share/ruby-build/jruby-9.1.5.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.5.0/jruby-bin-9.1.5.0.tar.gz#28e4f3aefbb4497c5c5edc04246778b3305105c3d3d6de11be067826cc5bb766" jruby
+install_package "jruby-9.1.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.5.0/jruby-bin-9.1.5.0.tar.gz#28e4f3aefbb4497c5c5edc04246778b3305105c3d3d6de11be067826cc5bb766" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.6.0
+++ b/share/ruby-build/jruby-9.1.6.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.6.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.tar.gz#a32dc54b80aa0069323654e06b84fdcea077d3601ec54208a67c4b969f369b89" jruby
+install_package "jruby-9.1.6.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.6.0/jruby-bin-9.1.6.0.tar.gz#a32dc54b80aa0069323654e06b84fdcea077d3601ec54208a67c4b969f369b89" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.7.0
+++ b/share/ruby-build/jruby-9.1.7.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.7.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.7.0/jruby-bin-9.1.7.0.tar.gz#95ac7d2316fb7698039267265716dd2159fa5b49f0e0dc6e469c80ad59072926" jruby
+install_package "jruby-9.1.7.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.7.0/jruby-bin-9.1.7.0.tar.gz#95ac7d2316fb7698039267265716dd2159fa5b49f0e0dc6e469c80ad59072926" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.8.0
+++ b/share/ruby-build/jruby-9.1.8.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.8.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.8.0/jruby-bin-9.1.8.0.tar.gz#20ac501c99a7cb3cf53ded64ac1b8bb6e0b0f6ba34a41b8bacc9715cd4bb2601" jruby
+install_package "jruby-9.1.8.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.8.0/jruby-bin-9.1.8.0.tar.gz#20ac501c99a7cb3cf53ded64ac1b8bb6e0b0f6ba34a41b8bacc9715cd4bb2601" warn_eol jruby

--- a/share/ruby-build/jruby-9.1.9.0
+++ b/share/ruby-build/jruby-9.1.9.0
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.1.9.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.9.0/jruby-bin-9.1.9.0.tar.gz#36b802050155dccd808b4f69f01db4aa1599de467be657bdf81659aab9e8084e" jruby
+install_package "jruby-9.1.9.0" "https://s3.amazonaws.com/jruby.org/downloads/9.1.9.0/jruby-bin-9.1.9.0.tar.gz#36b802050155dccd808b4f69f01db4aa1599de467be657bdf81659aab9e8084e" warn_eol jruby


### PR DESCRIPTION
Ruby 2.3 EOL at 2019-03-31 https://www.ruby-lang.org/en/downloads/branches/
jruby 9.1 EOL at  end of 2017 https://github.com/jruby/jruby/wiki/Roadmap