### PR TITLE
Remove AWS access key ID from version control

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0
+        fetch-depth: 100
     - name: Update download mirror
       run: script/mirror update "${BEFORE_REF}.."
       env:

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -24,7 +24,7 @@ jobs:
       run: script/mirror update "${BEFORE_REF}.."
       env:
         BEFORE_REF: ${{ github.event.before }}${{ github.event.inputs.beforeRef }}
-        AMAZON_S3_BUCKET: ruby-build-mirror
-        AWS_ACCESS_KEY_ID: AKIAJKAUQVHU6X4CODDQ
+        AMAZON_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.MIRROR_UPLOAD_SECRET }}
         AWS_REGION: us-east-1

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -27,4 +27,4 @@ jobs:
         AMAZON_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
         AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.MIRROR_UPLOAD_SECRET }}
-        AWS_REGION: us-east-1
+        AWS_REGION: ${{ vars.AWS_REGION }}


### PR DESCRIPTION
This is to stop people's security software from complaining about it.

Fixes https://github.com/rbenv/ruby-build/issues/2161