### PR TITLE
Fix hashes for TruffleRuby 21.1.0

### DIFF
--- a/share/ruby-build/truffleruby-21.1.0
+++ b/share/ruby-build/truffleruby-21.1.0
@@ -1,10 +1,10 @@
 case $(uname -s) in
 Linux)
-  install_package "truffleruby-21.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.1.0/truffleruby-21.1.0-linux-amd64.tar.gz#55fa126ebf7bb34b3933d160015e71930abfdddfa66b98d2cabe180367733831" truffleruby
+  install_package "truffleruby-21.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.1.0/truffleruby-21.1.0-linux-amd64.tar.gz#e3ed5bffb8af040d174817b267581a9dfa7f18a7dc79d1c5e7a6a4670ad318fb" truffleruby
   ;;
 Darwin)
   use_homebrew_openssl
-  install_package "truffleruby-21.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.1.0/truffleruby-21.1.0-macos-amd64.tar.gz#e272db06381790930fa7898c7995a98b24a4abf84502a79fee23f6117bcf6468" truffleruby
+  install_package "truffleruby-21.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.1.0/truffleruby-21.1.0-macos-amd64.tar.gz#e2ada5a6c9dd6dcac6e1f1f04f290283182c3cf985ba9b599350b1f98f72c0d7" truffleruby
   ;;
 *)
   colorize 1 "Unsupported operating system: $(uname -s)"


### PR DESCRIPTION
* Unfortunately the original builds were based on incorrect JDK versions,
  these new hashes represent the correct builds based on JDK11.