### PR TITLE
Fix gem installations that rely on OpenSSL when build_package_mac_openssl() is used

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1057,6 +1057,7 @@ build_package_mac_openssl() {
 
   # Tell Ruby to use this openssl for its extension.
   package_option ruby configure --with-openssl-dir="$OPENSSL_PREFIX_PATH"
+  package_option ruby configure --with-opt-dir="$OPENSSL_PREFIX_PATH"
 
   # Make sure pkg-config finds our build first.
   export PKG_CONFIG_PATH="${OPENSSL_PREFIX_PATH}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"


### PR DESCRIPTION
This PR is an alternate approach to #1439. Credit goes to @puyo for identifying the issue.

Looking through the code, I believe using `package_option` is the preferred way to add configuration options. I took @puyo's fix and converted it to use `package_option` instead.

I can confirm this fix works—I was having the same issue compiling `mysql2` on macOS Catalina. It's no longer a problem with this change in place.