### PR TITLE
Add Ruby 2.6.8, 2.7.4, 3.0.2

### DIFF
--- a/share/ruby-build/2.6.8
+++ b/share/ruby-build/2.6.8
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.6.8" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.bz2#dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.4
+++ b/share/ruby-build/2.7.4
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.2
+++ b/share/ruby-build/3.0.2
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1k" "https://www.openssl.org/source/openssl-1.1.1k.tar.gz#892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-3.0.2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.2.tar.gz#5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 2.6.8, 2.7.4, 3.0.2 has been released.

https://www.ruby-lang.org/en/news/2021/07/07/ruby-2-6-8-released/
https://www.ruby-lang.org/en/news/2021/07/07/ruby-2-7-4-released/
https://www.ruby-lang.org/en/news/2021/07/07/ruby-3-0-2-released/