### PR TITLE
Do not automatically enable YJIT nor attempt to detect rustc

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1284,27 +1284,6 @@ build_package_ldflags_dirs() {
   done
 }
 
-build_package_enable_yjit() {
-  # If YJIT is explicitly enabled or disabled, don't change the config
-  if [[ " ${RUBY_CONFIGURE_OPTS} " == *" --enable-yjit"* || " ${RUBY_CONFIGURE_OPTS} " == *" --disable-yjit"* ]]; then
-    return 0
-  fi
-
-  # If we aren't on x86_64/aarch64/arm64, don't enable YJIT
-  local arch="$(uname -m)"
-  [ "$arch" = "x86_64" -o "$arch" = "arm64" -o "$arch" = "aarch64" ] || return 0
-
-  local rustc_ver="$(rustc --version 2>/dev/null)"
-  [ -n "$rustc_ver" ] || return 0
-  # YJIT supports Rust 1.58.1 and later
-  if [[ "${rustc_ver}" =~ ^rustc\ 1\.(58\.1|59\.|[6789][0-9]\.) ]]; then
-    echo "Building with YJIT by default because ${rustc_ver} is installed; add RUBY_CONFIGURE_OPTS='--disable-yjit' to disable explicitly" >&3
-    package_option ruby configure --enable-yjit
-  else
-    echo "rustc 1.58.1+ is not installed, YJIT will not be built; if you want to use YJIT, install rustc 1.58.1+ and rerun this command." >&3
-  fi
-}
-
 build_package_enable_shared() {
   if [[ " ${RUBY_CONFIGURE_OPTS} " != *" --disable-shared"* ]]; then
     package_option ruby configure --enable-shared

--- a/share/ruby-build/3.2.0-dev
+++ b/share/ruby-build/3.2.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" ldflags_dirs autoconf enable_yjit standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.2.0-preview2
+++ b/share/ruby-build/3.2.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
-install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" ldflags_dirs enable_yjit enable_shared standard verify_openssl
+install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
-install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" ldflags_dirs enable_yjit enable_shared standard verify_openssl
+install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Latest Ruby 3.2 development version now detects `rustc` on the system and automatically assumes `--enable-yjit` on susupported platforms unless `--disable-yjit` was explicitly passed. https://github.com/ruby/ruby/pull/6662

I propose that ruby-build does not attempt to duplicate this logic, but that it leaves it completely to Ruby's own build system.

Followup to https://github.com/rbenv/ruby-build/issues/1970 /cc @byroot @maximecb 

