### PR TITLE
Remove yjit-dev

### DIFF
--- a/share/ruby-build/yjit-dev
+++ b/share/ruby-build/yjit-dev
@@ -1,2 +1,0 @@
-install_package "openssl-1.1.1l" "https://www.openssl.org/source/openssl-1.1.1l.tar.gz#0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" mac_openssl --if has_broken_mac_openssl
-install_git "ruby-master" "https://github.com/Shopify/yjit.git" "main" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
YJIT has been merged with upstream CRuby and the repo used by ruby-build is no longer maintained properly.

At this point the best way to build YJIT is with 3.1.0-dev or similar head-of-CRuby-master.

cc: @casperisfine
