### PR TITLE
Add jruby-dev

### DIFF
--- a/share/ruby-build/jruby-dev
+++ b/share/ruby-build/jruby-dev
@@ -1,0 +1,13 @@
+case $(uname -s) in
+Linux)
+  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-ubuntu-20.04.tar.gz" jruby
+  ;;
+Darwin)
+  use_homebrew_openssl
+  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-macos-latest.tar.gz" jruby
+  ;;
+*)
+  colorize 1 "Unsupported operating system: $(uname -s)"
+  return 1
+  ;;
+esac


### PR DESCRIPTION
* Uses the latest nightly, which is automatically built.

This is a shameless copy of https://github.com/rbenv/ruby-build/pull/1405.