### PR TITLE
Allow to download truffleruby-dev builds for Darwin-arm64 and Linux-aarch64

### DIFF
--- a/share/ruby-build/truffleruby+graalvm-dev
+++ b/share/ruby-build/truffleruby+graalvm-dev
@@ -10,6 +10,10 @@ Darwin-x86_64)
   use_homebrew_openssl
   install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java11-darwin-amd64-dev.tar.gz" truffleruby_graalvm
   ;;
+Darwin-arm64)
+  use_homebrew_openssl
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java11-darwin-aarch64-dev.tar.gz" truffleruby_graalvm
+  ;;
 *)
   colorize 1 "Unsupported platform: $platform"
   return 1

--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -7,6 +7,10 @@ Darwin-x86_64)
   use_homebrew_openssl
   install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-macos-latest.tar.gz" truffleruby
   ;;
+Darwin-arm64)
+  use_homebrew_openssl
+  install_package "truffleruby-head" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-dev-macos-aarch64.tar.gz" truffleruby
+  ;;
 *)
   colorize 1 "Unsupported platform: $platform"
   return 1

--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -3,6 +3,9 @@ case $platform in
 Linux-x86_64)
   install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-18.04.tar.gz" truffleruby
   ;;
+Linux-aarch64)
+  install_package "truffleruby-head" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-dev-linux-aarch64.tar.gz" truffleruby
+  ;;
 Darwin-x86_64)
   use_homebrew_openssl
   install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-macos-latest.tar.gz" truffleruby


### PR DESCRIPTION
@eregon there are native builds of TruffleRuby available in Graal build repo. So let's download them from there for dev at least