### PR TITLE
add definition 2.4.10, 2.5.8, 2.6.6, 2.7.1 and ruby 2.4 EOL

### DIFF
--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_unsupported ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.4.0-preview1
+++ b/share/ruby-build/2.4.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2#17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649" warn_unsupported ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2#17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-preview2
+++ b/share/ruby-build/2.4.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2#2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d" warn_unsupported ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2#2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-preview3
+++ b/share/ruby-build/2.4.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2#305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52" warn_unsupported ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2#305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.0-rc1
+++ b/share/ruby-build/2.4.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2q" "https://www.openssl.org/source/openssl-1.0.2q.tar.gz#5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-rc1.tar.bz2#3b156b20f9df0dd62cbeeb8e57e66ea872d2a5b55fabdef1889650122bcc2ea7" warn_unsupported ldflags_dirs standard verify_openssl
+install_package "ruby-2.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-rc1.tar.bz2#3b156b20f9df0dd62cbeeb8e57e66ea872d2a5b55fabdef1889650122bcc2ea7" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.4.1
+++ b/share/ruby-build/2.4.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.10
+++ b/share/ruby-build/2.4.10
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.4.10" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.tar.bz2#6ea3ce7fd0064524ae06dbdcd99741c990901dfc9c66d8139a02f907d30b95a8" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.2
+++ b/share/ruby-build/2.4.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.5
+++ b/share/ruby-build/2.4.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.6
+++ b/share/ruby-build/2.4.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.7
+++ b/share/ruby-build/2.4.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.8
+++ b/share/ruby-build/2.4.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.9
+++ b/share/ruby-build/2.4.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.8
+++ b/share/ruby-build/2.5.8
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.5.8" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2#41fc93731ad3f3aa597d657f77ed68fa86b5e93c04dfbf7e542a8780702233f0" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.6
+++ b/share/ruby-build/2.6.6
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.6" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2#f08b779079ecd1498e6a2548c39a86144c6c784dcec6f7e8a93208682eb8306e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.1
+++ b/share/ruby-build/2.7.1
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1d" "https://www.openssl.org/source/openssl-1.1.1d.tar.gz#1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-5-8-released/
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-6-6-released/
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/
https://www.ruby-lang.org/en/downloads/branches/