### PR TITLE
Add definition for JRuby 9.2.11.1

### DIFF
--- a/share/ruby-build/jruby-9.2.11.1
+++ b/share/ruby-build/jruby-9.2.11.1
@@ -1,0 +1,2 @@
+require_java 8
+install_package "jruby-9.2.11.1" "https://s3.amazonaws.com/jruby.org/downloads/9.2.11.1/jruby-bin-9.2.11.1.tar.gz#f10449c82567133908e5e1ac076438307a7f0916f617f40fa314b78873a195dc" jruby


### PR DESCRIPTION
JRuby 9.2.11.1 has been released.
https://www.jruby.org/2020/03/25/jruby-9-2-11-1