### PR TITLE
Updates for DESTDIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The build process may be configured through the following environment variables:
 | `CONFIGURE_OPTS`         | Additional `./configure` options.                                                                |
 | `MAKE`                   | Custom `make` command (_e.g.,_ `gmake`).                                                         |
 | `MAKE_OPTS` / `MAKEOPTS` | Additional `make` options.                                                                       |
+| `MAKE_INSTALL_DESTDIR`   | Set `DESTDIR` for `make install`.                                                                |
 | `MAKE_INSTALL_OPTS`      | Additional `make install` options.                                                               |
 | `RUBY_CONFIGURE_OPTS`    | Additional `./configure` options (applies only to Ruby source).                                  |
 | `RUBY_MAKE_OPTS`         | Additional `make` options (applies only to Ruby source).                                         |

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -629,6 +629,8 @@ build_package_autoconf() {
 build_package_ruby() {
   local package_name="$1"
 
+  have_installed_ruby || echo 'Skipping package_ruby due to DESTDIR installation'; return 0
+
   { "$RUBY_BIN" setup.rb
   } >&4 2>&1
 }
@@ -1088,6 +1090,8 @@ build_package_mac_openssl() {
 
 # Post-install check that the openssl extension was built.
 build_package_verify_openssl() {
+  have_installed_ruby || echo 'Skipping verify_openssl due to DESTDIR installation'; return 0
+
   "$RUBY_BIN" -e '
     manager = ARGV[0]
     packages = {
@@ -1195,6 +1199,11 @@ apply_ruby_patch() {
     patch -p$striplevel --force -i "$patchfile"
     ;;
   esac
+}
+
+have_installed_ruby() {
+    [ "$BUILT_PREFIX_PATH" = "$PREFIX_PATH" ]
+    return $?
 }
 
 version() {
@@ -1403,7 +1412,7 @@ WGET_OPTS="${RUBY_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
 
 SEED="$(date "+%Y%m%d%H%M%S").$$"
 LOG_PATH="${TMP}/ruby-build.${SEED}.log"
-RUBY_BIN="${BUILT_PREFIX_PATH}/bin/ruby"
+RUBY_BIN="${PREFIX_PATH}/bin/ruby"
 CWD="$(pwd)"
 
 if [ -z "$RUBY_BUILD_BUILD_PATH" ]; then

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -629,7 +629,7 @@ build_package_autoconf() {
 build_package_ruby() {
   local package_name="$1"
 
-  have_installed_ruby || echo 'Skipping package_ruby due to DESTDIR installation'; return 0
+  have_installed_ruby || { echo 'Skipping package_ruby due to DESTDIR installation'; return 0; }
 
   { "$RUBY_BIN" setup.rb
   } >&4 2>&1
@@ -1090,7 +1090,8 @@ build_package_mac_openssl() {
 
 # Post-install check that the openssl extension was built.
 build_package_verify_openssl() {
-  have_installed_ruby || echo 'Skipping verify_openssl due to DESTDIR installation'; return 0
+  have_installed_ruby || { echo 'Skipping verify_openssl due to DESTDIR installation'; return 0; }
+  echo "Doing verify_openssl"
 
   "$RUBY_BIN" -e '
     manager = ARGV[0]

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -601,7 +601,9 @@ build_package_standard_install() {
   local PACKAGE_MAKE_INSTALL_OPTS="${package_var_name}_MAKE_INSTALL_OPTS"
   local PACKAGE_MAKE_INSTALL_OPTS_ARRAY="${package_var_name}_MAKE_INSTALL_OPTS_ARRAY[@]"
 
-  { "$MAKE" install $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}"
+  local DESTDIR_OPT="DESTDIR=${MAKE_INSTALL_DESTDIR}"
+
+  { "$MAKE" install "$DESTDIR_OPT" $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS} "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}"
   } >&4 2>&1
 }
 
@@ -643,8 +645,9 @@ build_package_ree_installer() {
   done
 
   # Work around install_useful_libraries crash with --dont-install-useful-gems
-  mkdir -p "$PREFIX_PATH/lib/ruby/gems/1.8/gems"
+  mkdir -p "$BUILT_PREFIX_PATH/lib/ruby/gems/1.8/gems"
 
+  # TODO: this is one PREFIX_PATH i'm not sure if it should be BUILT_ or not
   { ./installer --auto "$PREFIX_PATH" --dont-install-useful-gems $options $CONFIGURE_OPTS
   } >&4 2>&1
 }
@@ -672,26 +675,26 @@ build_package_rbx() {
 
     RUBYOPT="-rrubygems $RUBYOPT" ./configure --prefix="$PREFIX_PATH" $RUBY_CONFIGURE_OPTS "${configure_opts[@]}"
     rake install
-    fix_rbx_gem_binstubs "$PREFIX_PATH"
-    fix_rbx_irb "$PREFIX_PATH"
+    fix_rbx_gem_binstubs "$BUILT_PREFIX_PATH"
+    fix_rbx_irb "$BUILT_PREFIX_PATH"
   } >&4 2>&1
 }
 
 build_package_mruby() {
   { ./minirake
-    mkdir -p "$PREFIX_PATH"
-    cp -fR build/host/* include "$PREFIX_PATH"
-    ln -fs mruby "$PREFIX_PATH/bin/ruby"
-    ln -fs mirb "$PREFIX_PATH/bin/irb"
+    mkdir -p "$BUILT_PREFIX_PATH"
+    cp -fR build/host/* include "$BUILT_PREFIX_PATH"
+    ln -fs mruby "$BUILT_PREFIX_PATH/bin/ruby"
+    ln -fs mirb "$BUILT_PREFIX_PATH/bin/irb"
   } >&4 2>&1
 }
 
 build_package_maglev() {
   build_package_copy
 
-  { cd "${PREFIX_PATH}"
+  { cd "${BUILT_PREFIX_PATH}"
     ./install.sh
-    cd "${PREFIX_PATH}/bin"
+    cd "${BUILT_PREFIX_PATH}/bin"
     echo "Creating symlink for ruby*"
     ln -fs maglev-ruby ruby
     echo "Creating symlink for irb*"
@@ -703,7 +706,7 @@ build_package_maglev() {
 
 build_package_topaz() {
   build_package_copy
-  { cd "${PREFIX_PATH}/bin"
+  { cd "${BUILT_PREFIX_PATH}/bin"
     echo "Creating symlink for ruby*"
     ln -fs topaz ruby
   } >&4 2>&1
@@ -721,7 +724,7 @@ topaz_architecture() {
 
 build_package_jruby() {
   build_package_copy
-  cd "${PREFIX_PATH}/bin"
+  cd "${BUILT_PREFIX_PATH}/bin"
   ln -fs jruby ruby
   chmod +x ruby
   install_jruby_launcher
@@ -730,13 +733,13 @@ build_package_jruby() {
 }
 
 install_jruby_launcher() {
-  cd "${PREFIX_PATH}/bin"
+  cd "${BUILT_PREFIX_PATH}/bin"
   { ./ruby gem install jruby-launcher
   } >&4 2>&1
 }
 
 fix_jruby_shebangs() {
-  for file in "${PREFIX_PATH}/bin"/*; do
+  for file in "${BUILT_PREFIX_PATH}/bin"/*; do
     if [ "$(head -c 20 "$file")" = "#!/usr/bin/env jruby" ]; then
       sed -i.bak "1 s:.*:#\!${PREFIX_PATH}\/bin\/jruby:" "$file"
       rm "$file".bak
@@ -747,15 +750,15 @@ fix_jruby_shebangs() {
 build_package_truffleruby() {
   build_package_copy
 
-  cd "${PREFIX_PATH}"
-  "${PREFIX_PATH}/lib/truffle/post_install_hook.sh"
+  cd "${BUILT_PREFIX_PATH}"
+  "${BUILT_PREFIX_PATH}/lib/truffle/post_install_hook.sh"
 }
 
 build_package_artichoke() {
   build_package_copy
 
-  mkdir -p "$PREFIX_PATH/bin"
-  cd "${PREFIX_PATH}/bin"
+  mkdir -p "$BUILT_PREFIX_PATH/bin"
+  cd "${BUILT_PREFIX_PATH}/bin"
   ln -fs ../artichoke ruby
   ln -fs ../airb irb
   ln -fs ../artichoke artichoke
@@ -763,15 +766,15 @@ build_package_artichoke() {
 }
 
 remove_windows_files() {
-  cd "$PREFIX_PATH"
+  cd "$BUILT_PREFIX_PATH"
   rm -f bin/*.exe bin/*.dll bin/*.bat bin/jruby.sh
 }
 
 build_package_copy() {
-  # Make sure there are no leftover files in $PREFIX_PATH
-  rm -rf "$PREFIX_PATH"
-  mkdir -p "$PREFIX_PATH"
-  cp -fR . "$PREFIX_PATH"
+  # Make sure there are no leftover files in $BUILT_PREFIX_PATH
+  rm -rf "$BUILT_PREFIX_PATH"
+  mkdir -p "$BUILT_PREFIX_PATH"
+  cp -fR . "$BUILT_PREFIX_PATH"
 }
 
 before_install_package() {
@@ -1319,6 +1322,11 @@ elif [ "${PREFIX_PATH#/}" = "$PREFIX_PATH" ]; then
   PREFIX_PATH="${PWD}/${PREFIX_PATH}"
 fi
 
+BUILT_PREFIX_PATH="${MAKE_INSTALL_DESTDIR}${PREFIX_PATH}"
+if [ "${BUILT_PREFIX_PATH#/}" = "$BUILT_PREFIX_PATH" ]; then
+  BUILT_PREFIX_PATH="${PWD}/${BUILT_PREFIX_PATH}"
+fi
+
 if [ -z "$TMPDIR" ]; then
   TMP="/tmp"
 else
@@ -1395,7 +1403,7 @@ WGET_OPTS="${RUBY_BUILD_WGET_OPTS} ${IPV4+--inet4-only} ${IPV6+--inet6-only}"
 
 SEED="$(date "+%Y%m%d%H%M%S").$$"
 LOG_PATH="${TMP}/ruby-build.${SEED}.log"
-RUBY_BIN="${PREFIX_PATH}/bin/ruby"
+RUBY_BIN="${BUILT_PREFIX_PATH}/bin/ruby"
 CWD="$(pwd)"
 
 if [ -z "$RUBY_BUILD_BUILD_PATH" ]; then
@@ -1411,8 +1419,8 @@ if [ -n "$VERBOSE" ]; then
   trap "kill $TAIL_PID" SIGINT SIGTERM EXIT
 fi
 
-export LDFLAGS="-L${PREFIX_PATH}/lib ${LDFLAGS}"
-export CPPFLAGS="-I${PREFIX_PATH}/include ${CPPFLAGS}"
+export LDFLAGS="-L${BUILT_PREFIX_PATH}/lib ${LDFLAGS}"
+export CPPFLAGS="-I${BUILT_PREFIX_PATH}/include ${CPPFLAGS}"
 
 unset RUBYOPT
 unset RUBYLIB

--- a/test/build.bats
+++ b/test/build.bats
@@ -342,6 +342,28 @@ make install DESTDIR= DOGE="such wow"
 OUT
 }
 
+@test "setting MAKE_INSTALL_DESTDIR" {
+  cached_tarball "ruby-2.0.0"
+
+  stub uname '-s : echo Linux'
+  stub_make_install
+
+  export MAKE_INSTALL_DESTDIR='/tmp/foo'
+  run_inline_definition <<DEF
+install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+DEF
+  assert_success
+
+  unstub uname
+  unstub make
+
+  assert_build_log <<OUT
+ruby-2.0.0: --prefix=$INSTALL_ROOT
+make -j 2
+make install DESTDIR=/tmp/foo
+OUT
+}
+
 @test "setting MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "ruby-2.0.0"
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -75,10 +75,10 @@ assert_build_log() {
   assert_build_log <<OUT
 yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -106,11 +106,11 @@ PATCH
   assert_build_log <<OUT
 yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 patch -p0 --force -i $TMP/ruby-patch.XXX
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -138,11 +138,11 @@ PATCH
   assert_build_log <<OUT
 yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 patch -p1 --force -i $TMP/ruby-patch.XXX
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -171,11 +171,11 @@ PATCH
   assert_build_log <<OUT
 yaml-0.1.6: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 patch -p1 --force -i $TMP/ruby-patch.XXX
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -199,7 +199,7 @@ OUT
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT --with-libyaml-dir=$brew_libdir
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -223,7 +223,7 @@ DEF
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT --with-readline-dir=$readline_libdir
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -245,7 +245,7 @@ DEF
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT --with-readline-dir=/custom
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -268,7 +268,7 @@ DEF
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -292,7 +292,7 @@ DEF
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 4
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -316,7 +316,7 @@ DEF
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 1
-make install
+make install DESTDIR=
 OUT
 }
 
@@ -338,7 +338,7 @@ DEF
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install DOGE="such wow"
+make install DESTDIR= DOGE="such wow"
 OUT
 }
 
@@ -360,7 +360,7 @@ DEF
   assert_build_log <<OUT
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install DOGE="such wow"
+make install DESTDIR= DOGE="such wow"
 OUT
 }
 
@@ -413,7 +413,7 @@ DEF
 apply -p1 -i /my/patch.diff
 ruby-2.0.0: --prefix=$INSTALL_ROOT
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }
 

--- a/test/compiler.bats
+++ b/test/compiler.bats
@@ -81,6 +81,6 @@ DEF
 CC=clang
 CFLAGS=no
 make -j 2
-make install
+make install DESTDIR=
 OUT
 }


### PR DESCRIPTION
This fixes #1415 

I had already started work before seeing #1416 and so this duplicates some of the work there, and integrates some of the discussion output that doesn't seem to have made it in over there yet.

So far this has only been run with a few normal Ruby builds, and many of the modified functions have not yet been run. I'm much less familiar with the other capabilities of `ruby-build`, and I'm not sure how to validate the builds that aren't just configure/make/install.