### PR TITLE
The list `rbenv install -l` is too long, show latest stable releases by default

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -8,6 +8,8 @@
 #        rbenv install --version
 #
 #   -l/--list          List all available versions
+#   -L/--list-exclude-eol
+#                      List available versions excluding EoL'ed
 #   -f/--force         Install even if the version appears to be installed already
 #   -s/--skip-existing Skip if the version appears to be installed already
 #
@@ -38,6 +40,7 @@ shopt -u nullglob
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
   echo --list
+  echo --list-exclude-eol
   echo --force
   echo --skip-existing
   echo --keep
@@ -79,6 +82,9 @@ for option in "${OPTIONS[@]}"; do
   "l" | "list" )
     ruby-build --definitions
     exit
+    ;;
+  "L" | "list-exclude-eol" )
+    ruby-build --definitions-exclude-eol
     ;;
   "f" | "force" )
     FORCE=true

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -7,9 +7,8 @@
 #        rbenv install -l|--list
 #        rbenv install --version
 #
-#   -l/--list          List all available versions
-#   -L/--list-exclude-eol
-#                      List available versions excluding EoL'ed
+#   -l/--list          List available versions except EoL'ed versions
+#   -L/--list-all      List all available versions
 #   -f/--force         Install even if the version appears to be installed already
 #   -s/--skip-existing Skip if the version appears to be installed already
 #
@@ -40,7 +39,7 @@ shopt -u nullglob
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
   echo --list
-  echo --list-exclude-eol
+  echo --list-all
   echo --force
   echo --skip-existing
   echo --keep
@@ -80,11 +79,12 @@ for option in "${OPTIONS[@]}"; do
     usage 0
     ;;
   "l" | "list" )
-    ruby-build --definitions
+    ruby-build --list
     exit
     ;;
-  "L" | "list-exclude-eol" )
-    ruby-build --definitions-exclude-eol
+  "L" | "list-all" )
+    ruby-build --definitions
+    exit
     ;;
   "f" | "force" )
     FORCE=true

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -83,7 +83,7 @@ for option in "${OPTIONS[@]}"; do
     {
       echo
       echo "Only latest stable releases for each Ruby implementation are shown."
-      echo "Use 'rbenv install --list-all' to show all available versions."
+      echo "Use 'rbenv install --list-all' to show all local versions."
     } 1>&2
     exit
     ;;

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -8,7 +8,7 @@
 #        rbenv install --version
 #
 #   -l/--list          List latest stable versions for each Ruby
-#   -L/--list-all      List all available versions
+#   -L/--list-all      List all local versions
 #   -f/--force         Install even if the version appears to be installed already
 #   -s/--skip-existing Skip if the version appears to be installed already
 #

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -83,7 +83,7 @@ for option in "${OPTIONS[@]}"; do
     {
       echo
       echo "Only latest stable releases for each Ruby implementation are shown."
-      echo "Try 'rbenv install --list-all' to show all available versions."
+      echo "Use 'rbenv install --list-all' to show all available versions."
     } 1>&2
     exit
     ;;

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -7,7 +7,7 @@
 #        rbenv install -l|--list
 #        rbenv install --version
 #
-#   -l/--list          List available versions except EoL'ed versions
+#   -l/--list          List latest stable versions for each Ruby
 #   -L/--list-all      List all available versions
 #   -f/--force         Install even if the version appears to be installed already
 #   -s/--skip-existing Skip if the version appears to be installed already
@@ -80,6 +80,11 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "l" | "list" )
     ruby-build --list
+    {
+      echo
+      echo "Only latest stable releases for each Ruby implementation are shown."
+      echo "Try 'rbenv install --list-all' to show all available versions."
+    } 1>&2
     exit
     ;;
   "L" | "list-all" )

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -10,7 +10,7 @@
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
 #   -d/--definitions List all built-in definitions
