### PR TITLE
Upgrade to OpenSSL 1.1.1i (solves issues on Apple Silicon chips 🚀😹)

### DIFF
--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.4.1
+++ b/share/ruby-build/2.4.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.10
+++ b/share/ruby-build/2.4.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.10" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.tar.bz2#6ea3ce7fd0064524ae06dbdcd99741c990901dfc9c66d8139a02f907d30b95a8" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.2
+++ b/share/ruby-build/2.4.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.5
+++ b/share/ruby-build/2.4.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.6
+++ b/share/ruby-build/2.4.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.7
+++ b/share/ruby-build/2.4.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.8
+++ b/share/ruby-build/2.4.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.9
+++ b/share/ruby-build/2.4.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.0
+++ b/share/ruby-build/2.5.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_unsupported ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.5.0-preview1
+++ b/share/ruby-build/2.5.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2#1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.0-rc1
+++ b/share/ruby-build/2.5.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" warn_unsupported ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.1
+++ b/share/ruby-build/2.5.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.2
+++ b/share/ruby-build/2.5.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.3
+++ b/share/ruby-build/2.5.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.4
+++ b/share/ruby-build/2.5.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.5
+++ b/share/ruby-build/2.5.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.6
+++ b/share/ruby-build/2.5.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.7
+++ b/share/ruby-build/2.5.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.8
+++ b/share/ruby-build/2.5.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.5.8" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2#41fc93731ad3f3aa597d657f77ed68fa86b5e93c04dfbf7e542a8780702233f0" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.0
+++ b/share/ruby-build/2.6.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.0-dev
+++ b/share/ruby-build/2.6.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.6.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.6.0-preview1
+++ b/share/ruby-build/2.6.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-preview2
+++ b/share/ruby-build/2.6.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-preview3
+++ b/share/ruby-build/2.6.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview3.tar.bz2#1f09a2ac1ab26721923cbf4b9302a66d36bb302dc45e72112b41d6fccc5b5931" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-rc1
+++ b/share/ruby-build/2.6.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc1.tar.bz2#b4e9c0e8801946e9f0baba30948955f4341e9e04f363c206b7bd774208053eb5" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-rc2
+++ b/share/ruby-build/2.6.0-rc2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2#b3d03e471e3136f43bb948013d4f4974abb63d478e8ff7ec2741b22750a3ec50" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.1
+++ b/share/ruby-build/2.6.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.2
+++ b/share/ruby-build/2.6.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.3
+++ b/share/ruby-build/2.6.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.4
+++ b/share/ruby-build/2.6.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.5
+++ b/share/ruby-build/2.6.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.6
+++ b/share/ruby-build/2.6.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.6.6" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2#f08b779079ecd1498e6a2548c39a86144c6c784dcec6f7e8a93208682eb8306e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0
+++ b/share/ruby-build/2.7.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-dev
+++ b/share/ruby-build/2.7.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-2.7.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.7.0-preview1
+++ b/share/ruby-build/2.7.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview2
+++ b/share/ruby-build/2.7.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview3
+++ b/share/ruby-build/2.7.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2#df2ddee659873e6fc30a8590ecffa49cf3a4ef81fa922b0d09f821b69ee88bc3" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-rc1
+++ b/share/ruby-build/2.7.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc1.tar.bz2#1c5a02b63fa9fca37c41681bbbf20c55818a32315958c0a6c8f505943bfcb2d2" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-rc2
+++ b/share/ruby-build/2.7.0-rc2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc2.tar.bz2#8f94ea7ba79b6e95225fb4a7870e882081182c3d12d58c4cad2a7d2e7865cf8e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.1
+++ b/share/ruby-build/2.7.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.2
+++ b/share/ruby-build/2.7.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-dev
+++ b/share/ruby-build/3.0.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.0.0-preview1
+++ b/share/ruby-build/3.0.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-3.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview1.tar.bz2#013bdc6e859d76d67a6fcd990d401ed57e6e25896bab96d1d0648a877f556dbb" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-preview2
+++ b/share/ruby-build/3.0.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1h" "https://www.openssl.org/source/openssl-1.1.1h.tar.gz#5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" mac_openssl --if has_broken_mac_openssl
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
 install_package "ruby-3.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview2.tar.gz#9de8661565c2b1007d91a580e9a7e02d23f1e8fc8df371feb15a2727aa05fd9a" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
OpenSSL 1.1.1i is possible to compile without problems on new Apple Silicon chips.

This solves #1496, #1493, #1456. There is no need to apply this patch https://github.com/rbenv/ruby-build/issues/1456#issuecomment-670051168 as well.

Homebrew offers already some prelimited ARM bottles (https://github.com/Homebrew/brew/issues/9488). One of them is `readline`. So I just `brew install readline` and compiled `readline` for Apple Silicon was installed.

I was able to compile `ruby 2.7.2` on Apple Silicon using `ruby-build` without any issues as before on Intel Macs.

```
$ ruby-build 2.7.2 ~/.rubies/ruby-2.7.2-arm
Downloading openssl-1.1.1i.tar.gz...
-> https://www.openssl.org/source/openssl-1.1.1i.tar.gz
Installing openssl-1.1.1i...
Installed openssl-1.1.1i to ~/deepj/.rubies/ruby-2.7.2-arm

Downloading ruby-2.7.2.tar.bz2...
-> https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2
Installing ruby-2.7.2...
ruby-build: using readline from homebrew
Installed ruby-2.7.2 to ~/.rubies/ruby-2.7.2-arm

... magic switch to Ruby 2.7.2 for Apple Silicon using chruby

$ ruby -v
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [arm64-darwin20]
$ ruby -e 'puts "Hello from Apple Silicon Mac!"'
Hello from Apple Silicon Mac!
```