### PR TITLE
Support specifying the complete mirror URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,28 +64,29 @@ definitions.
 
 The build process may be configured through the following environment variables:
 
-| Variable                 | Function                                                                                         |
-| ------------------------ | ------------------------------------------------------------------------------------------------ |
-| `TMPDIR`                 | Where temporary files are stored.                                                                |
-| `RUBY_BUILD_BUILD_PATH`  | Where sources are downloaded and built. (Default: a timestamped subdirectory of `TMPDIR`)        |
-| `RUBY_BUILD_CACHE_PATH`  | Where to cache downloaded package files. (Default: `~/.rbenv/cache` if invoked as rbenv plugin)  |
-| `RUBY_BUILD_HTTP_CLIENT` | One of `aria2c`, `curl`, or `wget` to use for downloading. (Default: first one found in PATH)    |
-| `RUBY_BUILD_ARIA2_OPTS`  | Additional options to pass to `aria2c` for downloading.                                          |
-| `RUBY_BUILD_CURL_OPTS`   | Additional options to pass to `curl` for downloading.                                            |
-| `RUBY_BUILD_WGET_OPTS`   | Additional options to pass to `wget` for downloading.                                            |
-| `RUBY_BUILD_MIRROR_URL`  | Custom mirror URL root.                                                                          |
-| `RUBY_BUILD_SKIP_MIRROR` | Bypass the download mirror and fetch all package files from their original URLs.                  |
-| `RUBY_BUILD_ROOT`        | Custom build definition directory. (Default: `share/ruby-build`)                                 |
-| `RUBY_BUILD_DEFINITIONS` | Additional paths to search for build definitions. (Colon-separated list)                         |
-| `CC`                     | Path to the C compiler.                                                                          |
-| `RUBY_CFLAGS`            | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |
-| `CONFIGURE_OPTS`         | Additional `./configure` options.                                                                |
-| `MAKE`                   | Custom `make` command (_e.g.,_ `gmake`).                                                         |
-| `MAKE_OPTS` / `MAKEOPTS` | Additional `make` options.                                                                       |
-| `MAKE_INSTALL_OPTS`      | Additional `make install` options.                                                               |
-| `RUBY_CONFIGURE_OPTS`    | Additional `./configure` options (applies only to Ruby source).                                  |
-| `RUBY_MAKE_OPTS`         | Additional `make` options (applies only to Ruby source).                                         |
-| `RUBY_MAKE_INSTALL_OPTS` | Additional `make install` options (applies only to Ruby source).                                 |
+| Variable                        | Function                                                                                         |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `TMPDIR`                        | Where temporary files are stored.                                                                |
+| `RUBY_BUILD_BUILD_PATH`         | Where sources are downloaded and built. (Default: a timestamped subdirectory of `TMPDIR`)        |
+| `RUBY_BUILD_CACHE_PATH`         | Where to cache downloaded package files. (Default: `~/.rbenv/cache` if invoked as rbenv plugin)  |
+| `RUBY_BUILD_HTTP_CLIENT`        | One of `aria2c`, `curl`, or `wget` to use for downloading. (Default: first one found in PATH)    |
+| `RUBY_BUILD_ARIA2_OPTS`         | Additional options to pass to `aria2c` for downloading.                                          |
+| `RUBY_BUILD_CURL_OPTS`          | Additional options to pass to `curl` for downloading.                                            |
+| `RUBY_BUILD_WGET_OPTS`          | Additional options to pass to `wget` for downloading.                                            |
+| `RUBY_BUILD_MIRROR_URL`         | Custom mirror URL root.                                                                          |
+| `RUBY_BUILD_MIRROR_PACKAGE_URL` | Custom complete mirror URL (e.g. http://mirror.example.com/package-1.0.0.tar.gz).                  |
+| `RUBY_BUILD_SKIP_MIRROR`        | Bypass the download mirror and fetch all package files from their original URLs.                 |
+| `RUBY_BUILD_ROOT`               | Custom build definition directory. (Default: `share/ruby-build`)                                 |
+| `RUBY_BUILD_DEFINITIONS`        | Additional paths to search for build definitions. (Colon-separated list)                         |
+| `CC`                            | Path to the C compiler.                                                                          |
+| `RUBY_CFLAGS`                   | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |
+| `CONFIGURE_OPTS`                | Additional `./configure` options.                                                                |
+| `MAKE`                          | Custom `make` command (_e.g.,_ `gmake`).                                                         |
+| `MAKE_OPTS` / `MAKEOPTS`        | Additional `make` options.                                                                       |
+| `MAKE_INSTALL_OPTS`             | Additional `make install` options.                                                               |
+| `RUBY_CONFIGURE_OPTS`           | Additional `./configure` options (applies only to Ruby source).                                  |
+| `RUBY_MAKE_OPTS`                | Additional `make` options (applies only to Ruby source).                                         |
+| `RUBY_MAKE_INSTALL_OPTS`        | Additional `make install` options (applies only to Ruby source).                                 |
 
 #### Applying Patches
 
@@ -133,6 +134,10 @@ will fall back to downloading the package from the original location if:
 - `RUBY_BUILD_SKIP_MIRROR` is enabled.
 
 You may specify a custom mirror by setting `RUBY_BUILD_MIRROR_URL`.
+
+If a mirror site doesn't conform to the above URL format, you can specify the
+complete URL by setting `RUBY_BUILD_MIRROR_PACKAGE_URL`. It behaves the same as
+`RUBY_BUILD_MIRROR_URL` except being a complete URL.
 
 The default ruby-build download mirror is sponsored by
 [Basecamp](https://basecamp.com/).

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -365,6 +365,8 @@ fetch_tarball() {
       if [[ -z "$RUBY_BUILD_DEFAULT_MIRROR" || $package_url != */cache.ruby-lang.org/* ]]; then
         mirror_url="${RUBY_BUILD_MIRROR_URL}/$checksum"
       fi
+    elif [ -n "$RUBY_BUILD_MIRROR_PACKAGE_URL" ]; then
+      mirror_url="$RUBY_BUILD_MIRROR_PACKAGE_URL"
     fi
   fi
 
@@ -1377,7 +1379,7 @@ else
   unset RUBY_BUILD_CACHE_PATH
 fi
 
-if [ -z "$RUBY_BUILD_MIRROR_URL" ]; then
+if [ -z "$RUBY_BUILD_MIRROR_URL" -a -z "$RUBY_BUILD_MIRROR_PACKAGE_URL" ]; then
   RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
   RUBY_BUILD_DEFAULT_MIRROR=1
 else
@@ -1386,7 +1388,7 @@ else
 fi
 
 if [ -n "$RUBY_BUILD_SKIP_MIRROR" ] || ! has_checksum_support compute_sha2; then
-  unset RUBY_BUILD_MIRROR_URL
+  unset RUBY_BUILD_MIRROR_URL RUBY_BUILD_MIRROR_PACKAGE_URL
 fi
 
 ARIA2_OPTS="${RUBY_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disable-ipv6=false}"


### PR DESCRIPTION
When using a mirror, `ruby-build` requires the package is located at `$RUBY_BUILD_MIRROR_URL/<SHA2>`, which is not a generic case.

[Here](https://www.ruby-lang.org/en/downloads/mirrors/) list all mirror sites of ruby source, and most of them provide the tarball with name format like `http://host/pub/ruby/2.7/2.7.1.tar.bz2`. To benefit from more mirror sites, and also keep compatibility, I propose adding another variable (which can be named as `RUBY_BUILD_MIRROR_PACKAGE_URL`) to specify the complete mirror URL. So a user can use it like this:

```
# I use `asdf` to manage versions, which depends on `ruby-build`.
$ RUBY_BUILD_MIRROR_PACKAGE_URL=https://cache.ruby-china.com/pub/ruby/2.7/ruby-2.7.1.tar.bz2 asdf install ruby 2.7.1
```

Fix #1032. As [this comment](https://github.com/rbenv/ruby-build/issues/1032#issuecomment-266220709) said, the download speed in China is too slow when installing a new version from official ruby CDN, so at least this feature will be especially useful for users living in China.
