### PR TITLE
Allow to install Artichoke's ARM builds on macOS

### DIFF
--- a/share/ruby-build/artichoke-dev
+++ b/share/ruby-build/artichoke-dev
@@ -3,7 +3,18 @@ Linux)
   install_package "artichoke-nightly" "https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-unknown-linux-gnu.tar.gz" artichoke
   ;;
 Darwin)
-  install_package "artichoke-nightly" "https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-apple-darwin.tar.gz" artichoke
+  case $(uname -m) in
+  arm64)
+    install_package "artichoke-nightly" "https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-aarch64-apple-darwin.tar.gz" artichoke
+    ;;
+  x86_64)
+    install_package "artichoke-nightly" "https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-apple-darwin.tar.gz" artichoke
+    ;;
+  *)
+    colorize 1 "Unsupported architecture: $(uname -m)"
+    return 1
+    ;;
+  esac
   ;;
 *)
   colorize 1 "Unsupported operating system: $(uname -s)"


### PR DESCRIPTION
Closes #1701

ARM
```
$ uname -m
arm64
$ ruby-build artichoke-dev ~/.rubies/artichoke-dev
Downloading artichoke-nightly-aarch64-apple-darwin.tar.gz...
-> https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-aarch64-apple-darwin.tar.gz
Installing artichoke-nightly...
Installed artichoke-nightly to ~/.rubies/artichoke-dev

$ ~/.rubies/artichoke-dev/bin/ruby --version
artichoke 0.1.0-pre.0
$ ~/.rubies/artichoke-dev/bin/ruby -e "puts RUBY_PLATFORM"
aarch64-apple-darwin
```

x86_64

```
$ uname -m
x86_64
$ ruby-build artichoke-dev ~/.rubies/artichoke-dev
Downloading artichoke-nightly-x86_64-apple-darwin.tar.gz...
-> https://github.com/artichoke/nightly/releases/latest/download/artichoke-nightly-x86_64-apple-darwin.tar.gz
Installing artichoke-nightly...
Installed artichoke-nightly to ~/.rubies/artichoke-dev

$ ~/.rubies/artichoke-dev/bin/ruby --version
artichoke 0.1.0-pre.0
$ ~/.rubies/artichoke-dev/bin/ruby -e "puts RUBY_PLATFORM"
x86_64-apple-darwin
```

/cc @lopopolo  @hsbt 