### PR TITLE
http://topazruby.com/ is 404 now

### DIFF
--- a/share/ruby-build/topaz-dev
+++ b/share/ruby-build/topaz-dev
@@ -1,1 +1,0 @@
-install_package topaz "http://topazruby.com/builds/$(topaz_architecture)/latest/?_=.tar.bz2" topaz


### PR DESCRIPTION
Unfortunately, http://topazruby.com/ is 404 today.