### PR TITLE
s/all built-in definitions/all available definitions/

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -9,7 +9,7 @@
 #   -v/--verbose     Verbose mode: print compilation status to stdout
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
-#   --definitions    List all built-in definitions
+#   --definitions    List all available definitions
 #   --version        Show version of ruby-build
 #
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -9,7 +9,7 @@
 #   -v/--verbose     Verbose mode: print compilation status to stdout
 #   -4/--ipv4        Resolve names to IPv4 addresses only
 #   -6/--ipv6        Resolve names to IPv6 addresses only
-#   --definitions    List all available definitions
+#   --definitions    List all local definitions
 #   --version        Show version of ruby-build
 #
 

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -3,7 +3,7 @@
 load test_helper
 NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
 
-@test "list built-in definitions" {
+@test "list all available definitions" {
   run ruby-build --definitions
   assert_success
   assert_output_contains "1.9.3-p194"

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -3,7 +3,7 @@
 load test_helper
 NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
 
-@test "list all available definitions" {
+@test "list all local definitions" {
   run ruby-build --definitions
   assert_success
   assert_output_contains "1.9.3-p194"


### PR DESCRIPTION
Suggested by mislav: https://github.com/rbenv/ruby-build/pull/1402#discussion_r389060742

> I wonder should we substitute "built-in" with something like "all
> available definitions". Since ruby-build will additionally pick up
> definitions found under the paths listed in RUBY_BUILD_DEFINITIONS,
> these definitions will get listed even if they are not "built-in".
> Therefore, "built-in" feels like a misnomer here.

Searched by `git grep built-in`.