### PR TITLE
Add 3.0.0 RC1

### DIFF
--- a/share/ruby-build/3.0.0-rc1
+++ b/share/ruby-build/3.0.0-rc1
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1i" "https://www.openssl.org/source/openssl-1.1.1i.tar.gz#e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-3.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-rc1.tar.gz#e1270f38b969ce7b124f0a4c217e33eda643f75c7cb20debc62c17535406e37f" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
See: https://www.ruby-lang.org/en/news/2020/12/20/ruby-3-0-0-rc1-released/

https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-rc1.tar.gz
```
SIZE: 19488885
SHA1: 34ede2128a90ef3217d9cab9efcdf20fc444f67c
SHA256: e1270f38b969ce7b124f0a4c217e33eda643f75c7cb20debc62c17535406e37f
SHA512: 798926db82d27366b39be97556ac5cb322986b96df913c398449bd3ece533e484a3047fe35e7a6241dfbd0f7da803438f5b04b805b33f95c73e3e41d0bb51183
```