### PR TITLE
Display the actual error when testing for Ruby's openssl extension

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1243,7 +1243,7 @@ build_package_verify_openssl() {
       begin
         require lib
       rescue LoadError => e
-        $stderr.puts "There was a problem loading the Ruby #{lib} extension; make sure it compiled successfully.  (#{e})"
+        $stderr.puts "Loading the Ruby #{lib} extension failed (#{e})"
       end
     end
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1242,8 +1242,8 @@ build_package_verify_openssl() {
     failed = %w[openssl readline zlib yaml].reject do |lib|
       begin
         require lib
-      rescue LoadError
-        $stderr.puts "The Ruby #{lib} extension was not compiled."
+      rescue LoadError => e
+        $stderr.puts "The Ruby #{lib} extension was not compiled.  (#{e})"
       end
     end
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1243,7 +1243,7 @@ build_package_verify_openssl() {
       begin
         require lib
       rescue LoadError => e
-        $stderr.puts "The Ruby #{lib} extension was not compiled.  (#{e})"
+        $stderr.puts "There was a problem loading the Ruby #{lib} extension; make sure it compiled successfully.  (#{e})"
       end
     end
 


### PR DESCRIPTION
I was encountering some build issues on MicroOS and needed the actual exception message in order to pinpoint a workaround.