### PR TITLE
Fix a bash 4.4 warning when installing jruby

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -736,7 +736,7 @@ install_jruby_launcher() {
 
 fix_jruby_shebangs() {
   for file in "${PREFIX_PATH}/bin"/*; do
-    if [ "$(head -c 20 "$file")" = "#!/usr/bin/env jruby" ]; then
+    if [ "$(head -c 20 "$file" | tr -d '\0')" = "#!/usr/bin/env jruby" ]; then
       sed -i.bak "1 s:.*:#\!${PREFIX_PATH}\/bin\/jruby:" "$file"
       rm "$file".bak
     fi


### PR DESCRIPTION
When installing jruby, and using bash 4.4 or higher, you get the following warning:

```
$ rbenv install jruby-9.2.11.1 
Downloading jruby-bin-9.2.11.1.tar.gz...
-> https://dqw8nmjcqpjn7.cloudfront.net/f10449c82567133908e5e1ac076438307a7f0916f617f40fa314b78873a195dc
Installing jruby-9.2.11.1...
/home/deivid/.rbenv/plugins/ruby-build/bin/ruby-build: line 739: warning: command substitution: ignored null byte in input
/home/deivid/.rbenv/plugins/ruby-build/bin/ruby-build: line 739: warning: command substitution: ignored null byte in input
Installed jruby-9.2.11.1 to /home/deivid/.rbenv/versions/jruby-9.2.11.1
```

This PR explicitly removes the null byte bash is complaining about.

But other approach could be to explicitly exclude "binary binstubs" from the check. In particular, this warning is printed when running this check for the `bin/ruby` and `bin/jruby` binaries.