-#   -l/--list        List built-in definitions except EoL'ed versions
+#   -l/--list        List latest stable releases for each Ruby
 #   --version        Show version of ruby-build
 #
 
@@ -1196,6 +1196,7 @@ usage() {
   [ -z "$1" ] || exit "$1"
 }
 
+# list all versions
 list_definitions() {
   { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
       [ -d "$DEFINITION_DIR" ] && ls "$DEFINITION_DIR"
@@ -1203,8 +1204,8 @@ list_definitions() {
   } | sort_versions | uniq
 }
 
-# listing exclude RC, preview, dev versions and EoL'ed versions
-list_definitions_exclude_eol() {
+# list only latest stable versions excluding RC, preview, dev and EoL'ed
+list_latest_definitions() {
   { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
       [ -d "$DEFINITION_DIR" ] && \
       (
@@ -1213,7 +1214,16 @@ list_definitions_exclude_eol() {
         grep -v -e '-rc[0-9]*$' -e '-preview[0-9]*$' -e '-dev$'
       )
     done
-  } | sort_versions | uniq
+  } | filter_previous_versions | sort_versions | uniq
+}
+
+filter_previous_versions() {
+  # sort in this function looks redundunt but it is necessary
+  # rbx-3.99 appears latest unless the sort
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | \
+    sed 's/[+.]/ /; s/[0-9].*z //; s/^\([0-9].[0-9]\)/mri\1 \1/' | \
+    awk '{ latest[$1] =$2 } END{ for(key in latest) { print latest[key] } }'
 }
 
 sort_versions() {
@@ -1247,7 +1257,7 @@ for option in "${OPTIONS[@]}"; do
     exit 0
     ;;
   "l" | "list")
-    list_definitions_exclude_eol
+    list_latest_definitions
     exit 0
     ;;
   "k" | "keep" )

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1208,11 +1208,9 @@ list_definitions() {
 list_maintained_versions() {
   { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
       [ -d "$DEFINITION_DIR" ] && \
-      (
-        cd "$DEFINITION_DIR";
-        grep -L -e warn_eol * | \
+        grep -L -e warn_eol "$DEFINITION_DIR"/* 2>/dev/null | \
+        sed 's|.*/||' | \
         grep -v -e '-rc[0-9]*$' -e '-preview[0-9]*$' -e '-dev$'
-      )
     done
   } | extract_latest_versions | sort_versions | uniq
 }

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1203,9 +1203,15 @@ list_definitions() {
   } | sort_versions | uniq
 }
 
+# listing exclude RC, preview, dev versions and EoL'ed versions
 list_definitions_exclude_eol() {
   { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
-    [ -d "$DEFINITION_DIR" ] && (cd "$DEFINITION_DIR"; grep -L -e warn_eol -e warn_unsupported *)
+      [ -d "$DEFINITION_DIR" ] && \
+      (
+        cd "$DEFINITION_DIR";
+        grep -L -e warn_eol -e warn_unsupported * | \
+        grep -v -e '-rc[0-9]*$' -e '-preview[0-9]*$' -e '-dev$'
+      )
     done
   } | sort_versions | uniq
 }

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -9,7 +9,7 @@
 #   -v/--verbose     Verbose mode: print compilation status to stdout
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
-#   --definitions    List all built-in definitions
+#   -d/--definitions List all built-in definitions
 #   --definitions-exclude-eol
 #                    List all builtt-in definitions excluding EoL'ed
 #   --version        Show version of ruby-build
@@ -1237,7 +1237,7 @@ for option in "${OPTIONS[@]}"; do
     echo
     usage 0
     ;;
-  "definitions" )
+  "d" | "definitions" )
     list_definitions
     exit 0
     ;;

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1205,7 +1205,7 @@ list_definitions() {
 }
 
 # list only latest stable versions excluding RC, preview, dev and EoL'ed
