### PR TITLE
Add truffleruby-dev to install the latest TruffleRuby nightly build

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -756,6 +756,8 @@ remove_windows_files() {
 }
 
 build_package_copy() {
+  # Make sure there are no leftover files in $PREFIX_PATH
+  rm -rf "$PREFIX_PATH"
   mkdir -p "$PREFIX_PATH"
   cp -fR . "$PREFIX_PATH"
 }

--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -1,0 +1,13 @@
+case $(uname -s) in
+Linux)
+  install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-18.04.tar.gz" truffleruby
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-macos-latest.tar.gz" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: $(uname -s)"
+  return 1
+  ;;
+esac


### PR DESCRIPTION
* Uses the latest nightly, which is automatically built.
* I checked locally and it works well with:
  `ruby-build truffleruby-dev ~/.rubies/truffleruby-dev`.

cc @hsbt @deepj 

Ref: https://github.com/oracle/truffleruby/issues/1483