### PR TITLE
Add definition for JRuby 9.2.13.0

### DIFF
--- a/share/ruby-build/jruby-9.2.13.0
+++ b/share/ruby-build/jruby-9.2.13.0
@@ -1,0 +1,2 @@
+require_java 8
+install_package "jruby-9.2.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.13.0/jruby-bin-9.2.13.0.tar.gz#73a8c241a162e644c87e864c3485c55adedeb82a6fd80fa3cb538fdacda7af58" jruby


### PR DESCRIPTION
JRuby 9.2.13.0 has been released.
https://www.jruby.org/2020/08/03/jruby-9-2-13-0