### PR TITLE
Add definition for Ruby 3.2.0 RC 1

### DIFF
--- a/share/ruby-build/3.2.0-rc1
+++ b/share/ruby-build/3.2.0-rc1
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
Ruby 3.2.0 RC 1 has been released.
https://www.ruby-lang.org/en/news/2022/12/06/ruby-3-2-0-rc1-released/