### PR TITLE
Add TruffleRuby 21.2.0.1

### DIFF
--- a/share/ruby-build/truffleruby-21.2.0.1
+++ b/share/ruby-build/truffleruby-21.2.0.1
@@ -1,0 +1,17 @@
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
+  install_package "truffleruby-21.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0.1/truffleruby-21.2.0.1-linux-amd64.tar.gz#288c8af3ee161677298f1571ee340c2f34dd2bb02a47549177ae0900f66511be" truffleruby
+  ;;
+Linux-aarch64)
+  install_package "truffleruby-21.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0.1/truffleruby-21.2.0.1-linux-aarch64.tar.gz#ddaf53a9921d2a5b5151300c30848519db2a3f9f146f47d4d883ccbbad6cab08" truffleruby
+  ;;
+Darwin-x86_64)
+  use_homebrew_openssl
+  install_package "truffleruby-21.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0.1/truffleruby-21.2.0.1-macos-amd64.tar.gz#beee953c06a3eabe37ab227dde5dacd2d0f60e941fa93189ced77395e864f50d" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported platform: $platform"
+  return 1
+  ;;
+esac


### PR DESCRIPTION
https://github.com/oracle/truffleruby/releases/tag/vm-21.2.0.1

For truffleruby+graalvm it will automatically pick the ruby 21.2.0.1 installable when installing `truffleruby+graalvm-21.2.0`, so no need to change anything there.