### PR TITLE
Mark Ruby 2.6 as EOL and 2.7 as "unsupported"

### DIFF
--- a/share/ruby-build/2.6.0
+++ b/share/ruby-build/2.6.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.1
+++ b/share/ruby-build/2.6.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.10
+++ b/share/ruby-build/2.6.10
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.10" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.bz2#399e1f13e7fedc3c6ae2ff541bbf26c44dfb63b07b6c186fdd15b4e526e27e9c" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.10" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.bz2#399e1f13e7fedc3c6ae2ff541bbf26c44dfb63b07b6c186fdd15b4e526e27e9c" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.2
+++ b/share/ruby-build/2.6.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.3
+++ b/share/ruby-build/2.6.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.4
+++ b/share/ruby-build/2.6.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.5
+++ b/share/ruby-build/2.6.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.6
+++ b/share/ruby-build/2.6.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.6" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2#f08b779079ecd1498e6a2548c39a86144c6c784dcec6f7e8a93208682eb8306e" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.6" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2#f08b779079ecd1498e6a2548c39a86144c6c784dcec6f7e8a93208682eb8306e" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.7
+++ b/share/ruby-build/2.6.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.7" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.7.tar.bz2#775a5d47b73ce3ee5d600f993badd7b640a2caca138573326db6632858517710" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.7" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.7.tar.bz2#775a5d47b73ce3ee5d600f993badd7b640a2caca138573326db6632858517710" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.8
+++ b/share/ruby-build/2.6.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.8" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.bz2#dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.8" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.bz2#dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.9
+++ b/share/ruby-build/2.6.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.9" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.bz2#a0639060c4519572e51828eb742f09dd40f154c820f6007246de7a2090e3ee45" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.6.9" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.bz2#a0639060c4519572e51828eb742f09dd40f154c820f6007246de7a2090e3ee45" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0
+++ b/share/ruby-build/2.7.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.1
+++ b/share/ruby-build/2.7.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.2
+++ b/share/ruby-build/2.7.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.3
+++ b/share/ruby-build/2.7.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.4
+++ b/share/ruby-build/2.7.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.5
+++ b/share/ruby-build/2.7.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.6
+++ b/share/ruby-build/2.7.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1q" "https://www.openssl.org/source/openssl-1.1.1q.tar.gz#d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_unsupported ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Note: I wish we could somehow embed the support/EOL date into the build definition itself so that these warnings could automatically start printing when past the cutoff date instead of us having to ship updates to ruby-build.

Ref. #942