### PR TITLE
Allow truffleruby to install in an existing empty directory

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -794,10 +794,12 @@ remove_windows_files() {
 }
 
 clean_prefix_path_truffleruby() {
-  if [ -d "$PREFIX_PATH" ] && [ ! -e "$PREFIX_PATH/bin/truffleruby" ]; then
+  if [ -d "$PREFIX_PATH" ] &&
+     [ ! -e "$PREFIX_PATH/bin/truffleruby" ] &&
+     [ ! -z "$(ls -A $PREFIX_PATH)" ]; then
     echo
     echo "ERROR: cannot install TruffleRuby to $PREFIX_PATH, which does not look like a valid TruffleRuby prefix" >&2
-    echo "TruffleRuby only supports being installed to a not existing directory or replacing an existing TruffleRuby installation"
+    echo "TruffleRuby only supports being installed to a not existing directory, an empty directory, or replacing an existing TruffleRuby installation"
     echo "See https://github.com/oracle/truffleruby/issues/1389 for details" >&2
     return 1
   fi


### PR DESCRIPTION
Fix for #1955 #1911 

The check to prevent deleting user files during clean_prefix_path by disallowing installs into existing directories that weren't earlier truffleruby installs broke asdf installs, as asdf always creates an empty directory before installing.

This fix adds a second exception to the existing directory case when that directory is empty. The check is done by testing the string length of ls output. The logic was manually tested against non-existing directories, existing empty directories, existing non-empty directories in general, and existing non-empty directories that contained a file named "bin/truffleruby".

I also copied the file over my existing asdf version of ruby-build and made sure that it successfully installed truffleruby.