### PR TITLE
Local openssl for old rubies

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -101,6 +101,10 @@ os_information() {
   fi
 }
 
+is_linux() {
+  [ "$(uname -s)" = "Linux" ] || return 1
+}
+
 is_mac() {
   [ "$(uname -s)" = "Darwin" ] || return 1
   [ $# -eq 0 ] || [ "$(osx_version)" "$@" ]
@@ -1069,6 +1073,13 @@ has_broken_mac_openssl() {
   [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]]
 }
 
+has_wrong_openssl() {
+  is_linux || return 1
+  local openssl_version="$(/usr/bin/openssl version 2>/dev/null || true)"
+  [[ $openssl_version != "OpenSSL 1.0"?* ]] &&
+  [[ "$RUBY_CONFIGURE_OPTS" != *--with-openssl-dir=* ]]
+}
+
 use_homebrew_openssl() {
   local ssldir="$(brew --prefix openssl@1.1 2>/dev/null || true)"
   if [ -d "$ssldir" ]; then
@@ -1078,6 +1089,39 @@ use_homebrew_openssl() {
     colorize 1 "ERROR openssl@1.1 from Homebrew is required, run 'brew install openssl@1.1'"
     return 1
   fi
+}
+
+build_package_linux_legacy_openssl() {
+  # Install to a subdirectory since we don't want shims for bin/openssl.
+  OPENSSL_PREFIX_PATH="${PREFIX_PATH}/openssl"
+
+  # Put openssl.conf, certs, etc in ~/.rbenv/versions/*/openssl/ssl
+  OPENSSLDIR="${OPENSSLDIR:-$OPENSSL_PREFIX_PATH/ssl}"
+
+  # Tell Ruby to use this openssl for its extension.
+  package_option ruby configure --with-openssl-dir="$OPENSSL_PREFIX_PATH"
+
+  # Make sure pkg-config finds our build first.
+  export PKG_CONFIG_PATH="${OPENSSL_PREFIX_PATH}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+
+  # Hint OpenSSL that we prefer a 64-bit build.
+  export KERNEL_BITS="64"
+  OPENSSL_CONFIGURE="${OPENSSL_CONFIGURE:-./config}"
+
+  local nokerberos
+  [[ "$1" != openssl-1.0.* ]] || nokerberos=1
+
+  # Compile a shared lib with zlib dynamically linked.
+  package_option openssl configure --openssldir="$OPENSSLDIR" zlib-dynamic no-ssl3 shared ${nokerberos:+no-ssl2 no-krb5}
+
+  # Default MAKE_OPTS are -j 2 which can confuse the build. Thankfully, make
+  # gives precedence to the last -j option, so we can override that.
+  package_option openssl make -j 1
+
+  build_package_standard "$@"
+
+  # Copy systems certs to local install
+  rsync -av /etc/ssl/certs/ "$OPENSSLDIR"/certs/
 }
 
 build_package_mac_openssl() {

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1120,8 +1120,9 @@ build_package_linux_legacy_openssl() {
 
   build_package_standard "$@"
 
-  # Copy systems certs to local install
-  rsync -av /etc/ssl/certs/ "$OPENSSLDIR"/certs/
+  # Link to systems certs
+  rmdir "$OPENSSLDIR"/certs
+  ln -s /etc/ssl/certs "$OPENSSLDIR"/certs
 }
 
 build_package_mac_openssl() {

--- a/share/ruby-build/1.8.7-p375
+++ b/share/ruby-build/1.8.7-p375
@@ -1,3 +1,4 @@
 require_gcc
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_svn "ruby-1.8.7-p375" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8_7" "44351" warn_eol autoconf auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.9.3-p551
+++ b/share/ruby-build/1.9.3-p551
@@ -1,3 +1,4 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2#b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e" warn_eol standard

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,4 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,4 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.10
+++ b/share/ruby-build/2.1.10
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.10" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2#a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.3
+++ b/share/ruby-build/2.1.3
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.4
+++ b/share/ruby-build/2.1.4
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.5
+++ b/share/ruby-build/2.1.5
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.8
+++ b/share/ruby-build/2.1.8
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.9
+++ b/share/ruby-build/2.1.9
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.0
+++ b/share/ruby-build/2.2.0
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2#1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.1
+++ b/share/ruby-build/2.2.1
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.bz2#4e5676073246b7ade207be3e80a930567a88100513591a0f19fc38e247370065" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.10
+++ b/share/ruby-build/2.2.10
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.10" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.bz2#a54204d2728283c9eff0cf81d654f245fa5b3447d0824f1a6bc3b2c5c827381e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.2
+++ b/share/ruby-build/2.2.2
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.bz2#f3b8ffa6089820ee5bdc289567d365e5748d4170e8aa246d2ea6576f24796535" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.3
+++ b/share/ruby-build/2.2.3
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.bz2#c745cb98b29127d7f19f1bf9e0a63c384736f4d303b83c4f4bda3c2ee3c5e41f" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.4
+++ b/share/ruby-build/2.2.4
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.4" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2#31203696adbfdda6f2874a2de31f7c5a1f3bcb6628f4d1a241de21b158cd5c76" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.5
+++ b/share/ruby-build/2.2.5
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.5" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2#22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.6
+++ b/share/ruby-build/2.2.6
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.6" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.bz2#e845ba41ea3525aafaa4094212f1eadc57392732232b67b4394a7e0f046dddf7" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.7
+++ b/share/ruby-build/2.2.7
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.7" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.bz2#80486c5991783185afeceeb315060a3dafc3889a2912e145b1a8457d7b005c5b" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.8
+++ b/share/ruby-build/2.2.8
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.8" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2#b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.9
+++ b/share/ruby-build/2.2.9
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.2.9" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2#5e3cfcc3b69638e165f72f67b1321fa05aff62b0f9e9b32042a5a79614e7c70a" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.0
+++ b/share/ruby-build/2.3.0
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.1
+++ b/share/ruby-build/2.3.1
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.2
+++ b/share/ruby-build/2.3.2
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.3
+++ b/share/ruby-build/2.3.3
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.4
+++ b/share/ruby-build/2.3.4
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.5
+++ b/share/ruby-build/2.3.5
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.6
+++ b/share/ruby-build/2.3.6
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.7
+++ b/share/ruby-build/2.3.7
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.3.8
+++ b/share/ruby-build/2.3.8
@@ -1,2 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" linux_legacy_openssl --if has_wrong_openssl
 install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" warn_eol ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Hi!

We have problems with missing openssl-1.0 for older Ruby versions in newer distribution and I saw multiple other issues here with a similar topic.
As I saw, there are alreay local openssl installs used for Macs, I thought this could also be used for older Ruby versions.

Let me know if this could be an approach for Linux without the correct openssl installed. Feedback is welcome.

Best regards,
Stefan