### PR TITLE
Avoid test failure when stubbing FreeBSD environment

### DIFF
--- a/test/build.bats
+++ b/test/build.bats
@@ -334,6 +334,7 @@ OUT
   stub_make_install
 
   export -n MAKE_OPTS
+  export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/test"
   run_inline_definition <<DEF
 install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
@@ -344,7 +345,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: --prefix=$INSTALL_ROOT --with-openssl-dir=/test
 make -j 1
 make install
 OUT


### PR DESCRIPTION
I think Linux actions runner images now have a `/usr/local/include/openssl/ssl.h` file, which triggers this condition:

```sh
if is_freebsd && [ -f /usr/local/include/openssl/ssl.h ]; then
  # use openssl installed from Ports Collection
  package_option ruby configure --with-openssl-dir="/usr/local"
fi
```

We can't stub the root filesystem, so instead use RUBY_CONFIGURE_OPTS to override this.

https://github.com/rbenv/ruby-build/actions/runs/5719870214/job/15517987944#step:4:18

/cc @hsbt https://github.com/rbenv/ruby-build/pull/2227