### PR TITLE
Fix version of mislav/bump-homebrew-formula-action to avoid bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v1
+      - uses: mislav/bump-homebrew-formula-action@v1.13
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: ruby-build


### PR DESCRIPTION
Version 1.14 [has a bug](https://github.com/mislav/bump-homebrew-formula-action/issues/25) that prevents ruby-build to be pushed to homebrew and rubyists to enjoy the latest flavor of ruby, [as we can see here ](https://github.com/rbenv/ruby-build/runs/4631985764?check_suite_focus=true)

This PR fixes the version to the previous one to avoid this issue

Edit: just realised the build seems to have been retried and worked, maybe the error is just transient