### PR TITLE
Add ruby 3.2.2

### DIFF
--- a/share/ruby-build/3.2.2
+++ b/share/ruby-build/3.2.2
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.8" "https://www.openssl.org/source/openssl-3.0.8.tar.gz#6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e" openssl --if needs_openssl_102_300
+install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/


I'm not sure if I should've used `scripts/update-openssl` to update openssl or not, I just copied the install_package from the 3.2.1 release as mentioned in the `scripts/update-cruby` script's `TODO` comment