### PR TITLE
Drop svn support

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -174,10 +174,6 @@ install_git() {
   install_package_using "git" 2 "$@"
 }
 
-install_svn() {
-  install_package_using "svn" 2 "$@"
-}
-
 install_package_using() {
   local package_type="$1"
   local package_type_nargs="$2"
@@ -489,23 +485,6 @@ fetch_git() {
     fi
   else
     echo "error: please install \`git\` and try again" >&2
-    exit 1
-  fi
-}
-
-fetch_svn() {
-  local package_name="$1"
-  local svn_url="$2"
-  local svn_rev="$3"
-
-  echo "Checking out ${svn_url}..." >&2
-
-  if type svn &>/dev/null; then
-    svn co -r "$svn_rev" "$svn_url" "${package_name}" >&4 2>&1
-  elif type svnlite &>/dev/null; then
-    svnlite co -r "$svn_rev" "$svn_url" "${package_name}" >&4 2>&1
-  else
-    echo "error: please install Subversion and try again" >&2
     exit 1
   fi
 }

--- a/share/ruby-build/1.9.2-p326
+++ b/share/ruby-build/1.9.2-p326
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_svn "ruby-1.9.2-p326" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_2" "44353" warn_eol autoconf standard
+install_git "ruby-1.9.2-p326" "https://github.com/ruby/ruby.git" "2b93dbd8e7e3d71dc4cb4c7e381974176b134c5b" warn_eol autoconf standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby


### PR DESCRIPTION
The ruby core team already shutdown svn.ruby-lang.org via https://github.com/rbenv/ruby-build/issues/2119

I removed svn feature and replace definition to use it.