### PR TITLE
Update TruffleRuby dev release URLs

### DIFF
--- a/share/ruby-build/truffleruby+graalvm-dev
+++ b/share/ruby-build/truffleruby+graalvm-dev
@@ -1,18 +1,18 @@
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java19-linux-amd64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-linux-amd64-dev.tar.gz" truffleruby_graalvm
   ;;
 Linux-aarch64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java19-linux-aarch64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-linux-aarch64-dev.tar.gz" truffleruby_graalvm
   ;;
 Darwin-x86_64)
   use_homebrew_openssl
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java19-darwin-amd64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-darwin-amd64-dev.tar.gz" truffleruby_graalvm
   ;;
 Darwin-arm64)
   use_homebrew_openssl
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java19-darwin-aarch64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-ce-java17-darwin-aarch64-dev.tar.gz" truffleruby_graalvm
   ;;
 *)
   colorize 1 "Unsupported platform: $platform"

--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -1,7 +1,7 @@
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)
-  install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-18.04.tar.gz" truffleruby
+  install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-20.04.tar.gz" truffleruby
   ;;
 Linux-aarch64)
   install_package "truffleruby-head" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-dev-linux-aarch64.tar.gz" truffleruby


### PR DESCRIPTION
The current _truffleruby-dev_ builds are based on Ubuntu 18.04. Since Ubuntu 18.04 will be EOL in two months, we should switch over to Ubuntu 20.04 as our newest base.

Likewise, the _truffleruby+graalvm-dev_ installation URLs broke because Java 19 was not an LTS release and there are no longer snapshot builds based on Java 19. While Java 20 builds are available, we should just use Java 17 as that's the most recent Java LTS. As such, those URLs will be more stable; they won't change until the next Java LTS release.