### PR TITLE
Add definition for Ruby 3.1.3, 3.0.5, and 2.7.7

### DIFF
--- a/share/ruby-build/2.7.7
+++ b/share/ruby-build/2.7.7
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_101_111
+install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_unsupported ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.5
+++ b/share/ruby-build/3.0.5
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_101_111
+install_package "ruby-3.0.5" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz#9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.3
+++ b/share/ruby-build/3.1.3
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
These Rubies have been released.

- https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-1-3-released/
- https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-0-5-released/
- https://www.ruby-lang.org/en/news/2022/11/24/ruby-2-7-7-released/