### PR TITLE
warn eol for ruby 2.5

### DIFF
--- a/share/ruby-build/2.5.0
+++ b/share/ruby-build/2.5.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_unsupported ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.5.0-preview1
+++ b/share/ruby-build/2.5.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2#1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446" warn_unsupported ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2#1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.0-rc1
+++ b/share/ruby-build/2.5.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" warn_unsupported ldflags_dirs standard verify_openssl
+install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.5.1
+++ b/share/ruby-build/2.5.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.2
+++ b/share/ruby-build/2.5.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.3
+++ b/share/ruby-build/2.5.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.4
+++ b/share/ruby-build/2.5.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.5
+++ b/share/ruby-build/2.5.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.6
+++ b/share/ruby-build/2.5.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.7
+++ b/share/ruby-build/2.5.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.8
+++ b/share/ruby-build/2.5.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.8" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2#41fc93731ad3f3aa597d657f77ed68fa86b5e93c04dfbf7e542a8780702233f0" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.8" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2#41fc93731ad3f3aa597d657f77ed68fa86b5e93c04dfbf7e542a8780702233f0" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.9
+++ b/share/ruby-build/2.5.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1j" "https://www.openssl.org/source/openssl-1.1.1j.tar.gz#aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.5.9" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.bz2#bebbe3fe7899acd3ca2f213de38158709555e88a13f85ba5dc95239654bcfeeb" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.5.9" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.bz2#bebbe3fe7899acd3ca2f213de38158709555e88a13f85ba5dc95239654bcfeeb" warn_eol ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
This PR updates the warning for Ruby 2.5.x to indicate, that it is no longer supported.

Ruby 2.5 is EOL from 2021-03-31.
