### PR TITLE
Add TruffleRuby and TruffleRuby+GraalVM 23.0.0

### DIFF
--- a/script/update-truffleruby-graalvm
+++ b/script/update-truffleruby-graalvm
@@ -18,8 +18,9 @@ add_platform() {
     basename="graalvm-ruby-community-${version}-jdk17-${platform}.tar.gz"
     url="https://github.com/oracle/truffleruby/releases/download/vm-${version}/${basename}"
   else
-    basename="graalvm-ce-java17-${platform}-${version}.tar.gz"
-    url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${version}/${basename}"
+    jdk_version="17.0.7"
+    basename="graalvm-jdk-${jdk_version}_${platform}_bin.tar.gz"
+    url="https://download.oracle.com/graalvm/17/archive/${basename}"
   fi
   sha256=$(sha256sum "$release_directory/$basename" | cut -d ' ' -f 1)
 
@@ -34,7 +35,7 @@ platform="\$(uname -s)-\$(uname -m)"
 case \$platform in
 Linux-x86_64)
 EOS
-add_platform "linux-amd64"
+add_platform "linux-x64"
 cat >> "$file" <<EOS
 Linux-aarch64)
 EOS
@@ -43,12 +44,12 @@ cat >> "$file" <<EOS
 Darwin-x86_64)
   use_homebrew_openssl
 EOS
-add_platform "darwin-amd64"
+add_platform "macos-x64"
 cat >> "$file" <<EOS
 Darwin-arm64)
   use_homebrew_openssl
 EOS
-add_platform "darwin-aarch64"
+add_platform "macos-aarch64"
 cat >> "$file" <<EOS
 *)
   colorize 1 "Unsupported platform: \$platform"

--- a/share/ruby-build/truffleruby+graalvm-23.0.0
+++ b/share/ruby-build/truffleruby+graalvm-23.0.0
@@ -1,0 +1,21 @@
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
+  install_package "truffleruby+graalvm-23.0.0" "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.7_linux-x64_bin.tar.gz#93db5fd373fc8eb5a5578387f7646cfd414b82e8cfaf9dbcd0145ceae0137398" truffleruby_graalvm
+  ;;
+Linux-aarch64)
+  install_package "truffleruby+graalvm-23.0.0" "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.7_linux-aarch64_bin.tar.gz#73256df1af0507f8cb230bafe506e4dcaba2b3e6d8bb1324bf5a02198890ef97" truffleruby_graalvm
+  ;;
+Darwin-x86_64)
+  use_homebrew_openssl
+  install_package "truffleruby+graalvm-23.0.0" "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.7_macos-x64_bin.tar.gz#905255762546c69e3bb8d815a5d20e2e3cfa5332b868ab90af7aa0afe21e74ea" truffleruby_graalvm
+  ;;
+Darwin-arm64)
+  use_homebrew_openssl
+  install_package "truffleruby+graalvm-23.0.0" "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.7_macos-aarch64_bin.tar.gz#cb45f6585ef02134a6a6ffb6de20db96197486ffef8821ad97b11fe2fc0c23b8" truffleruby_graalvm
+  ;;
+*)
+  colorize 1 "Unsupported platform: $platform"
+  return 1
+  ;;
+esac

--- a/share/ruby-build/truffleruby-23.0.0
+++ b/share/ruby-build/truffleruby-23.0.0
@@ -1,0 +1,21 @@
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
+  install_package "truffleruby-23.0.0" "https://gds.oracle.com/api/20220101/artifacts/FD4AB182EA4CEDFDE0531518000AF13E/content#57f770e7ba754327c8c160571978c7da0e10a086f8b5dc542e5c8ff5b2c83190" truffleruby
+  ;;
+Linux-aarch64)
+  install_package "truffleruby-23.0.0" "https://gds.oracle.com/api/20220101/artifacts/FD40BA2367C226B6E0531518000AE71A/content#b75b6ddab76bda5d9cbff2fb53f5c5559fa6c5e11b845986b02c3cd4d3b98b3a" truffleruby
+  ;;
+Darwin-x86_64)
+  use_homebrew_openssl
+  install_package "truffleruby-23.0.0" "https://gds.oracle.com/api/20220101/artifacts/FD4AB182EA51EDFDE0531518000AF13E/content#793afdc8c2bd35e6c229e833da0105f34e48e5dc872eb3e8d03d81f516e16191" truffleruby
+  ;;
+Darwin-arm64)
+  use_homebrew_openssl
+  install_package "truffleruby-23.0.0" "https://gds.oracle.com/api/20220101/artifacts/FD40BBF6750C366CE0531518000ABEAF/content#3e6fa0d4a76d9d7d701fe1ea1b75a5d3eab29e77d21bf9454a67b0aa31c63bb6" truffleruby
+  ;;
+*)
+  colorize 1 "Unsupported platform: $platform"
+  return 1
+  ;;
+esac


### PR DESCRIPTION
* Use the new Oracle GraalVM distribution which uses the GFTC license as it is significantly faster than GraalVM CE and is free for development and production use.
* See https://medium.com/graalvm/whats-new-in-graalvm-languages-161527df3d76