### PR TITLE
adds jruby 9.2.15.0

### DIFF
--- a/jruby-9.2.15.0
+++ b/jruby-9.2.15.0
@@ -1,0 +1,2 @@
+require_java 8
+install_package "jruby-9.2.15.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.15.0/jruby-bin-9.2.15.0.tar.gz#9e8e5d73c42d1dad8a795a6dc39bd87e88fc8863f76e065e4099c32d085205b0" jruby


### PR DESCRIPTION
JRuby 9.2.15.0 was released today (https://www.jruby.org/2021/02/24/jruby-9-2-15-0.html). I believe this is the file that would make it available for ruby-build env.