### PR TITLE
Add definitions for Ruby 2.7.8, 3.0.6, 3.1.4, 3.2.2

### DIFF
--- a/share/ruby-build/2.7.8
+++ b/share/ruby-build/2.7.8
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
+install_package "ruby-2.7.8" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz#c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.6
+++ b/share/ruby-build/3.0.6
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
+install_package "ruby-3.0.6" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz#6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.4
+++ b/share/ruby-build/3.1.4
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.8" "https://www.openssl.org/source/openssl-3.0.8.tar.gz#6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e" openssl --if needs_openssl_102_300
+install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.2
+++ b/share/ruby-build/3.2.2
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.8" "https://www.openssl.org/source/openssl-3.0.8.tar.gz#6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e" openssl --if needs_openssl_102_300
+install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
See security/release announcements for:

* [2.7.8](https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/)
* [3.0.6](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-0-6-released/)
* [3.1.4](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-1-4-released/)
* [3.2.2](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/)