### PR TITLE
Only check the opensslv.h header to find the system openssl version

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1090,15 +1090,13 @@ has_broken_mac_openssl() {
 }
 
 system_openssl_version() {
-  local version_text=$(
-    openssl version 2>/dev/null ||
-    printf '#include <openssl/opensslv.h>\nOPENSSL_VERSION_TEXT\n' | cc -xc -E - 2>/dev/null | tail -n 1)
+  local version_text=$(printf '#include <openssl/opensslv.h>\nOPENSSL_VERSION_TEXT\n' | cc -xc -E - 2>/dev/null | tail -n 1)
   if [[ $version_text == *"OpenSSL "* ]]; then
     local version=${version_text#*OpenSSL }
     version=${version%% *}
     echo $version | sed 's/[^0-9]//g' | sed 's/^0*//'
   else
-    echo "No system openssl version was found" >&2
+    echo "No system openssl version was found, ensure openssl headers are installed (https://github.com/rbenv/ruby-build/wiki#suggested-build-environment)" >&2
     echo 000
   fi
 }


### PR DESCRIPTION
* `openssl version` can be another version than the header, for instance with
  `apt-get install --no-install-recommends ca-certificates libssl1.0-dev` on Ubuntu 18.04:
  https://github.com/rbenv/ruby-build/discussions/2014#discussioncomment-3224237