### PR TITLE
Don't use OpenSSL-3, `openssl` gem doesn't support it yet

### DIFF
--- a/share/ruby-build/3.1.0
+++ b/share/ruby-build/3.1.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.0-dev
+++ b/share/ruby-build/3.1.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_git "ruby-3.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.1.0-preview1
+++ b/share/ruby-build/3.1.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.1
+++ b/share/ruby-build/3.1.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.2
+++ b/share/ruby-build/3.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.3
+++ b/share/ruby-build/3.1.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-dev
+++ b/share/ruby-build/3.2.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" ldflags_dirs autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.2.0-preview1
+++ b/share/ruby-build/3.2.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-preview2
+++ b/share/ruby-build/3.2.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-rc1
+++ b/share/ruby-build/3.2.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.7" "https://www.openssl.org/source/openssl-3.0.7.tar.gz#83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e" openssl --if needs_openssl_102_300
+install_package "openssl-1.1.1s" "https://www.openssl.org/source/openssl-1.1.1s.tar.gz#c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa" openssl --if needs_openssl_102_300
 install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
While `openssl` gem could be build with openssl-3, it would work correctly in many cases, see https://github.com/ruby/openssl/issues/369.

Use openssl-1.1 instead until compatibility is fixed.