### PR TITLE
Stop deleting the prefix path on install of TruffleRuby

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -754,7 +754,6 @@ build_package_truffleruby() {
 }
 
 build_package_truffleruby_graalvm() {
-  clean_prefix_path
   build_package_copy_to "${PREFIX_PATH}/graalvm"
 
   cd "${PREFIX_PATH}/graalvm"
@@ -792,11 +791,6 @@ remove_windows_files() {
   rm -f bin/*.exe bin/*.dll bin/*.bat bin/jruby.sh
 }
 
-clean_prefix_path() {
-  # Make sure there are no leftover files in $PREFIX_PATH
-  rm -rf "$PREFIX_PATH"
-}
-
 build_package_copy_to() {
   to="$1"
   mkdir -p "$to"
@@ -804,7 +798,6 @@ build_package_copy_to() {
 }
 
 build_package_copy() {
-  clean_prefix_path
   build_package_copy_to "$PREFIX_PATH"
 }
 


### PR DESCRIPTION
This is essentially a revert of https://github.com/rbenv/ruby-build/commit/cda9b11733546c23db2ab70817648dcc7a48cba9

I understand the intent of helping people using `ruby-build` for their dev environment, where multiple rubies coexists in multiple sub directories, but:

  - MRI recipes don't behave like that, so it's surprising.
  - In my case I `ruby-build` to generate production Docker images, so I directly install ruby with `/usr/local` as a prefix, and this delete important, unrelated files.

So I believe it does more harm than good.

cc @eregon 
cc @tomstuart @chrisseaton 