### PR TITLE
Show openssl version used from homebrew by default

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1153,7 +1153,7 @@ needs_openssl_102_300() {
 use_homebrew_openssl() {
   local ssldir="$(brew --prefix openssl@1.1 2>/dev/null || true)"
   if [ -d "$ssldir" ]; then
-    echo "ruby-build: using openssl from homebrew"
+    echo "ruby-build: using openssl@1.1 from homebrew"
     package_option ruby configure --with-openssl-dir="$ssldir"
   else
     colorize 1 "ERROR openssl@1.1 from Homebrew is required, run 'brew install openssl@1.1'"


### PR DESCRIPTION
Hello maintainers, 

Based on the request made by @sos4nt in the issue https://github.com/rbenv/ruby-build/issues/2224 I wanted to add the openssl version that is used by default by ruby-build. Printing it to the screen in the same way as the issue requester suggested, to the stdout. 

Let me know if you have any questions or concerns, it's my first PR to this project so all feedback is welcome!

Thanks