### PR TITLE
Print a message about the new distribution and license when installing TruffleRuby 23.0

### DIFF
--- a/share/ruby-build/truffleruby+graalvm-23.0.0
+++ b/share/ruby-build/truffleruby+graalvm-23.0.0
@@ -1,3 +1,6 @@
+colorize 1 "TruffleRuby+GraalVM 23.0 and later installed by ruby-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)

--- a/share/ruby-build/truffleruby-23.0.0
+++ b/share/ruby-build/truffleruby-23.0.0
@@ -1,3 +1,6 @@
+colorize 1 "TruffleRuby 23.0 and later installed by ruby-build use the faster Oracle GraalVM distribution" && echo
+colorize 1 "Oracle GraalVM uses the GFTC license, which is free for development and production use, see https://medium.com/graalvm/161527df3d76" && echo
+
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)


### PR DESCRIPTION
Follow-up of https://github.com/rbenv/ruby-build/pull/2207, it seems best to be explicit about the change of distribution.