### PR TITLE
Ensure it is safe to remove the prefix path for TruffleRuby or error

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -747,6 +747,7 @@ fix_jruby_shebangs() {
 }
 
 build_package_truffleruby() {
+  clean_prefix_path_truffleruby || return $?
   build_package_copy
 
   cd "${PREFIX_PATH}"
@@ -754,7 +755,7 @@ build_package_truffleruby() {
 }
 
 build_package_truffleruby_graalvm() {
-  clean_prefix_path
+  clean_prefix_path_truffleruby || return $?
   build_package_copy_to "${PREFIX_PATH}/graalvm"
 
   cd "${PREFIX_PATH}/graalvm"
@@ -792,7 +793,15 @@ remove_windows_files() {
   rm -f bin/*.exe bin/*.dll bin/*.bat bin/jruby.sh
 }
 
-clean_prefix_path() {
+clean_prefix_path_truffleruby() {
+  if [ -d "$PREFIX_PATH" ] && [ ! -e "$PREFIX_PATH/bin/truffleruby" ]; then
+    echo
+    echo "ERROR: cannot install TruffleRuby to $PREFIX_PATH, which does not look like a valid TruffleRuby prefix" >&2
+    echo "TruffleRuby only supports being installed to a not existing directory or replacing an existing TruffleRuby installation"
+    echo "See https://github.com/oracle/truffleruby/issues/1389 for details" >&2
+    return 1
+  fi
+
   # Make sure there are no leftover files in $PREFIX_PATH
   rm -rf "$PREFIX_PATH"
 }
@@ -804,7 +813,6 @@ build_package_copy_to() {
 }
 
 build_package_copy() {
-  clean_prefix_path
   build_package_copy_to "$PREFIX_PATH"
 }
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -664,6 +664,7 @@ DEF
 }
 
 @test "TruffleRuby post-install hook" {
+  rmdir "$INSTALL_ROOT"
   executable "${RUBY_BUILD_CACHE_PATH}/truffleruby-test/lib/truffle/post_install_hook.sh" <<OUT
 echo Running post-install hook
 OUT


### PR DESCRIPTION
* Only do clean_prefix_path for TruffleRuby and rename for clarity,
  since the logic is now TruffleRuby-specific.
* Alternative to https://github.com/rbenv/ruby-build/pull/1783, cc @casperisfine

The error message looks like:
```
$ bin/ruby-build truffleruby-dev /usr/local
Downloading truffleruby-head-ubuntu-18.04.tar.gz...
-> https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-18.04.tar.gz
Installing truffleruby-head...

ERROR: cannot install TruffleRuby to /usr/local, which does not look like a valid TruffleRuby prefix
TruffleRuby only supports being installed to a not existing directory or replacing an existing TruffleRuby installation
See https://github.com/oracle/truffleruby/issues/1389 for details

BUILD FAILED (OS VERSION using ruby-build 20210720-2-g6fa319f)

Inspect or clean up the working tree at /tmp/ruby-build.20210726155937.184076.UFViZv
Results logged to /tmp/ruby-build.20210726155937.184076.log
```