### PR TITLE
macOS: Use GMP from homebrew

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -580,6 +580,7 @@ build_package_standard_build() {
 
   if [ "$package_var_name" = "RUBY" ]; then
       use_homebrew_readline || use_freebsd_pkg ||true
+      use_homebrew_gmp || true
   fi
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
@@ -1042,6 +1043,16 @@ use_homebrew_yaml() {
   if [ -d "$libdir" ]; then
     echo "ruby-build: using libyaml from homebrew"
     package_option ruby configure --with-libyaml-dir="$libdir"
+  else
+    return 1
+  fi
+}
+
+use_homebrew_gmp() {
+  local libdir="$(brew --prefix gmp 2>/dev/null || true)"
+  if [ -d "$libdir" ]; then
+    echo "ruby-build: using gmp from homebrew"
+    package_option ruby configure --with-gmp-dir="$libdir"
   else
     return 1
   fi

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-bats ${CI:+--tap} test
+bats ${CI:+--tap} test "$@"

--- a/test/build.bats
+++ b/test/build.bats
@@ -186,7 +186,7 @@ OUT
   mkdir -p "$brew_libdir"
 
   stub uname '-s : echo Linux'
-  stub brew "--prefix libyaml : echo '$brew_libdir'" false
+  stub brew "--prefix libyaml : echo '$brew_libdir'" false false
   stub_make_install
 
   install_fixture definitions/needs-yaml
@@ -203,13 +203,37 @@ make install
 OUT
 }
 
+@test "gmp is linked from Homebrew" {
+  cached_tarball "ruby-2.0.0"
+
+  gmp_libdir="$TMP/homebrew-gmp"
+  mkdir -p "$gmp_libdir"
+
+  stub brew false "--prefix gmp : echo '$gmp_libdir'"
+  stub_make_install
+
+  run_inline_definition <<DEF
+install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+DEF
+  assert_success
+
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+ruby-2.0.0: --prefix=$INSTALL_ROOT --with-gmp-dir=$gmp_libdir
+make -j 2
+make install
+OUT
+}
+
 @test "readline is linked from Homebrew" {
   cached_tarball "ruby-2.0.0"
 
   readline_libdir="$TMP/homebrew-readline"
   mkdir -p "$readline_libdir"
 
-  stub brew "--prefix readline : echo '$readline_libdir'"
+  stub brew "--prefix readline : echo '$readline_libdir'" false
   stub_make_install
 
   run_inline_definition <<DEF
@@ -230,7 +254,7 @@ OUT
 @test "readline is not linked from Homebrew when explicitly defined" {
   cached_tarball "ruby-2.0.0"
 
-  stub brew
+  stub brew false
   stub_make_install
 
   export RUBY_CONFIGURE_OPTS='--with-readline-dir=/custom'


### PR DESCRIPTION
MRI's BigInt use GMP under the hood if available, and if not fallbacks to an homemade implementation with much worse performance.

Without GMP:
```
>> Benchmark.realtime { Integer('1' * (10 ** 7)) }
=> 13.80743500002427
```

With GMP
```
>> Benchmark.realtime { Integer('1' * (10 ** 7)) }
=> 0.4098639999865554
```

macOS not being a common production platform, it's not a huge deal but it would still preferable to compile with `gmp.h` if present.

I'd also suggest to print a warning if compiling on macOS and gmp isn't installed, but I don't know if it's desirable.

cc @eregon @hsbt 