-list_latest_definitions() {
+list_maintained_versions() {
   { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
       [ -d "$DEFINITION_DIR" ] && \
       (
@@ -1214,10 +1214,10 @@ list_latest_definitions() {
         grep -v -e '-rc[0-9]*$' -e '-preview[0-9]*$' -e '-dev$'
       )
     done
-  } | filter_previous_versions | sort_versions | uniq
+  } | extract_latest_versions | sort_versions | uniq
 }
 
-filter_previous_versions() {
+extract_latest_versions() {
   # sort in this function looks redundunt but it is necessary
   # rbx-3.99 appears latest unless the sort
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \
@@ -1257,7 +1257,7 @@ for option in "${OPTIONS[@]}"; do
     exit 0
     ;;
   "l" | "list")
-    list_latest_definitions
+    list_maintained_versions
     exit 0
     ;;
   "k" | "keep" )

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1209,7 +1209,7 @@ list_definitions_exclude_eol() {
       [ -d "$DEFINITION_DIR" ] && \
       (
         cd "$DEFINITION_DIR";
-        grep -L -e warn_eol -e warn_unsupported * | \
+        grep -L -e warn_eol * | \
         grep -v -e '-rc[0-9]*$' -e '-preview[0-9]*$' -e '-dev$'
       )
     done

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -9,7 +9,7 @@
 #   -v/--verbose     Verbose mode: print compilation status to stdout
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
-#   -d/--definitions List all built-in definitions
+#   --definitions    List all built-in definitions
 #   -l/--list        List latest stable releases for each Ruby
 #   --version        Show version of ruby-build
 #
@@ -1252,7 +1252,7 @@ for option in "${OPTIONS[@]}"; do
     echo
     usage 0
     ;;
-  "d" | "definitions" )
+  "definitions" )
     list_definitions
     exit 0
     ;;

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -10,8 +10,7 @@
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
 #   -d/--definitions List all built-in definitions
-#   --definitions-exclude-eol
-#                    List all builtt-in definitions excluding EoL'ed
+#   -l/--list        List built-in definitions except EoL'ed versions
 #   --version        Show version of ruby-build
 #
 
@@ -1241,7 +1240,7 @@ for option in "${OPTIONS[@]}"; do
     list_definitions
     exit 0
     ;;
-  "definitions-exclude-eol")
+  "l" | "list")
     list_definitions_exclude_eol
     exit 0
     ;;

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -10,6 +10,8 @@
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
 #   --definitions    List all built-in definitions
+#   --definitions-exclude-eol
+#                    List all builtt-in definitions excluding EoL'ed
 #   --version        Show version of ruby-build
 #
 
@@ -1202,6 +1204,13 @@ list_definitions() {
   } | sort_versions | uniq
 }
 
+list_definitions_exclude_eol() {
+  { for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
+    [ -d "$DEFINITION_DIR" ] && (cd "$DEFINITION_DIR"; grep -L -e warn_eol -e warn_unsupported *)
+    done
+  } | sort_versions | uniq
+}
+
 sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z.\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
@@ -1230,6 +1239,10 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "definitions" )
     list_definitions
+    exit 0
+    ;;
+  "definitions-exclude-eol")
+    list_definitions_exclude_eol
     exit 0
     ;;
   "k" | "keep" )

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -102,6 +102,71 @@ truffleruby-19.3.0"
   assert_success "$expected"
 }
 
