### PR TITLE
Remove brew update instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ brew install ruby-build
 
 Upgrade with:
 ```sh
-brew update && brew upgrade ruby-build
+brew upgrade ruby-build
 ```
 
 ### Clone as rbenv plugin using git
@@ -48,7 +48,7 @@ $ ruby-build --definitions             # lists all available versions of Ruby
 $ ruby-build 2.2.0 ~/local/ruby-2.2.0  # installs Ruby 2.2.0 to ~/local/ruby-2.2.0
 ```
 
-> **Warning**  
+> **Warning**
 > ruby-build mostly does not verify that system dependencies are present before downloading and attempting to compile Ruby from source. Please ensure that [all requisite libraries][build-env] such as build tools and development headers are already present on your system.
 
 Basically, what ruby-build does when installing a Ruby version is this:

--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -240,7 +240,7 @@ if [ "$STATUS" == "2" ]; then
     echo -n "If the version you need is missing, try upgrading ruby-build"
     if [ "$here" != "${here#$(brew --prefix 2>/dev/null)}" ]; then
       printf ":\n\n"
-      echo "  brew update && brew upgrade ruby-build"
+      echo "  brew upgrade ruby-build"
     elif [ -d "${here}/.git" ]; then
       printf ":\n\n"
       echo "  git -C ${here} pull"

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -114,7 +114,7 @@ See all available versions with \`rbenv install --list'.
 
 If the version you need is missing, try upgrading ruby-build:
 
-  brew update && brew upgrade ruby-build
+  brew upgrade ruby-build
 OUT
 
   unstub brew


### PR DESCRIPTION
Same motivation as https://github.com/cli/cli/pull/6087.
I just found that `rbenv` suggests `brew update` but it's basically unnecessary.