### PR TITLE
Fix version check for Java 17

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -854,8 +854,8 @@ fix_rbx_irb() {
 require_java() {
   local required="$1"
   local java_version="$(java -version 2>&1)"
-  local version_string="$(grep 'java version' <<<"$java_version" | head -1 | grep -o '[0-9.]\+' || true)"
-  [ -n "$version_string" ] || version_string="$(grep 'openjdk version' <<<"$java_version" | head -1 | grep -o '[0-9.]\+' || true)"
+  local version_string="$(grep 'java version' <<<"$java_version" | head -1 | grep -o '[0-9.]\+' | head -1 || true)"
+  [ -n "$version_string" ] || version_string="$(grep 'openjdk version' <<<"$java_version" | head -1 | grep -o '[0-9.]\+' | head -1 || true)"
   IFS="."
   local nums=($version_string)
   IFS="$OLDIFS"
@@ -863,7 +863,7 @@ require_java() {
   [ "$found_version" -gt 1 ] 2>/dev/null || found_version="${nums[1]}"
   [ "$found_version" -ge "$required" ] 2>/dev/null && return 0
   colorize 1 "ERROR" >&3
-  echo ": Java ${required} required, but your Java version was:" >&3
+  echo ": Java >= ${required} required, but your Java version was:" >&3
   cat <<<"$java_version" >&3
   return 1
 }

--- a/test/build.bats
+++ b/test/build.bats
@@ -586,7 +586,7 @@ require_java7
 install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
 DEF
   assert_failure
-  assert_output_contains "ERROR: Java 7 required, but your Java version was:"
+  assert_output_contains "ERROR: Java >= 7 required, but your Java version was:"
 }
 
 @test "JRuby Java is outdated" {
@@ -599,7 +599,7 @@ require_java7
 install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
 DEF
   assert_failure
-  assert_output_contains "ERROR: Java 7 required, but your Java version was:"
+  assert_output_contains "ERROR: Java >= 7 required, but your Java version was:"
   assert_output_contains 'java version "1.6.0_21"'
 }
 
@@ -658,6 +658,30 @@ DEF
 
   run_inline_definition <<DEF
 require_java 9
+install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+DEF
+  assert_success
+}
+
+@test "JRuby Java 11 version string" {
+  cached_tarball "jruby-9000.dev" bin/jruby
+
+  stub java "-version : echo 'openjdk version \"11.0.10\" 2021-01-19' >&2"
+
+  run_inline_definition <<DEF
+require_java 8
+install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+DEF
+  assert_success
+}
+
+@test "JRuby Java 17 version string" {
+  cached_tarball "jruby-9000.dev" bin/jruby
+
+  stub java "-version : echo 'openjdk version \"17\" 2021-09-14' >&2"
+
+  run_inline_definition <<DEF
+require_java 8
 install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
 DEF
   assert_success


### PR DESCRIPTION
* Fixes https://github.com/rbenv/ruby-build/issues/1798
* OpenJDK 17 reports:
  $ java -version
  openjdk version "17" 2021-09-14
  There is no dot in the version, so we need to only use the first match from grep -o.
* Clarify it is a minimum required java version, not an exact version.