### PR TITLE
Prefer maven URLs going forward

### DIFF
--- a/script/update-jruby
+++ b/script/update-jruby
@@ -12,8 +12,8 @@ version="$1"
 release_directory="$2"
 file="share/ruby-build/jruby-${version}"
 
-basename="jruby-bin-${version}.tar.gz"
-url="https://s3.amazonaws.com/jruby.org/downloads/${version}/${basename}"
+basename="jruby-dist-${version}-bin.tar.gz"
+url="https://repo1.maven.org/maven2/org/jruby/jruby-dist/${version}/${basename}"
 archive="$release_directory/$basename"
 [ -e "$archive" ] || wget -O "$archive" "$url"
 sha256=$(sha256sum "$archive" | cut -d ' ' -f 1)

--- a/share/ruby-build/jruby-9.3.0.0
+++ b/share/ruby-build/jruby-9.3.0.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.3.0.0/jruby-bin-9.3.0.0.tar.gz#2dc1f85936d3ff3adc20d90e5f4894499c585a7ea5fedec67154e2f9ecb1bc9b" jruby
+install_package "jruby-9.3.0.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.0.0/jruby-dist-9.3.0.0-bin.tar.gz#2dc1f85936d3ff3adc20d90e5f4894499c585a7ea5fedec67154e2f9ecb1bc9b" jruby


### PR DESCRIPTION
Following up from https://github.com/ruby/setup-ruby/issues/220...

The S3 URLs used by ruby-build are still maintained, but we prefer that apps and tools switch to the Maven URLs. They are mirrored and federated and not dependent on us maintaining our own data store.

Pinging @enebo to see if we should make this change for earlier versions, perhaps back to the earliest version for which we push jruby-dist?