### PR TITLE
Don't auto-enable YJIT except on x86_64

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1268,7 +1268,7 @@ build_package_enable_yjit() {
   local rustc_ver="$(rustc --version 2>/dev/null)"
   [ -n "$rustc_ver" ] || return 0
   # Some kind of built-in bash comparison for dotted version strings would be awesome.
-  if [[ "${rustc_ver})" == *"rustc 1."[6789]* ]]; then
+  if [[ "${rustc_ver}" == *"rustc 1."[6789]* ]]; then
     echo "Building with YJIT by default because ${rustc_ver} is installed; add RUBY_CONFIGURE_OPTS='--disable-yjit' to disable explicitly" >&3
     package_option ruby configure --enable-yjit
   else


### PR DESCRIPTION
As @hsbt points out on my previous PR (https://github.com/rbenv/ruby-build/pull/2005#issuecomment-1184023153), we should only enable YJIT on x86_64, not on arm64 like Mac M1s.