### PR TITLE
Split macOS test to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: test with macos
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git clone --depth 1 https://github.com/sstephenson/bats.git
+    - run: PATH="./bats/bin:$PATH" script/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 sudo: false
-os:
-  - osx
-  - linux
 install: git clone --depth 1 https://github.com/sstephenson/bats.git
 script: PATH="./bats/bin:$PATH" script/test
 language: c


### PR DESCRIPTION
Because Travis CI add a rate-limit for OSS project. I'm waiting with 30 minutes for invoking all of jobs now.