+@test "filtering previous Ruby versions" {
+  export RUBY_BUILD_ROOT="$TMP"
+  mkdir -p "${RUBY_BUILD_ROOT}/share/ruby-build"
+
+  all_versions="
+2.4.0
+2.4.1
+2.4.2
+2.4.3
+2.4.4
+2.4.5
+2.4.6
+2.4.7
+2.4.8
+2.4.9
+2.5.0
+2.5.1
+2.5.2
+2.5.3
+2.5.4
+2.5.5
+2.5.6
+2.5.7
+2.6.0
+2.6.1
+2.6.2
+2.6.3
+2.6.4
+2.6.5
+2.7.0
+jruby-1.5.6
+jruby-9.2.7.0
+jruby-9.2.8.0
+jruby-9.2.9.0
+maglev-1.0.0
+mruby-1.4.1
+mruby-2.0.0
+mruby-2.0.1
+mruby-2.1.0
+rbx-3.104
+rbx-3.105
+rbx-3.106
+rbx-3.107
+truffleruby-19.2.0.1
+truffleruby-19.3.0
+truffleruby-19.3.0.2
+truffleruby-19.3.1"
+
+  expected="2.4.9
+2.5.7
+2.6.5
+2.7.0
+jruby-9.2.9.0
+maglev-1.0.0
+mruby-2.1.0
+rbx-3.107
+truffleruby-19.3.1"
+
+  for ver in $all_versions; do
+    touch "${RUBY_BUILD_ROOT}/share/ruby-build/$ver"
+  done
+  run ruby-build --list
+  assert_success "$expected"
+}
+
 @test "removing duplicate Ruby versions" {
   export RUBY_BUILD_ROOT="$TMP"
   export RUBY_BUILD_DEFINITIONS="${RUBY_BUILD_ROOT}/share/ruby-build"

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -140,7 +140,7 @@ OUT
   assert_success
   assert_output <<OUT
 --list
---list-exclude-eol
+--list-all
 --force
 --skip-existing
 --keep

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -38,7 +38,7 @@ stub_ruby_build() {
   stub_ruby_build \
     "--definitions : echo 1.8.7 1.9.3-p0 1.9.3-p194 2.1.2 | tr ' ' $'\\n'"
 
-  run rbenv-install --list
+  run rbenv-install --list-all
   assert_success
   assert_output <<OUT
 1.8.7
@@ -122,7 +122,7 @@ OUT
   mkdir -p "${RBENV_ROOT}/plugins/bar/share/ruby-build"
   stub_ruby_build "--definitions : echo \$RUBY_BUILD_DEFINITIONS | tr ':' $'\\n'"
 
-  run rbenv-install --list
+  run rbenv-install --list-all
   assert_success
   assert_output <<OUT
 

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -140,6 +140,7 @@ OUT
   assert_success
   assert_output <<OUT
 --list
+--list-exclude-eol
 --force
 --skip-existing
 --keep


### PR DESCRIPTION
## Background 

As time passes, list of available ruby versions is growing. However, I think ordinary users hardly install ancient versions such as Ruby 1.8 and Ruby 1.9. Now `rbenv install -l` became too big and is filled up with obsolete unused versions.

## What I did 
I implemented new options to show only supported versions. 
* `rbenv install -L (--list-exclude-eol)`
* `ruby-build --definitions-exclude-eol`

I used `warn_eol` `warn_unsupported` flag to determine if the version is EoL'ed.

## Result

Now I get significantly compact list.

```
% ruby-build --definitions | wc -l
     463
% ruby-build --definitions-exclude-eol | wc -l
     186
```

Also I can easily know which versions are supported. I believe this feature is helpful for most users.

```
% ruby-build --definitions-exclude-eol |grep ^'[0-9]'
2.5.0-dev
2.5.0-preview1
2.5.0-rc1
2.5.0
2.5.1
2.5.2
2.5.3
2.5.4
2.5.5
2.5.6
2.5.7
2.6.0-dev
2.6.0-preview1
2.6.0-preview2
2.6.0-preview3
2.6.0-rc1
2.6.0-rc2
2.6.0
2.6.1
2.6.2
2.6.3
2.6.4
2.6.5
2.7.0-dev
2.7.0-preview1
2.7.0-preview2
2.7.0-preview3
2.7.0-rc1
2.7.0-rc2
2.7.0
2.8.0-dev
```

```
% ruby-build --definitions |grep ^'[0-9]'|less
1.8.5-p52
1.8.5-p113
1.8.5-p114
1.8.5-p115
1.8.5-p231
1.8.6
1.8.6-p36
(snip)
```