### PR TITLE
Add TruffleRuby+GraalVM 23.0.0-preview1

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -777,7 +777,9 @@ build_package_truffleruby_graalvm() {
     cd Contents/Home || return $?
   fi
 
-  bin/gu install ruby || return $?
+  if [ -e bin/gu ]; then
+    bin/gu install ruby || return $?
+  fi
 
   local ruby_home
   ruby_home=$(bin/ruby -e 'print RbConfig::CONFIG["prefix"]')

--- a/script/update-truffleruby-graalvm
+++ b/script/update-truffleruby-graalvm
@@ -14,8 +14,13 @@ file="share/ruby-build/truffleruby+graalvm-${version}"
 
 add_platform() {
   platform="$1"
-  basename="graalvm-ce-java17-${platform}-${version}.tar.gz"
-  url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/${basename}"
+  if [[ "$version" = *preview* ]]; then
+    basename="graalvm-ruby-community-${version}-jdk17-${platform}.tar.gz"
+    url="https://github.com/oracle/truffleruby/releases/download/vm-${version}/${basename}"
+  else
+    basename="graalvm-ce-java17-${platform}-${version}.tar.gz"
+    url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/${basename}"
+  fi
   sha256=$(sha256sum "$release_directory/$basename" | cut -d ' ' -f 1)
 
   cat >> "$file" <<EOS

--- a/share/ruby-build/truffleruby+graalvm-23.0.0-preview1
+++ b/share/ruby-build/truffleruby+graalvm-23.0.0-preview1
@@ -1,0 +1,21 @@
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
+  install_package "truffleruby+graalvm-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/graalvm-ruby-community-23.0.0-preview1-jdk17-linux-amd64.tar.gz#973aabc7b5bd5d6c0c67c03e83972173a74b16f4905785988a13daff7107ed4c" truffleruby_graalvm
+  ;;
+Linux-aarch64)
+  install_package "truffleruby+graalvm-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/graalvm-ruby-community-23.0.0-preview1-jdk17-linux-aarch64.tar.gz#b8b6f6493219b5435eea87305cdb14b8f5af7b8d45097840afaf314428756748" truffleruby_graalvm
+  ;;
+Darwin-x86_64)
+  use_homebrew_openssl
+  install_package "truffleruby+graalvm-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/graalvm-ruby-community-23.0.0-preview1-jdk17-darwin-amd64.tar.gz#dd7370352697325e0cfa25d069a64903103601bfacc7c7e1c515409e9cf74386" truffleruby_graalvm
+  ;;
+Darwin-arm64)
+  use_homebrew_openssl
+  install_package "truffleruby+graalvm-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/graalvm-ruby-community-23.0.0-preview1-jdk17-darwin-aarch64.tar.gz#bfe1c1227d3648bbdaf4e40716e12729c5f1f66a40983d3ca3d2f814f570d4e0" truffleruby_graalvm
+  ;;
+*)
+  colorize 1 "Unsupported platform: $platform"
+  return 1
+  ;;
+esac


### PR DESCRIPTION
For this release it's packaged a bit differently, we have a GraalVM with JDK and already including the TruffleRuby component at https://github.com/oracle/truffleruby/releases/tag/vm-23.0.0-preview1.