### PR TITLE
Fix openssl dependent gem compilation (e.g. mysql2) when using downloaded and compiled mac_openssl

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1069,6 +1069,9 @@ build_package_mac_openssl() {
   local pem_file="$OPENSSLDIR/cert.pem"
   security find-certificate -a -p /Library/Keychains/System.keychain > "$pem_file"
   security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain >> "$pem_file"
+
+  # add --with-opt-dir to ruby configure to ensure gems dependent on openssl build OK
+  RUBY_CONFIGURE_OPTS_ARRAY+=("--with-opt-dir=${OPENSSL_PREFIX_PATH}")
 }
 
 # Post-install check that the openssl extension was built.


### PR DESCRIPTION
Hi!

I started using asdf-ruby which uses ruby-build. I noticed that after installing a standard Ruby, I could not install the mysql2 gem.

Since ruby-build downloaded and compiled openssl, it should be able to configure Ruby so that gems that use openssl use this version that was downloaded and compiled. AFAIK the key to doing this is to pass `--with-opt-dir` to Ruby's configure script. It then gets set in `RbConfig::CONFIG` which is then used during gem compilation.

I added this to ruby-build to see if it would work. It did for me.


#### Before

```
$ gem install mysql2
Building native extensions. This could take a while...
ERROR:  Error installing mysql2:
	ERROR: Failed to build gem native extension.

    current directory: /Users/greg/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/mysql2-0.5.3/ext/mysql2
/Users/greg/.asdf/installs/ruby/2.7.1/bin/ruby -I /Users/greg/.asdf/installs/ruby/2.7.1/lib/ruby/2.7.0 -r ./siteconf20200504-69297-aw49lw.rb extconf.rb
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for rb_wait_for_single_fd()... yes
-----
Using mysql_config at /usr/local/opt/mysql@5.6/bin/mysql_config
-----
checking for mysql.h... yes
checking for errmsg.h... yes
checking for SSL_MODE_DISABLED in mysql.h... no
checking for MYSQL_OPT_SSL_ENFORCE in mysql.h... no
checking for MYSQL.net.vio in mysql.h... yes
checking for MYSQL.net.pvio in mysql.h... no
checking for MYSQL_ENABLE_CLEARTEXT_PLUGIN in mysql.h... yes
checking for SERVER_QUERY_NO_GOOD_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_NO_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_WAS_SLOW in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_ON in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_OFF in mysql.h... yes
checking for my_bool in mysql.h... yes
-----
Don't know how to set rpath on your system, if MySQL libraries are not in path mysql2 may not load
-----
-----
Setting libpath to /usr/local/opt/mysql@5.6/lib
-----
creating Makefile

current directory: /Users/greg/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/mysql2-0.5.3/ext/mysql2
make "DESTDIR=" clean

current directory: /Users/greg/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/mysql2-0.5.3/ext/mysql2
make "DESTDIR="
compiling client.c
client.c:787:14: warning: incompatible pointer types passing 'VALUE (void *)' (aka 'unsigned long (void *)') to parameter of type 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') [-Wincompatible-pointer-types]
  rb_rescue2(do_send_query, (VALUE)&args, disconnect_and_raise, self, rb_eException, (VALUE)0);
             ^~~~~~~~~~~~~
/Users/greg/.asdf/installs/ruby/2.7.1/include/ruby-2.7.0/ruby/ruby.h:1988:25: note: passing argument to parameter here
VALUE rb_rescue2(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE,VALUE),VALUE,...);
                        ^
client.c:795:16: warning: incompatible pointer types passing 'VALUE (void *)' (aka 'unsigned long (void *)') to parameter of type 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') [-Wincompatible-pointer-types]
    rb_rescue2(do_query, (VALUE)&async_args, disconnect_and_raise, self, rb_eException, (VALUE)0);
               ^~~~~~~~
/Users/greg/.asdf/installs/ruby/2.7.1/include/ruby-2.7.0/ruby/ruby.h:1988:25: note: passing argument to parameter here
VALUE rb_rescue2(VALUE(*)(VALUE),VALUE,VALUE(*)(VALUE,VALUE),VALUE,...);
                        ^
2 warnings generated.
compiling infile.c
compiling mysql2_ext.c
compiling result.c
compiling statement.c
linking shared-object mysql2/mysql2.bundle
ld: library not found for -lssl
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [mysql2.bundle] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/greg/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/gems/mysql2-0.5.3 for inspection.
Results logged to /Users/greg/.asdf/installs/ruby/2.7.1/lib/ruby/gems/2.7.0/extensions/x86_64-darwin-18/2.7.0/mysql2-0.5.3/gem_make.out
```

The key line is `ld: library not found for -lssl`

#### After

```
$ gem install mysql2
Building native extensions. This could take a while...
Successfully installed mysql2-0.5.3
1 gem installed
```

#### Notes

You can see the difference in `RbConfig::CONFIG`:

Before:

```
$ ruby -rrbconfig -e 'p RbConfig::CONFIG["DLDFLAGS"]'
"-L/Users/greg/.asdf/installs/ruby/2.5.1/lib  -Wl,-undefined,dynamic_lookup -Wl,-multiply_defined,suppress"

$ ruby -rrbconfig -e 'p RbConfig::CONFIG["LDFLAGS"]'
"-L. -L/Users/greg/.asdf/installs/ruby/2.5.1/lib  -fstack-protector-strong -L/usr/local/lib"
```

After:

```
$ ruby -rrbconfig -e 'p RbConfig::CONFIG["DLDFLAGS"]'
"-L/Users/greg/.asdf/installs/ruby/2.5.1/lib  -Wl,-undefined,dynamic_lookup -Wl,-multiply_defined,suppress -L/Users/greg/.asdf/installs/ruby/2.5.1/openssl/lib"

$ ruby -rrbconfig -e 'p RbConfig::CONFIG["LDFLAGS"]'
"-L. -L/Users/greg/.asdf/installs/ruby/2.5.1/lib  -fstack-protector -L/usr/local/lib -L/Users/greg/.asdf/installs/ruby/2.5.1/openssl/lib"
```
