### PR TITLE
Use OpenSSL 3.x with Ruby 3.1.x

### DIFF
--- a/share/ruby-build/3.1.0
+++ b/share/ruby-build/3.1.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_102_300
+install_package "openssl-3.0.5" "https://www.openssl.org/source/openssl-3.0.5.tar.gz#aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.0-dev
+++ b/share/ruby-build/3.1.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_102_300
+install_package "openssl-3.0.5" "https://www.openssl.org/source/openssl-3.0.5.tar.gz#aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" openssl --if needs_openssl_102_300
 install_git "ruby-3.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.1.0-preview1
+++ b/share/ruby-build/3.1.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_102_300
+install_package "openssl-3.0.5" "https://www.openssl.org/source/openssl-3.0.5.tar.gz#aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.1
+++ b/share/ruby-build/3.1.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_102_300
+install_package "openssl-3.0.5" "https://www.openssl.org/source/openssl-3.0.5.tar.gz#aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.2
+++ b/share/ruby-build/3.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_102_300
+install_package "openssl-3.0.5" "https://www.openssl.org/source/openssl-3.0.5.tar.gz#aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Related with https://github.com/rbenv/ruby-build/issues/1998#issuecomment-1180698666

Ruby 3.1.x already support OpenSSL 3.0. There is no reason why Ruby 3.1 use OpenSSL 1.1.