### PR TITLE
compatible with macOS 11

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -91,7 +91,7 @@ os_information() {
   if type -p lsb_release >/dev/null; then
     lsb_release -sir | xargs echo
   elif type -p sw_vers >/dev/null; then
-    echo "OS X $(sw_vers -productVersion)"
+    echo "$(sw_vers -productName) $(sw_vers -productVersion)"
   elif [ -r /etc/os-release ]; then
     source /etc/os-release
     echo "$NAME" $VERSION_ID


### PR DESCRIPTION
https://en.wikipedia.org/wiki/MacOS_Big_Sur

stop hardcoding `OS X` since `macOS Big Sur` version no. is 11.0