### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,16 @@
+---
+name: "🐛 Bug report"
+about: Report a bug with ruby-build. For "BUILD FAILED" scenarios, see below
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Steps to reproduce the behavior
+
+### Expected vs. actual behavior
+
+### Logs
+
+<!-- Paste the output from your terminal. Please enclose the pasted content within triple backticks. If the output suggests the full log was written to a file, copy the contents of that file to a new Gist and link it here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: BUILD FAILED
+    about: Check the Discussions section for reports of a failing Ruby build. Submit your experience (plus logs) if you cannot find reports similar to yours.
+    url: https://github.com/cli/cli/discussions
+  - name: Suggested build environment
+    about: Review the instructions about the suggested build environment for your operating system.
+    url: https://github.com/rbenv/ruby-build/wiki

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: BUILD FAILED
     about: Check the Discussions section for reports of a failing Ruby build. Submit your experience (plus logs) if you cannot find reports similar to yours.
-    url: https://github.com/cli/cli/discussions
+    url: https://github.com/rbenv/ruby-build/discussions
   - name: Suggested build environment
     about: Review the instructions about the suggested build environment for your operating system.
     url: https://github.com/rbenv/ruby-build/wiki

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,8 @@
+---
+name: "⭐ Submit a feature request"
+about: Suggest a feature to be added to ruby-build
+title: ''
+labels: enhancement
+assignees: ''
+
+---


### PR DESCRIPTION
This adds issue templates for this repository. It defines 3 categories of reports:
- "bug"
- "enhancement" (feature requests) 
- "BUILD FAILED" - instructs people to post to the Discussions section instead of filing Issues.

The goal is to redirect people to Discussions instead of Issues when seeking support for various build failures which, historically, are rarely caused by bugs in ruby-build code.
