### PR TITLE
Fix the installer of truffleruby+graalvm with macOS

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -756,6 +756,12 @@ build_package_truffleruby_graalvm() {
   build_package_copy_to "${PREFIX_PATH}/graalvm"
 
   cd "${PREFIX_PATH}/graalvm"
+
+  if is_mac; then
+    mv Contents/Home/* .
+    rm -rf Contents 
+  fi
+
   bin/gu install ruby || return $?
 
   local ruby_home


### PR DESCRIPTION
@eregon 

I try to install truffleruby+graalvm with macOS. But it always failed because the macOS package is different from linux version.

macOS package is:

```
Contents
Contants/Home <- This path is root of graalvm
Contents/Info.plist
Contents/MacOS
(snip)
THIRD_PARTY_README_JDK
```

I resolved the directory structure with linux package on macOS. I could install `truffleruby+graalvm-20.1.0` with this patch.