### PR TITLE
TruffleRuby 21.2+ adds support for linux-aarch64

### DIFF
--- a/script/update-truffleruby
+++ b/script/update-truffleruby
@@ -25,18 +25,23 @@ EOS
 }
 
 cat > "$file" <<EOS
-case \$(uname -s) in
-Linux)
+platform="\$(uname -s)-\$(uname -m)"
+case \$platform in
+Linux-x86_64)
 EOS
 add_platform "linux-amd64"
 cat >> "$file" <<EOS
-Darwin)
+Linux-aarch64)
+EOS
+add_platform "linux-aarch64"
+cat >> "$file" <<EOS
+Darwin-x86_64)
   use_homebrew_openssl
 EOS
 add_platform "macos-amd64"
 cat >> "$file" <<EOS
 *)
-  colorize 1 "Unsupported operating system: \$(uname -s)"
+  colorize 1 "Unsupported platform: \$platform"
   return 1
   ;;
 esac

--- a/script/update-truffleruby-graalvm
+++ b/script/update-truffleruby-graalvm
@@ -25,18 +25,23 @@ EOS
 }
 
 cat > "$file" <<EOS
-case \$(uname -s) in
-Linux)
+platform="\$(uname -s)-\$(uname -m)"
+case \$platform in
+Linux-x86_64)
 EOS
 add_platform "linux-amd64"
 cat >> "$file" <<EOS
-Darwin)
+Linux-aarch64)
+EOS
+add_platform "linux-aarch64"
+cat >> "$file" <<EOS
+Darwin-x86_64)
   use_homebrew_openssl
 EOS
 add_platform "darwin-amd64"
 cat >> "$file" <<EOS
 *)
-  colorize 1 "Unsupported operating system: \$(uname -s)"
+  colorize 1 "Unsupported platform: \$platform"
   return 1
   ;;
 esac

--- a/share/ruby-build/truffleruby+graalvm-21.2.0
+++ b/share/ruby-build/truffleruby+graalvm-21.2.0
@@ -1,13 +1,17 @@
-case $(uname -s) in
-Linux)
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
   install_package "truffleruby+graalvm-21.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-amd64-21.2.0.tar.gz#bbd3e03025168172a76c2a29e6a14c1c37e3476b30774259c3ef5952fb86f470" truffleruby_graalvm
   ;;
-Darwin)
+Linux-aarch64)
+  install_package "truffleruby+graalvm-21.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-aarch64-21.2.0.tar.gz#bbdf38d5e6871f7e3b2470ab9b9bb760667d4524ee2a20eadfaf13636a2d018c" truffleruby_graalvm
+  ;;
+Darwin-x86_64)
   use_homebrew_openssl
   install_package "truffleruby+graalvm-21.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-darwin-amd64-21.2.0.tar.gz#f62cdc44a031731aa221426724a55eb09c79d6b2e9275ae3ca7003da5884ca36" truffleruby_graalvm
   ;;
 *)
-  colorize 1 "Unsupported operating system: $(uname -s)"
+  colorize 1 "Unsupported platform: $platform"
   return 1
   ;;
 esac

--- a/share/ruby-build/truffleruby-21.2.0
+++ b/share/ruby-build/truffleruby-21.2.0
@@ -1,13 +1,17 @@
-case $(uname -s) in
-Linux)
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
   install_package "truffleruby-21.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0/truffleruby-21.2.0-linux-amd64.tar.gz#3c6a3deb74c38fc20ca47fda566c3ac3296bcb66240be7735fdedebb8e29f9c9" truffleruby
   ;;
-Darwin)
+Linux-aarch64)
+  install_package "truffleruby-21.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0/truffleruby-21.2.0-linux-aarch64.tar.gz#f45f3046d604d99cc0c7b5c643fca0c16aecdfdef9cb1e5f385a255a0213cad3" truffleruby
+  ;;
+Darwin-x86_64)
   use_homebrew_openssl
   install_package "truffleruby-21.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0/truffleruby-21.2.0-macos-amd64.tar.gz#c1eeb3692200c812329fa50c506dcb0ff246e7fb7780cd661fce2227fe507be1" truffleruby
   ;;
 *)
-  colorize 1 "Unsupported operating system: $(uname -s)"
+  colorize 1 "Unsupported platform: $platform"
   return 1
   ;;
 esac

--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -1,13 +1,14 @@
-case $(uname -s) in
-Linux)
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
   install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-18.04.tar.gz" truffleruby
   ;;
-Darwin)
+Darwin-x86_64)
   use_homebrew_openssl
   install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-macos-latest.tar.gz" truffleruby
   ;;
 *)
-  colorize 1 "Unsupported operating system: $(uname -s)"
+  colorize 1 "Unsupported platform: $platform"
   return 1
   ;;
 esac


### PR DESCRIPTION
* Fixes #1786

The linux-aarch64 standalone should soon be available at https://github.com/oracle/truffleruby/releases/tag/vm-21.2.0, so I will wait for that.