### PR TITLE
Add definition for Ruby 2.7.2

### DIFF
--- a/share/ruby-build/2.7.2
+++ b/share/ruby-build/2.7.2
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1g" "https://www.openssl.org/source/openssl-1.1.1g.tar.gz#ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 2.7.2 has been released.
https://www.ruby-lang.org//en/news/2020/10/02/ruby-2-7-2-released/