### PR TITLE
Add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,6 +10,9 @@ on:
         description: Git commit reference to start comparing from
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   mirror:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags: 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   homebrew:
     name: Bump Homebrew formula


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows. 

GitHub Actions workflows have a GITHUB_TOKEN with `write` access to multiple scopes. 
Here is an example of the permissions in one of the workflows:
https://github.com/rbenv/ruby-build/runs/8282527096?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for each workflow. 

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced. 
- GitHub recommends defining minimum GITHUB_TOKEN permissions. 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>