### PR TITLE
For Ruby 3.2.0-dev, install YJIT by default if rustc 1.60+ is available

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1256,6 +1256,29 @@ build_package_ldflags_dirs() {
   done
 }
 
+build_package_enable_yjit() {
+  local rustc_installed rustc_ver
+
+  rustc_installed=""
+  if type -p rustc &>/dev/null; then
+    rustc_ver=`rustc --version`
+    # Some kind of built-in bash comparison for dotted version strings would be awesome.
+    if [[ "${rustc_ver}" == *"rustc 1."[6789]* ]]; then
+      rustc_installed="1"
+    fi
+  fi
+
+  # If YJIT is explicitly specified, don't change anything
+  if [[ " ${RUBY_CONFIGURE_OPTS} " != *" --enable-yjit"* ]] && [[ " ${RUBY_CONFIGURE_OPTS} " != *" --disable-yjit"* ]]; then
+    if [[ "${rustc_installed}" == "1" ]]; then
+      echo "Building with YJIT by default because ${rustc_ver} is installed; add RUBY_CONFIGURE_OPTS='--disable-yjit' to disable explicitly"
+      package_option ruby configure --enable-yjit
+    else
+      echo "rustc 1.60+ is not installed, YJIT will not be built; if you want to use YJIT, install rustc 1.60+ and rerun this command."
+    fi
+  fi
+}
+
 build_package_enable_shared() {
   if [[ " ${RUBY_CONFIGURE_OPTS} " != *" --disable-shared"* ]]; then
     package_option ruby configure --enable-shared

--- a/share/ruby-build/3.2.0-dev
+++ b/share/ruby-build/3.2.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.5" "https://www.openssl.org/source/openssl-3.0.5.tar.gz#aa7d8d9bef71ad6525c55ba11e5f4397889ce49c2c9349dcea6d3e4f0b024a7a" openssl --if needs_openssl_102_300
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" ldflags_dirs autoconf enable_yjit standard_build standard_install_with_bundled_gems verify_openssl


### PR DESCRIPTION
This PR is a followup to https://github.com/rbenv/ruby-build/issues/1970. It adds build_package_enable_yjit.

If YJIT is explicitly enabled or disabled in RUBY_CONFIGURE_OPTS, enable_yjit should do nothing.
If YJIT is not specified and rustc is 1.6 or higher, it should print a message and enable YJIT.
If YJIT is not specified and rustc is not found or too old, it should print a "yjit disabled by default" message and do nothing else.

I've added the enable_yjit package to 3.2.0-dev only. In theory this could cause problems for 3.2.0 dev versions earlier than Rust-YJIT integration (19th April, CRuby SHA f90549). But it looks like 3.2.0-dev will only install latest master, not earlier random CRuby SHAs.

Rust-YJIT technically supports rustc 1.58+. But we said 1.60+ in the issue, so that's what I used here.