### PR TITLE
Suggest `rbenv global` if there is no explicit global setting

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -63,6 +63,7 @@ definitions() {
 }
 
 suggest_selecting_global() {
+  # shellcheck disable=SC2155
   local version_file="$(rbenv-version-file)"
   [[ "$version_file" != "$RBENV_ROOT"/version || -e "$version_file" ]] && return 0
   echo 
@@ -206,6 +207,7 @@ fi
 # REE installer requires an existing Ruby installation to run. An
 # unsatisfied local .ruby-version file can cause the installer to
 # fail.)
+# shellcheck disable=SC2155
 export RBENV_VERSION="$(rbenv-global 2>/dev/null || true)"
 
 

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -62,6 +62,22 @@ definitions() {
   ruby-build --definitions | $(type -p ggrep grep | head -1) -F "$query" || true
 }
 
+suggest_selecting_global() {
+  local version_file="$(rbenv-version-file)"
+  [[ "$version_file" != "$RBENV_ROOT"/version || -e "$version_file" ]] && return 0
+  echo 
+  colorize 1 "NOTE:"
+  echo -n " to activate this Ruby version as the new default, run: "
+  colorize 33 "rbenv global $VERSION_NAME"
+  echo
+}
+
+colorize() {
+  if [ -t 1 ]; then printf "\e[%sm%s\e[m" "$1" "$2"
+  else printf "%s" "$2"
+  fi
+}
+
 indent() {
   sed 's/^/  /'
 }
@@ -238,6 +254,7 @@ for hook in "${after_hooks[@]}"; do eval "$hook"; done
 # Run `rbenv-rehash` after a successful installation.
 if [ "$STATUS" == "0" ]; then
   rbenv-rehash
+  suggest_selecting_global
 else
   cleanup
 fi

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -15,6 +15,7 @@ after_install 'echo after: \$STATUS'
 OUT
   stub rbenv-hooks "install : echo '$HOOK_PATH'/install.bash"
   stub rbenv-rehash "echo rehashed"
+  stub rbenv-version-file "echo .ruby-version"
 
   definition="${TMP}/2.0.0"
   cat > "$definition" <<<"echo ruby-build"

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -6,6 +6,9 @@ export RBENV_ROOT="${TMP}/rbenv"
 setup() {
   stub rbenv-hooks 'install : true'
   stub rbenv-rehash 'true'
+  stub rbenv-version-file 'echo $RBENV_ROOT/version'
+  mkdir -p "$RBENV_ROOT"
+  echo "system" > "$RBENV_ROOT/version"
 }
 
 stub_ruby_build() {
@@ -21,6 +24,20 @@ stub_ruby_build() {
   unstub ruby-build
   unstub rbenv-hooks
   unstub rbenv-rehash
+}
+
+@test "suggest running rbenv global after install" {
+  rm -rf "$RBENV_ROOT/version"
+  stub_ruby_build 'echo ruby-build "$@"'
+
+  run rbenv-install 2.1.2
+  assert_success <<OUT
+ruby-build 2.1.2 ${RBENV_ROOT}/versions/2.1.2
+
+NOTE: to activate this Ruby version as the new default, run: rbenv global 2.1.2
+OUT
+
+  unstub ruby-build
 }
 
 @test "install rbenv local version by default" {


### PR DESCRIPTION
Upon installing their first Ruby version on the system, the user may want to set it as their default; otherwise the default will remain "system" and any `gem install` attempts will fail with a permission error.

This suggestion is skipped if the user already has chosen an explicit default, even if it's "system".

Ref. https://github.com/rbenv/rbenv/issues/1424