### PR TITLE
Add update-mri and update-jruby scripts

### DIFF
--- a/script/update-cruby
+++ b/script/update-cruby
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $0 VERSION RELEASE_DIRECTORY"
+  exit 1
+fi
+
+version="$1"
+release_directory="$2"
+file="share/ruby-build/${version}"
+
+basename="ruby-${version}.tar.bz2"
+major_minor_version=$(echo ${version} | cut -d '.' -f 1,2)
+url="https://cache.ruby-lang.org/pub/ruby/${major_minor_version}/${basename}"
+sha256=$(sha256sum "$release_directory/$basename" | cut -d ' ' -f 1)
+
+cat > "$file" <<EOS
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-${version}" "${url}#${sha256}" ldflags_dirs enable_shared standard verify_openssl
+EOS

--- a/script/update-jruby
+++ b/script/update-jruby
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $0 VERSION RELEASE_DIRECTORY"
+  exit 1
+fi
+
+version="$1"
+release_directory="$2"
+file="share/ruby-build/jruby-${version}"
+
+basename="jruby-bin-${version}.tar.gz"
+url="https://s3.amazonaws.com/jruby.org/downloads/${version}/${basename}"
+sha256=$(sha256sum "$release_directory/$basename" | cut -d ' ' -f 1)
+
+cat > "$file" <<EOS
+require_java 8
+install_package "jruby-${version}" "${url}#${sha256}" jruby
+EOS


### PR DESCRIPTION
This PR adds update-mri and update-jruby scripts.
They are provided to update MRI and JRuby definition files.

These scripts are based on script/update-truffleruby.
https://github.com/rbenv/ruby-build/blob/v20200224/script/update-truffleruby