### PR TITLE
Add definition for Ruby 3.2.0-preview3

### DIFF
--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" ldflags_dirs enable_yjit enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 3.2.0-preview3 has been released.
https://www.ruby-lang.org/en/news/2022/11/11/ruby-3-2-0-preview3-released/