### PR TITLE
Mark EOL status to Ruby 2.6 and 2.7

### DIFF
--- a/share/ruby-build/2.6.0-preview1
+++ b/share/ruby-build/2.6.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-preview2
+++ b/share/ruby-build/2.6.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-preview3
+++ b/share/ruby-build/2.6.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview3.tar.bz2#1f09a2ac1ab26721923cbf4b9302a66d36bb302dc45e72112b41d6fccc5b5931" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview3.tar.bz2#1f09a2ac1ab26721923cbf4b9302a66d36bb302dc45e72112b41d6fccc5b5931" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-rc1
+++ b/share/ruby-build/2.6.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc1.tar.bz2#b4e9c0e8801946e9f0baba30948955f4341e9e04f363c206b7bd774208053eb5" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc1.tar.bz2#b4e9c0e8801946e9f0baba30948955f4341e9e04f363c206b7bd774208053eb5" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.6.0-rc2
+++ b/share/ruby-build/2.6.0-rc2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.6.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2#b3d03e471e3136f43bb948013d4f4974abb63d478e8ff7ec2741b22750a3ec50" ldflags_dirs standard verify_openssl
+install_package "ruby-2.6.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2#b3d03e471e3136f43bb948013d4f4974abb63d478e8ff7ec2741b22750a3ec50" warn_eol ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.7.0
+++ b/share/ruby-build/2.7.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview1
+++ b/share/ruby-build/2.7.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview2
+++ b/share/ruby-build/2.7.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview3
+++ b/share/ruby-build/2.7.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2#df2ddee659873e6fc30a8590ecffa49cf3a4ef81fa922b0d09f821b69ee88bc3" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2#df2ddee659873e6fc30a8590ecffa49cf3a4ef81fa922b0d09f821b69ee88bc3" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-rc1
+++ b/share/ruby-build/2.7.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc1.tar.bz2#1c5a02b63fa9fca37c41681bbbf20c55818a32315958c0a6c8f505943bfcb2d2" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc1.tar.bz2#1c5a02b63fa9fca37c41681bbbf20c55818a32315958c0a6c8f505943bfcb2d2" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-rc2
+++ b/share/ruby-build/2.7.0-rc2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc2.tar.bz2#8f94ea7ba79b6e95225fb4a7870e882081182c3d12d58c4cad2a7d2e7865cf8e" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc2.tar.bz2#8f94ea7ba79b6e95225fb4a7870e882081182c3d12d58c4cad2a7d2e7865cf8e" warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.1
+++ b/share/ruby-build/2.7.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.2
+++ b/share/ruby-build/2.7.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.3
+++ b/share/ruby-build/2.7.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.4
+++ b/share/ruby-build/2.7.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.5
+++ b/share/ruby-build/2.7.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.6
+++ b/share/ruby-build/2.7.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.7
+++ b/share/ruby-build/2.7.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_unsupported ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_unsupported warn_eol ldflags_dirs enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.8
+++ b/share/ruby-build/2.7.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1t" "https://www.openssl.org/source/openssl-1.1.1t.tar.gz#8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.8" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz#c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0" ldflags_dirs enable_shared standard verify_openssl
+install_package "ruby-2.7.8" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz#c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0" warn_eol ldflags_dirs enable_shared standard verify_openssl


### PR DESCRIPTION
I added `warn_eol` flag to all of Ruby 2.7 versions and preview version of Ruby 2.6.