### PR TITLE
Update bump-homebrew-formula action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v1.13
+      - uses: mislav/bump-homebrew-formula-action@v1
         if: "!contains(github.ref, '-')" # skip prereleases
         with:
           formula-name: ruby-build


### PR DESCRIPTION
The v1 branch is now fixed. Ref. https://github.com/rbenv/ruby-build/pull/1839

Thanks @Intrepidd