### PR TITLE
List output: only print stderr notice if printing to a terminal

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -97,7 +97,7 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "l" | "list" )
     ruby-build --list
-    {
+    [ -t 1 ] && {
       echo
       echo "Only latest stable releases for each Ruby implementation are shown."
       echo "Use 'rbenv install --list-all / -L' to show all local versions."


### PR DESCRIPTION
This makes it easier to redirect `rbenv install -l` output without having to silence stderr to get rid of the extra notice.

Fixes https://github.com/rbenv/ruby-build/issues/2054