### PR TITLE
Added 3.0.1, 2.7.3, 2.6.7, 2.5.9

### DIFF
--- a/share/ruby-build/2.5.9
+++ b/share/ruby-build/2.5.9
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.5.9" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.bz2#bebbe3fe7899acd3ca2f213de38158709555e88a13f85ba5dc95239654bcfeeb" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.7
+++ b/share/ruby-build/2.6.7
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.7" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.7.tar.bz2#775a5d47b73ce3ee5d600f993badd7b640a2caca138573326db6632858517710" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.3
+++ b/share/ruby-build/2.7.3
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.1
+++ b/share/ruby-build/3.0.1
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-3.0.1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.1.tar.gz#369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 3.0.1, 2.7.3, 2.6.7, 2.5.9 has been released.

https://www.ruby-lang.org/en/news/2021/04/05/ruby-3-0-1-released/
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-7-3-released/
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-6-7-released/
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/