### PR TITLE
Add picoruby-3.0.0

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -688,6 +688,15 @@ build_package_mruby() {
   } >&4 2>&1
 }
 
+build_package_picoruby() {
+  { ./minirake
+    mkdir -p "$PREFIX_PATH"
+    cp -fR build/host/* include "$PREFIX_PATH"
+    ln -fs picoruby "$PREFIX_PATH/bin/ruby"
+    ln -fs picoirb "$PREFIX_PATH/bin/irb"
+  } >&4 2>&1
+}
+
 build_package_maglev() {
   build_package_copy
 

--- a/share/ruby-build/picoruby-3.0.0
+++ b/share/ruby-build/picoruby-3.0.0
@@ -1,0 +1,1 @@
+install_package "picoruby-3.0.0" "https://github.com/picoruby/picoruby/archive/3.0.0.tar.gz#f25faf1ca6dbc21e167dd4ad42e29ed61e9426a106c4170601a294e046ede430" picoruby


### PR DESCRIPTION
This is the first time to send a PR of adding PicoRuby to ruby-build, so I show you how it's working on my local computer:

![image](https://user-images.githubusercontent.com/8454208/176107114-0be659d1-0686-45f3-896d-b48de40c7ffd.png)

In addition to the above executables (`picoruby` and `picoirb`), `picorbc` which is the PicoRuby compiler executable will be installed, too.

This version number `3.0.0` corresponds to the mruby's version which means a VM code generated by the picorbc 3.0.0 runs on mruby virtual machine 3.0.0 like this:

![image](https://user-images.githubusercontent.com/8454208/176110021-a4e29d8f-f58f-4c75-b810-0970f32be92c.png)
