### PR TITLE
Feature: more flexible mirror URL by a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The build process may be configured through the following environment variables:
 | `RUBY_BUILD_WGET_OPTS`          | Additional options to pass to `wget` for downloading.                                            |
 | `RUBY_BUILD_MIRROR_URL`         | Custom mirror URL root.                                                                          |
 | `RUBY_BUILD_MIRROR_PACKAGE_URL` | Custom complete mirror URL (e.g. http://mirror.example.com/package-1.0.0.tar.gz).                |
+| `RUBY_BUILD_MIRROR_CMD`         | Custom mirror command (see [below](#more-flexible-mirror-url) for the usage).                    |
 | `RUBY_BUILD_SKIP_MIRROR`        | Bypass the download mirror and fetch all package files from their original URLs.                 |
 | `RUBY_BUILD_TARBALL_OVERRIDE`   | Override the URL to fetch the ruby tarball from, optionally followed by `#checksum`.             |
 | `RUBY_BUILD_DEFINITIONS`        | Colon-separated list of paths to search for build definition files.                              |
@@ -149,6 +150,25 @@ complete URL by setting `RUBY_BUILD_MIRROR_PACKAGE_URL`. It behaves the same as
 
 The default ruby-build download mirror is sponsored by
 [Basecamp](https://basecamp.com/).
+
+#### More flexible mirror URL
+
+For more flexible mirror URL, you can provide a custom command to output the
+desired mirror URL, as shown below:
+
+```sh
+# There are two arguments:
+#   1st arg: the original URL without checksum
+#   2nd arg: the checksum
+$ cat <<'EOF' >./get_mirror_url && chmod +x ./get_mirror_url
+#!/bin/sh
+echo "$1" | sed "s/cache.ruby-lang.org/mirror.example.com/"
+EOF
+
+$ export RUBY_BUILD_MIRROR_CMD="$(pwd)/get_mirror_url"
+```
+
+After executing the above script in your shell, install a version as usual.
 
 #### Keeping the build directory after installation
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -474,6 +474,8 @@ fetch_tarball() {
       fi
     elif [ -n "$RUBY_BUILD_MIRROR_PACKAGE_URL" ]; then
       mirror_url="$RUBY_BUILD_MIRROR_PACKAGE_URL"
+    elif [ -n "$RUBY_BUILD_MIRROR_CMD" ]; then
+      mirror_url="$("$RUBY_BUILD_MIRROR_CMD" "$package_url" "$checksum")"
     fi
   fi
 
@@ -1537,7 +1539,7 @@ else
   unset RUBY_BUILD_CACHE_PATH
 fi
 
-if [ -z "$RUBY_BUILD_MIRROR_URL" ] && [ -z "$RUBY_BUILD_MIRROR_PACKAGE_URL" ]; then
+if [ -z "$RUBY_BUILD_MIRROR_URL" -a -z "$RUBY_BUILD_MIRROR_PACKAGE_URL" -a -z "$RUBY_BUILD_MIRROR_CMD" ]; then
   RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
   RUBY_BUILD_DEFAULT_MIRROR=1
 else
@@ -1546,7 +1548,7 @@ else
 fi
 
 if [ -n "$RUBY_BUILD_SKIP_MIRROR" ] || ! has_checksum_support compute_sha2; then
-  unset RUBY_BUILD_MIRROR_URL RUBY_BUILD_MIRROR_PACKAGE_URL
+  unset RUBY_BUILD_MIRROR_URL RUBY_BUILD_MIRROR_PACKAGE_URL RUBY_BUILD_MIRROR_CMD
 fi
 
 ARIA2_OPTS="${RUBY_BUILD_ARIA2_OPTS} ${IPV4+--disable-ipv6=true} ${IPV6+--disable-ipv6=false}"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -475,7 +475,7 @@ fetch_tarball() {
     elif [ -n "$RUBY_BUILD_MIRROR_PACKAGE_URL" ]; then
       mirror_url="$RUBY_BUILD_MIRROR_PACKAGE_URL"
     elif [ -n "$RUBY_BUILD_MIRROR_CMD" ]; then
-      mirror_url="$("$RUBY_BUILD_MIRROR_CMD" "$package_url" "$checksum")"
+      mirror_url="$(command "$RUBY_BUILD_MIRROR_CMD" "$package_url" "$checksum")"
     fi
   fi
 


### PR DESCRIPTION
This PR provides a more flexible way to specify the mirror URL by using a shell function than #1457.

For #1457, users need to know the complete mirror URL, and another drawback is users need to change the `RUBY_BUILD_MIRROR_PACKAGE_URL` env every time they install a different version.

This PR resolves these two drawbacks. Users can build the final mirror URL by any shell commands.

Thanks to the author of #1032, the idea comes from that thread.