### PR TITLE
Add definition for Ruby 3.2.0-preview1

### DIFF
--- a/share/ruby-build/3.2.0-preview1
+++ b/share/ruby-build/3.2.0-preview1
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.2" "https://www.openssl.org/source/openssl-3.0.2.tar.gz#98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 3.2.0-preview1 has been released.
https://www.ruby-lang.org/en/news/2022/04/03/ruby-3-2-0-preview1-released/

This PR specifies the same OpenSSL version (3.0.2) as 3.2.0-dev.
https://github.com/rbenv/ruby-build/blob/v20220324/share/ruby-build/3.2.0-dev#L1