### PR TITLE
Automatically detect and link to Homebrew's libyaml

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -558,8 +558,21 @@ build_package_standard_build() {
   local PACKAGE_CFLAGS="${package_var_name}_CFLAGS"
 
   if [ "$package_var_name" = "RUBY" ]; then
-      use_homebrew_readline || use_freebsd_pkg ||true
+    if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-readline-dir=* ]]; then
+      use_homebrew_readline || use_freebsd_readline || true
+    fi
+    if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-libyaml-dir=* ]]; then
+      use_homebrew_yaml || true
+    fi
+    if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-gmp-dir=* ]]; then
       use_homebrew_gmp || true
+    fi
+    if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-openssl-dir=* ]]; then
+      if [ "FreeBSD" = "$(uname -s)" ] && [ -f /usr/local/include/openssl/ssl.h ]; then
+        # use openssl installed from Ports Collection
+        package_option ruby configure --with-openssl-dir="/usr/local"
+      fi
+    fi
   fi
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
@@ -1037,18 +1050,10 @@ use_homebrew_gmp() {
   fi
 }
 
-use_freebsd_pkg() {
-  # check if FreeBSD
+use_freebsd_readline() {
   if [ "FreeBSD" = "$(uname -s)" ]; then
-    # use openssl if installed from Ports Collection
-    if [ -f /usr/local/include/openssl/ssl.h ]; then
-      package_option ruby configure --with-openssl-dir="/usr/local"
-    fi
-
-    # check if 11-R or later
-    release="$(uname -r)"
+    local release="$(uname -r)"
     if [ "${release%%.*}" -ge 11 ]; then
-      # prefers readline to compile most of ruby versions
       if pkg info -e readline > /dev/null; then
         # use readline from Ports Collection
         package_option ruby configure --with-readline-dir="/usr/local"
@@ -1062,14 +1067,12 @@ use_freebsd_pkg() {
 }
 
 use_homebrew_readline() {
-  if [[ "$RUBY_CONFIGURE_OPTS" != *--with-readline-dir=* ]]; then
-    local libdir="$(brew --prefix readline 2>/dev/null || true)"
-    if [ -d "$libdir" ]; then
-      echo "ruby-build: using readline from homebrew"
-      package_option ruby configure --with-readline-dir="$libdir"
-    else
-      return 1
-    fi
+  local libdir="$(brew --prefix readline 2>/dev/null || true)"
+  if [ -d "$libdir" ]; then
+    echo "ruby-build: using readline from homebrew"
+    package_option ruby configure --with-readline-dir="$libdir"
+  else
+    return 1
   fi
 }
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -61,8 +61,8 @@ assert_build_log() {
   cached_tarball "yaml-0.1.6"
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Linux'
-  stub brew false
+  stub_repeated uname '-s : echo Linux'
+  stub_repeated brew false
   stub_make_install
   stub_make_install
 
@@ -70,6 +70,7 @@ assert_build_log() {
   assert_success
 
   unstub uname
+  unstub brew
   unstub make
 
   assert_build_log <<OUT
@@ -86,8 +87,8 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Linux'
-  stub brew false
+  stub_repeated uname '-s : echo Linux'
+  stub_repeated brew false
   stub_make_install
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
@@ -100,6 +101,7 @@ PATCH
   assert_success
 
   unstub uname
+  unstub brew
   unstub make
   unstub patch
 
@@ -118,8 +120,8 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Linux'
-  stub brew false
+  stub_repeated uname '-s : echo Linux'
+  stub_repeated brew false
   stub_make_install
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
@@ -132,6 +134,7 @@ PATCH
   assert_success
 
   unstub uname
+  unstub brew
   unstub make
   unstub patch
 
@@ -150,8 +153,8 @@ OUT
   cached_tarball "yaml-0.1.6"
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Linux'
-  stub brew false
+  stub_repeated uname '-s : echo Linux'
+  stub_repeated brew false
   stub_make_install
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
@@ -165,6 +168,7 @@ PATCH
   assert_success
 
   unstub uname
+  unstub brew
   unstub make
   unstub patch
 
@@ -185,8 +189,8 @@ OUT
   brew_libdir="$TMP/homebrew-yaml"
   mkdir -p "$brew_libdir"
 
-  stub uname '-s : echo Linux'
-  stub brew false "--prefix libyaml : echo '$brew_libdir'" false
+  stub_repeated uname '-s : echo Linux'
+  stub_repeated brew "--prefix libyaml : echo '$brew_libdir'"
   stub_make_install
 
   run_inline_definition <<DEF
@@ -211,7 +215,7 @@ OUT
   gmp_libdir="$TMP/homebrew-gmp"
   mkdir -p "$gmp_libdir"
 
-  stub brew false "--prefix gmp : echo '$gmp_libdir'"
+  stub_repeated brew "--prefix gmp : echo '$gmp_libdir'"
   stub_make_install
 
   run_inline_definition <<DEF
@@ -235,7 +239,7 @@ OUT
   readline_libdir="$TMP/homebrew-readline"
   mkdir -p "$readline_libdir"
 
-  stub brew "--prefix readline : echo '$readline_libdir'" false
+  stub_repeated brew "--prefix readline : echo '$readline_libdir'"
   stub_make_install
 
   run_inline_definition <<DEF
@@ -256,7 +260,7 @@ OUT
 @test "readline is not linked from Homebrew when explicitly defined" {
   cached_tarball "ruby-2.0.0"
 
-  stub brew false
+  stub_repeated brew false
   stub_make_install
 
   export RUBY_CONFIGURE_OPTS='--with-readline-dir=/custom'
@@ -278,7 +282,7 @@ OUT
 @test "number of CPU cores defaults to 2" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Darwin' false
+  stub_repeated uname '-s : echo Darwin'
   stub sysctl false
   stub_make_install
 
@@ -301,7 +305,7 @@ OUT
 @test "number of CPU cores is detected on Mac" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Darwin' false
+  stub_repeated uname '-s : echo Darwin'
   stub sysctl '-n hw.ncpu : echo 4'
   stub_make_install
 
@@ -325,7 +329,7 @@ OUT
 @test "number of CPU cores is detected on FreeBSD" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo FreeBSD' false
+  stub_repeated uname '-s : echo FreeBSD'
   stub sysctl '-n hw.ncpu : echo 1'
   stub_make_install
 
@@ -349,7 +353,7 @@ OUT
 @test "setting RUBY_MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Linux'
+  stub_repeated uname '-s : echo Linux'
   stub_make_install
 
   export RUBY_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -371,7 +375,7 @@ OUT
 @test "setting MAKE_INSTALL_OPTS to a multi-word string" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname '-s : echo Linux'
+  stub_repeated uname '-s : echo Linux'
   stub_make_install
 
   export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
@@ -402,7 +406,7 @@ OUT
 @test "make on FreeBSD defaults to gmake" {
   cached_tarball "ruby-2.0.0"
 
-  stub uname "-s : echo FreeBSD" false
+  stub_repeated uname "-s : echo FreeBSD"
   MAKE=gmake stub_make_install
 
   MAKE= install_fixture definitions/vanilla-ruby
@@ -421,7 +425,7 @@ apply -p1 -i /my/patch.diff
 exec ./configure "\$@"
 CONF
 
-  stub uname '-s : echo Linux'
+  stub_repeated uname '-s : echo Linux'
   stub apply 'echo apply "$@" >> build.log'
   stub_make_install
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -186,10 +186,12 @@ OUT
   mkdir -p "$brew_libdir"
 
   stub uname '-s : echo Linux'
-  stub brew "--prefix libyaml : echo '$brew_libdir'" false false
+  stub brew false "--prefix libyaml : echo '$brew_libdir'" false
   stub_make_install
 
-  install_fixture definitions/needs-yaml
+  run_inline_definition <<DEF
+install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+DEF
   assert_success
 
   unstub uname

--- a/test/compiler.bats
+++ b/test/compiler.bats
@@ -8,9 +8,9 @@ export -n CC
 export -n RUBY_CONFIGURE_OPTS
 
 @test "require_gcc on OS X 10.9" {
-  stub uname '-s : echo Darwin'
+  stub_repeated uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.9.5'
-  stub gcc '--version : echo 4.2.1' '--version : echo 4.2.1'
+  stub_repeated gcc '--version : echo 4.2.1'
 
   run_inline_definition <<DEF
 require_gcc
@@ -22,12 +22,16 @@ DEF
 CC=${TMP}/bin/gcc
 MACOSX_DEPLOYMENT_TARGET=no
 OUT
+
+  unstub uname
+  unstub sw_vers
+  unstub gcc
 }
 
 @test "require_gcc on OS X 10.10" {
-  stub uname '-s : echo Darwin'
+  stub_repeated uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
-  stub gcc '--version : echo 4.2.1' '--version : echo 4.2.1'
+  stub_repeated gcc '--version : echo 4.2.1'
 
   run_inline_definition <<DEF
 require_gcc
@@ -39,6 +43,10 @@ DEF
 CC=${TMP}/bin/gcc
 MACOSX_DEPLOYMENT_TARGET=10.9
 OUT
+
+  unstub uname
+  unstub sw_vers
+  unstub gcc
 }
 
 @test "require_gcc silences warnings" {
@@ -55,13 +63,10 @@ DEF
   mkdir -p "$INSTALL_ROOT"
   cd "$INSTALL_ROOT"
 
-  stub uname '-s : echo Darwin' '-s : echo Darwin'
+  stub_repeated uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
-  stub cc 'false'
-  stub brew 'false'
-  stub make \
-    'echo make $@' \
-    'echo make $@'
+  stub_repeated brew 'false'
+  stub_repeated make 'echo make $@'
 
   cat > ./configure <<CON
 #!${BASH}
@@ -83,4 +88,9 @@ CFLAGS=no
 make -j 2
 make install
 OUT
+
+  unstub uname
+  unstub sw_vers
+  unstub brew
+  unstub make
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -77,7 +77,7 @@ OUT
 }
 
 @test "nonexistent version" {
-  stub brew false
+  stub_repeated brew false
   stub_ruby_build 'echo ERROR >&2 && exit 2' \
     "--definitions : echo 1.8.7 1.9.3-p0 1.9.3-p194 2.1.2 | tr ' ' $'\\n'"
 
@@ -97,6 +97,7 @@ If the version you need is missing, try upgrading ruby-build:
   git -C ${BATS_TEST_DIRNAME}/.. pull
 OUT
 
+  unstub brew
   unstub ruby-build
 }
 

--- a/test/stubs/stub
+++ b/test/stubs/stub
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-status=0
+status=127
 program="${0##*/}"
 PROGRAM="$(echo "$program" | tr a-z- A-Z_)"
 [ -n "$TMPDIR" ] || TMPDIR="/tmp"
@@ -9,6 +9,7 @@ PROGRAM="$(echo "$program" | tr a-z- A-Z_)"
 _STUB_PLAN="${PROGRAM}_STUB_PLAN"
 _STUB_RUN="${PROGRAM}_STUB_RUN"
 _STUB_INDEX="${PROGRAM}_STUB_INDEX"
+_STUB_NOINDEX="${PROGRAM}_STUB_NOINDEX"
 _STUB_RESULT="${PROGRAM}_STUB_RESULT"
 _STUB_END="${PROGRAM}_STUB_END"
 _STUB_DEBUG="${PROGRAM}_STUB_DEBUG"
@@ -32,7 +33,7 @@ index=0
 while IFS= read -r line; do
   index=$(($index + 1))
 
-  if [ -z "${!_STUB_END}" ] && [ $index -eq "${!_STUB_INDEX}" ]; then
+  if [[ -z "${!_STUB_END}" && -n "${!_STUB_NOINDEX}" || $index -eq "${!_STUB_INDEX}" ]]; then
     # We found the plan line we're interested in.
     # Start off by assuming success.
     result=0
@@ -72,7 +73,8 @@ while IFS= read -r line; do
       ( eval "$command" )
       status="$?"
       set -e
-    else
+      [ -z "${!_STUB_NOINDEX}" ] || break
+    elif [ -z "${!_STUB_NOINDEX}" ]; then
       eval "${_STUB_RESULT}"=1
     fi
   fi
@@ -95,7 +97,7 @@ if [ -n "${!_STUB_END}" ]; then
 else
   # If the requested index is larger than the number
   # of lines in the plan file, we failed.
-  if [ "${!_STUB_INDEX}" -gt $index ]; then
+  if [[ -z "${!_STUB_NOINDEX}" && "${!_STUB_INDEX}" -gt $index ]]; then
     eval "${_STUB_RESULT}"=1
   fi
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -36,6 +36,7 @@ teardown() {
 
 stub() {
   local program="$1"
+  # shellcheck disable=SC2155
   local prefix="$(echo "$program" | tr a-z- A-Z_)"
   shift
 
@@ -52,6 +53,7 @@ stub() {
 
 stub_repeated() {
   local program="$1"
+  # shellcheck disable=SC2155
   local prefix="$(echo "$program" | tr a-z- A-Z_)"
   export "${prefix}_STUB_NOINDEX"=1
   stub "$@"
@@ -59,6 +61,7 @@ stub_repeated() {
 
 unstub() {
   local program="$1"
+  # shellcheck disable=SC2155
   local prefix="$(echo "$program" | tr a-z- A-Z_)"
   local path="${TMP}/bin/${program}"
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -50,6 +50,13 @@ stub() {
   for arg in "$@"; do printf "%s\n" "$arg" >> "${TMP}/${program}-stub-plan"; done
 }
 
+stub_repeated() {
+  local program="$1"
+  local prefix="$(echo "$program" | tr a-z- A-Z_)"
+  export "${prefix}_STUB_NOINDEX"=1
+  stub "$@"
+}
+
 unstub() {
   local program="$1"
   local prefix="$(echo "$program" | tr a-z- A-Z_)"


### PR DESCRIPTION
closes #1928 

turns out there already was a test for this behaviour but it was falsely passing due to `needs_yaml` (that was run only from tests) was calling `use_homebrew_yaml` (which was otherwise not called in production)

Bash is not my native language and I've had very limited experience with BATS framework so there might be things I've done wrong :)