### PR TITLE
bin/ruby-build: support DESTDIR setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,29 +64,30 @@ definitions.
 
 The build process may be configured through the following environment variables:
 
-| Variable                        | Function                                                                                         |
-| ------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `TMPDIR`                        | Where temporary files are stored.                                                                |
-| `RUBY_BUILD_BUILD_PATH`         | Where sources are downloaded and built. (Default: a timestamped subdirectory of `TMPDIR`)        |
-| `RUBY_BUILD_CACHE_PATH`         | Where to cache downloaded package files. (Default: `~/.rbenv/cache` if invoked as rbenv plugin)  |
-| `RUBY_BUILD_HTTP_CLIENT`        | One of `aria2c`, `curl`, or `wget` to use for downloading. (Default: first one found in PATH)    |
-| `RUBY_BUILD_ARIA2_OPTS`         | Additional options to pass to `aria2c` for downloading.                                          |
-| `RUBY_BUILD_CURL_OPTS`          | Additional options to pass to `curl` for downloading.                                            |
-| `RUBY_BUILD_WGET_OPTS`          | Additional options to pass to `wget` for downloading.                                            |
-| `RUBY_BUILD_MIRROR_URL`         | Custom mirror URL root.                                                                          |
+| Variable                 | Function                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `TMPDIR`                 | Where temporary files are stored.                                                                |
+| `RUBY_BUILD_BUILD_PATH`  | Where sources are downloaded and built. (Default: a timestamped subdirectory of `TMPDIR`)        |
+| `RUBY_BUILD_CACHE_PATH`  | Where to cache downloaded package files. (Default: `~/.rbenv/cache` if invoked as rbenv plugin)  |
+| `RUBY_BUILD_HTTP_CLIENT` | One of `aria2c`, `curl`, or `wget` to use for downloading. (Default: first one found in PATH)    |
+| `RUBY_BUILD_ARIA2_OPTS`  | Additional options to pass to `aria2c` for downloading.                                          |
+| `RUBY_BUILD_CURL_OPTS`   | Additional options to pass to `curl` for downloading.                                            |
+| `RUBY_BUILD_WGET_OPTS`   | Additional options to pass to `wget` for downloading.                                            |
+| `RUBY_BUILD_MIRROR_URL`  | Custom mirror URL root.                                                                          |
 | `RUBY_BUILD_MIRROR_PACKAGE_URL` | Custom complete mirror URL (e.g. http://mirror.example.com/package-1.0.0.tar.gz).                  |
-| `RUBY_BUILD_SKIP_MIRROR`        | Bypass the download mirror and fetch all package files from their original URLs.                 |
-| `RUBY_BUILD_ROOT`               | Custom build definition directory. (Default: `share/ruby-build`)                                 |
-| `RUBY_BUILD_DEFINITIONS`        | Additional paths to search for build definitions. (Colon-separated list)                         |
-| `CC`                            | Path to the C compiler.                                                                          |
-| `RUBY_CFLAGS`                   | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |
-| `CONFIGURE_OPTS`                | Additional `./configure` options.                                                                |
-| `MAKE`                          | Custom `make` command (_e.g.,_ `gmake`).                                                         |
-| `MAKE_OPTS` / `MAKEOPTS`        | Additional `make` options.                                                                       |
-| `MAKE_INSTALL_OPTS`             | Additional `make install` options.                                                               |
-| `RUBY_CONFIGURE_OPTS`           | Additional `./configure` options (applies only to Ruby source).                                  |
-| `RUBY_MAKE_OPTS`                | Additional `make` options (applies only to Ruby source).                                         |
-| `RUBY_MAKE_INSTALL_OPTS`        | Additional `make install` options (applies only to Ruby source).                                 |
+| `RUBY_BUILD_SKIP_MIRROR` | Bypass the download mirror and fetch all package files from their original URLs.                 |
+| `RUBY_BUILD_ROOT`        | Custom build definition directory. (Default: `share/ruby-build`)                                 |
+| `RUBY_BUILD_DEFINITIONS` | Additional paths to search for build definitions. (Colon-separated list)                         |
+| `CC`                     | Path to the C compiler.                                                                          |
+| `RUBY_CFLAGS`            | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |
+| `CONFIGURE_OPTS`         | Additional `./configure` options.                                                                |
+| `MAKE`                   | Custom `make` command (_e.g.,_ `gmake`).                                                         |
+| `MAKE_OPTS` / `MAKEOPTS` | Additional `make` options.                                                                       |
+| `DESTDIR`                | Install compiled Ruby to this directory instead of path e.g. `DESTDIR/usr/local/bin/ruby`        |
+| `MAKE_INSTALL_OPTS`      | Additional `make install` options (use DESTDIR above to set the DESTDIR option)                  |
+| `RUBY_CONFIGURE_OPTS`    | Additional `./configure` options (applies only to Ruby source).                                  |
+| `RUBY_MAKE_OPTS`         | Additional `make` options (applies only to Ruby source).                                         |
+| `RUBY_MAKE_INSTALL_OPTS` | Additional `make install` options (applies only to Ruby source).                                 |
 
 #### Applying Patches
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1471,10 +1471,19 @@ fi
 
 unset RUBYOPT
 if [ -n "${DESTDIR}" ]; then
-    export RUBYLIB="${DESTDIR}${PREFIX_PATH}/lib/ruby/${ARGUMENTS[0]}:${DESTDIR}${PREFIX_PATH}/lib/ruby/${ARGUMENTS[0]}/$(uname -m)-$(uname | tr '[:upper:]' '[:lower:]')"
+    argument_version="${ARGUMENTS[0]}"
+    # Ruby puts the lib for e.g "2.7.1" in "2.7.0", so also make that adjustment
+    # here, see
+    # https://github.com/rbenv/ruby-build/issues/1433#issuecomment-618833687.
+    IFS=. read major minor patch <<<"${argument_version##*-}"
+    argument_api_version="${major}.${minor}.0"
+    export RUBYLIB="${DESTDIR}${PREFIX_PATH}/lib/ruby/${argument_api_version}:${DESTDIR}${PREFIX_PATH}/lib/ruby/${argument_api_version}/$(uname -m)-$(uname | tr '[:upper:]' '[:lower:]')"
 else
     unset RUBYLIB
 fi
+# enable Ruby verbose logging
+export V=1
+echo "RUBYLIB set to $RUBYLIB"
 
 trap build_failed ERR
 mkdir -p "$BUILD_PATH"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1440,6 +1440,11 @@ WGET_OPTS="${RUBY_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
 SEED="$(date "+%Y%m%d%H%M%S").$$"
 LOG_PATH="${TMP}/ruby-build.${SEED}.log"
 RUBY_BIN="${PREFIX_PATH}/bin/ruby"
+if [ -n "${DESTDIR}" ]; then
+    RUBY_BIN="${DESTDIR}${RUBY_BIN}"
+    MAKE_INSTALL_OPTS="${MAKE_INSTALL_OPTS} DESTDIR=${DESTDIR}"
+fi
+
 CWD="$(pwd)"
 
 if [ -z "$RUBY_BUILD_BUILD_PATH" ]; then
@@ -1455,11 +1460,21 @@ if [ -n "$VERBOSE" ]; then
   trap "kill $TAIL_PID" SIGINT SIGTERM EXIT
 fi
 
-export LDFLAGS="-L${PREFIX_PATH}/lib ${LDFLAGS}"
-export CPPFLAGS="-I${PREFIX_PATH}/include ${CPPFLAGS}"
+if [ -n "${DESTDIR}" ]; then
+    export LDFLAGS="-L${DESTDIR}${PREFIX_PATH}/lib ${LDFLAGS}"
+    export LD_LIBRARY_PATH="${DESTDIR}${PREFIX_PATH}/lib:${LD_LIBRARY_PATH}"
+    export CPPFLAGS="-I${DESTDIR}${PREFIX_PATH}/include ${CPPFLAGS}"
+else
+    export LDFLAGS="-L${PREFIX_PATH}/lib ${LDFLAGS}"
+    export CPPFLAGS="-I${PREFIX_PATH}/include ${CPPFLAGS}"
+fi
 
 unset RUBYOPT
-unset RUBYLIB
+if [ -n "${DESTDIR}" ]; then
+    export RUBYLIB="${DESTDIR}${PREFIX_PATH}/lib/ruby/${ARGUMENTS[0]}:${DESTDIR}${PREFIX_PATH}/lib/ruby/${ARGUMENTS[0]}/$(uname -m)-$(uname | tr '[:upper:]' '[:lower:]')"
+else
+    unset RUBYLIB
+fi
 
 trap build_failed ERR
 mkdir -p "$BUILD_PATH"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1481,9 +1481,6 @@ if [ -n "${DESTDIR}" ]; then
 else
     unset RUBYLIB
 fi
-# enable Ruby verbose logging
-export V=1
-echo "RUBYLIB set to $RUBYLIB"
 
 trap build_failed ERR
 mkdir -p "$BUILD_PATH"


### PR DESCRIPTION
We can't just use MAKE_INSTALL_OPTS because DESTDIR modifies the
location of the installed ruby binary, so anything that used the old
RUBY_BIN also failed - it needed to be modified as well.

Instead introduce a new variable that edits both RUBY_BIN and
MAKE_INSTALL_OPTS if set.

Also edit LDFLAGS so we can find libruby.so in the DESTDIR for
post-install checks.

Fixes #1415.
Updates #413.