### PR TITLE
truffleruby+graalvm-dev builds are now based on Java 17

### DIFF
--- a/script/update-truffleruby-graalvm
+++ b/script/update-truffleruby-graalvm
@@ -14,7 +14,7 @@ file="share/ruby-build/truffleruby+graalvm-${version}"
 
 add_platform() {
   platform="$1"
-  basename="graalvm-ce-java11-${platform}-${version}.tar.gz"
+  basename="graalvm-ce-java17-${platform}-${version}.tar.gz"
   url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/${basename}"
   sha256=$(sha256sum "$release_directory/$basename" | cut -d ' ' -f 1)
 

--- a/share/ruby-build/truffleruby+graalvm-dev
+++ b/share/ruby-build/truffleruby+graalvm-dev
@@ -1,18 +1,18 @@
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java11-linux-amd64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-linux-amd64-dev.tar.gz" truffleruby_graalvm
   ;;
 Linux-aarch64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java11-linux-aarch64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-linux-aarch64-dev.tar.gz" truffleruby_graalvm
   ;;
 Darwin-x86_64)
   use_homebrew_openssl
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java11-darwin-amd64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-darwin-amd64-dev.tar.gz" truffleruby_graalvm
   ;;
 Darwin-arm64)
   use_homebrew_openssl
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java11-darwin-aarch64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-darwin-aarch64-dev.tar.gz" truffleruby_graalvm
   ;;
 *)
   colorize 1 "Unsupported platform: $platform"


### PR DESCRIPTION
* Fixes #2092.