### PR TITLE
Allow OPENSSL_VERSION_TEXT string match without last line for OpenSUSE

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1090,7 +1090,7 @@ has_broken_mac_openssl() {
 }
 
 system_openssl_version() {
-  local version_text=$(printf '#include <openssl/opensslv.h>\nOPENSSL_VERSION_TEXT\n' | cc -xc -E - 2>/dev/null | tail -n 1)
+  local version_text=$(printf '#include <openssl/opensslv.h>\nOPENSSL_VERSION_TEXT\n' | cc -xc -E - 2>/dev/null)
   if [[ $version_text == *"OpenSSL "* ]]; then
     local version=${version_text#*OpenSSL }
     version=${version%% *}


### PR DESCRIPTION
Fixed https://github.com/rbenv/ruby-build/issues/2043

I confirmed to work this with OpenSUSE leap 15.4.