### PR TITLE
ruby-build 20200401

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -13,7 +13,7 @@
 #   --version        Show version of ruby-build
 #
 
-RUBY_BUILD_VERSION="20200224"
+RUBY_BUILD_VERSION="20200401"
 
 OLDIFS="$IFS"
 


### PR DESCRIPTION
Hello, would you mind rolling a new release? There were [new definitions added](https://github.com/rbenv/ruby-build/commit/d45c4ed624812e27317c98b174bd4debd39a80f7) for ruby releases that addressed security vulnerabilities.

- [2.4.10](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/)
- [2.5.8](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-5-8-released/)
- [2.6.6](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-6-6-released/)
- [2.7.1](https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/)