### PR TITLE
Use autoreconf -i instead of autoconf 

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -622,7 +622,7 @@ build_package_standard() {
 }
 
 build_package_autoconf() {
-  { autoconf
+  { autoreconf -i
   } >&4 2>&1
 }
 


### PR DESCRIPTION
Because autoconf-2.71+ is incompatible with 2.69 or before.