### PR TITLE
Fix artichoke-dev installer

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -754,7 +754,6 @@ build_package_truffleruby() {
 build_package_artichoke() {
   build_package_copy
 
-  rm -rf "$PREFIX_PATH"
   mkdir -p "$PREFIX_PATH/bin"
   cd "${PREFIX_PATH}/bin"
   ln -fs ../artichoke ruby


### PR DESCRIPTION
The existing install function wiped out the prefix that `build_package_copy`
copied the binaries to. The subsequently created symlinks point to files
that don't exist on disk.

cc @deepj 

I'm hoping that ruby-build can push a release after merging this fix. The current release results in:

```console
$ ruby
rbenv: ruby: command not found

The `ruby' command exists in these Ruby versions:
  2.6.3
  2.6.5
  2.6.6
```