### PR TITLE
Enable YJIT only x86_64 and arm64

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1280,7 +1280,7 @@ build_package_enable_yjit() {
   fi
 
   # If we aren't on x86_64 and arm64, don't enable YJIT
-  [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "arm64" ] || return 0
+  [ "$(uname -m)" = "x86_64" -o "$(uname -m)" = "arm64" ] || return 0
 
   local rustc_ver="$(rustc --version 2>/dev/null)"
   [ -n "$rustc_ver" ] || return 0

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1279,6 +1279,9 @@ build_package_enable_yjit() {
     return 0
   fi
 
+  # If we aren't on x86_64 and arm64, don't enable YJIT
+  [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "arm64" ] || return 0
+
   local rustc_ver="$(rustc --version 2>/dev/null)"
   [ -n "$rustc_ver" ] || return 0
   # Some kind of built-in bash comparison for dotted version strings would be awesome.


### PR DESCRIPTION
Followed up https://github.com/rbenv/ruby-build/pull/2028