### PR TITLE
Remove `require_llvm` implementation

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -992,51 +992,9 @@ verify_gcc() {
   echo "$gcc"
 }
 
+# Kept for backward compatibility with 3rd-party Rubinius definitions.
 require_llvm() {
-  local llvm_version="$1"
-  if is_mac -ge 1010; then
-    if [[ "$RUBY_CONFIGURE_OPTS" != *--llvm-* ]]; then
-      case "$llvm_version" in
-      3.2 )
-        package_option ruby configure --prebuilt-name="llvm-3.2-x86_64-apple-darwin13.tar.bz2"
-        ;;
-      3.[56] )
-        local llvm_config="$(locate_llvm "$llvm_version")"
-        if [ -n "$llvm_config" ]; then
-          package_option ruby configure --llvm-config="$llvm_config"
-        else
-          local homebrew_package="llvm@$llvm_version"
-          { echo
-            colorize 1 "ERROR"
-            echo ": Rubinius will not be able to compile using Apple's LLVM-based "
-            echo "build tools on OS X. You will need to install LLVM $llvm_version first."
-            echo
-            colorize 1 "TO FIX THE PROBLEM"
-            echo ": Install Homebrew's llvm package with this"
-            echo -n "command: "
-            colorize 4 "brew install $homebrew_package"
-            echo
-          } >&3
-          return 1
-        fi
-        ;;
-      esac
-    fi
-  fi
-}
-
-locate_llvm() {
-  local llvm_version="$1"
-  local package llvm_config
-  shopt -s nullglob
-  for package in `brew list 2>/dev/null | grep "^llvm"`; do
-    llvm_config="$(echo "$(brew --prefix "$package")/bin/llvm-config"*)"
-    if [ -n "$llvm_config" ] && [[ "$("$llvm_config" --version)" = "$llvm_version"* ]]; then
-      echo "$llvm_config"
-      break
-    fi
-  done
-  shopt -u nullglob
+  local stub=1
 }
 
 needs_yaml() {

--- a/share/ruby-build/rbx-2.10
+++ b/share/ruby-build/rbx-2.10
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.10.tar.bz2#c8047557a3d8513e4b10c661014e22901a24ec0aad71f0f1ffd3a8b31d58e694" warn_eol rbx

--- a/share/ruby-build/rbx-2.11
+++ b/share/ruby-build/rbx-2.11
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.11.tar.bz2#5a9ce5c86a4a566a088f379cf2889aa14d8fcd8b2295d5571f61bf43a9548b97" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.10
+++ b/share/ruby-build/rbx-2.2.10
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.10" "https://github.com/rubinius/rubinius/releases/download/v2.2.10/rubinius-2.2.10.tar.bz2#3cb1a6ab2eba19b6dc84734666bb17a34332d247641b1a88b4c9324c69347780" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.2
+++ b/share/ruby-build/rbx-2.2.2
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.2" "https://github.com/rubinius/rubinius/releases/download/v2.2.2/rubinius-2.2.2.tar.bz2#a49d596f889405e4fc511da64b8afe5eccfafdcee5ea99be15d3ad36290ec2ba" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.3
+++ b/share/ruby-build/rbx-2.2.3
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.3" "https://github.com/rubinius/rubinius/releases/download/v2.2.3/rubinius-2.2.3.tar.bz2#b3426aa6996420f1d9d8a7926a94160b84d8bdf725793c64462b27b74f2f2acf" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.4
+++ b/share/ruby-build/rbx-2.2.4
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.4" "https://github.com/rubinius/rubinius/releases/download/v2.2.4/rubinius-2.2.4.tar.bz2#7d06d63d12d9eecff196d8f53953bd520c17fbb9baa921c5481c43af8129d85e" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.5
+++ b/share/ruby-build/rbx-2.2.5
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.5" "https://github.com/rubinius/rubinius/releases/download/v2.2.5/rubinius-2.2.5.tar.bz2#42cfae89d481dfa5e0ccb53a67720f109fc6c2e1b6ca68a8ae9676be6d0457de" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.6
+++ b/share/ruby-build/rbx-2.2.6
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.6" "https://github.com/rubinius/rubinius/releases/download/v2.2.6/rubinius-2.2.6.tar.bz2#8ad2cada05a20c708379c75607fd0c8259623b3699d36be41e509052164eb103" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.7
+++ b/share/ruby-build/rbx-2.2.7
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.7" "https://github.com/rubinius/rubinius/releases/download/v2.2.7/rubinius-2.2.7.tar.bz2#e1244b60ed790a3a33a7126a587c35acd041dcb2022b894833518490e872dc3d" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.8
+++ b/share/ruby-build/rbx-2.2.8
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.8" "https://github.com/rubinius/rubinius/releases/download/v2.2.8/rubinius-2.2.8.tar.bz2#dc29a67016eb6c7c2e3d0fd256594cf40d88f3b29989c0099fef2dcecf251fc8" warn_eol rbx

--- a/share/ruby-build/rbx-2.2.9
+++ b/share/ruby-build/rbx-2.2.9
@@ -1,2 +1,1 @@
-require_llvm 3.2
 install_package "rubinius-2.2.9" "https://github.com/rubinius/rubinius/releases/download/v2.2.9/rubinius-2.2.9.tar.bz2#7b01a7f2508167e73b5273b4e55e6616fc7fd975e79c84c4d2e3ef83d849d2ce" warn_eol rbx

--- a/share/ruby-build/rbx-2.3.0
+++ b/share/ruby-build/rbx-2.3.0
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.3.0" "https://github.com/rubinius/rubinius/releases/download/v2.3.0/rubinius-2.3.0.tar.bz2#9953c3af5e9694540859eaf55164a38d0c32c3ad35457e4351d20c28a25fecaa" warn_eol rbx

--- a/share/ruby-build/rbx-2.4.0
+++ b/share/ruby-build/rbx-2.4.0
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.4.0" "https://github.com/rubinius/rubinius/releases/download/v2.4.0/rubinius-2.4.0.tar.bz2#89390e8dd890ac4b8ad931e6277714e3d55560ee2f236b756bb4f83ee26eb9b0" warn_eol rbx

--- a/share/ruby-build/rbx-2.4.1
+++ b/share/ruby-build/rbx-2.4.1
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.4.1" "https://github.com/rubinius/rubinius/releases/download/v2.4.1/rubinius-2.4.1.tar.bz2#a5967afe9f9305c08f97a22dd210922c33be79b293fc346f617ff31f280f136e" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.0
+++ b/share/ruby-build/rbx-2.5.0
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.0" "https://github.com/rubinius/rubinius/releases/download/v2.5.0/rubinius-2.5.0.tar.bz2#9f14a47080e8f175afb94f6e600812115185c91f2e081f976262aea7804e4ceb" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.1
+++ b/share/ruby-build/rbx-2.5.1
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.1" "https://github.com/rubinius/rubinius/releases/download/v2.5.1/rubinius-2.5.1.tar.bz2#00d6f23b7632d035d322209e736a9341155350a9d169e8471d38a554a8e26600" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.2
+++ b/share/ruby-build/rbx-2.5.2
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.2" "https://github.com/rubinius/rubinius/releases/download/v2.5.2/rubinius-2.5.2.tar.bz2#1b077537224d4ff1f8c628e5bbe0621dc6f833bc2d67a03aa10173b72299a1a8" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.3
+++ b/share/ruby-build/rbx-2.5.3
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.3" "https://github.com/rubinius/rubinius/releases/download/v2.5.3/rubinius-2.5.3.tar.bz2#9af4d6e9d1e78a586579c86b9eb9a082cb863885d4a7cf33989d73280461e5fc" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.4
+++ b/share/ruby-build/rbx-2.5.4
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.4" "https://github.com/rubinius/rubinius/releases/download/v2.5.4/rubinius-2.5.4.tar.bz2#ed7104f6177dc2c5be346e5a7349118601d8b0b0a37eb76fa1a78da21b3fbcfc" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.5
+++ b/share/ruby-build/rbx-2.5.5
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.5" "https://github.com/rubinius/rubinius/releases/download/v2.5.5/rubinius-2.5.5.tar.bz2#217659849ca2c67322d24ce7167e760dc835f32a701ca6e558703914ca82d02f" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.6
+++ b/share/ruby-build/rbx-2.5.6
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.6" "https://github.com/rubinius/rubinius/releases/download/v2.5.6/rubinius-2.5.6.tar.bz2#a81f57c6a9d38122a974df1debd5dd7900cb9d4a5cd621b2105de716990f807a" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.7
+++ b/share/ruby-build/rbx-2.5.7
@@ -1,2 +1,1 @@
-require_llvm 3.5
 install_package "rubinius-2.5.7" "https://github.com/rubinius/rubinius/releases/download/v2.5.7/rubinius-2.5.7.tar.bz2#8ba8e75835e6df38453f6b6f65bdd296abee2df89ce488e6cc914059b6e1b385" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.8
+++ b/share/ruby-build/rbx-2.5.8
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.5.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.5.8.tar.bz2#d6b411732aa035865f2855845abe5405119560f0979062672d576601de89e59a" warn_eol rbx

--- a/share/ruby-build/rbx-2.6
+++ b/share/ruby-build/rbx-2.6
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.6.tar.bz2#f63bbcca7d1bc71b4c20a3bd5748430be001f3a39b14a903d3d4ca39a657cfe0" warn_eol rbx

--- a/share/ruby-build/rbx-2.7
+++ b/share/ruby-build/rbx-2.7
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.7.tar.bz2#6f121cccbbd5ad0183024bf2405ca627982d1890307c059c754a1847e19eadd1" warn_eol rbx

--- a/share/ruby-build/rbx-2.71828182
+++ b/share/ruby-build/rbx-2.71828182
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.71828182" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.71828182.tar.bz2" warn_eol rbx

--- a/share/ruby-build/rbx-2.8
+++ b/share/ruby-build/rbx-2.8
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.8.tar.bz2#93e798b4c79800d0543d8d78aa1066b4285af209ed9908c35e54260c13bc7e9d" warn_eol rbx

--- a/share/ruby-build/rbx-2.9
+++ b/share/ruby-build/rbx-2.9
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-2.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.9.tar.bz2#9f8ad067ce494d201dae359d132ddac275d0bd13315dc8fdd094c9aa661ce8b1" warn_eol rbx

--- a/share/ruby-build/rbx-3.0
+++ b/share/ruby-build/rbx-3.0
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.0.tar.bz2#fd4c9687af6e29939100610a231f13951ed763a9028c85878505f313857c43ca" warn_eol rbx

--- a/share/ruby-build/rbx-3.1
+++ b/share/ruby-build/rbx-3.1
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.1" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.1.tar.bz2#33e1b3b8e489a86f94de819fc478640150a4b1794c6a6ffe93d717fda6b610d8" warn_eol rbx

--- a/share/ruby-build/rbx-3.10
+++ b/share/ruby-build/rbx-3.10
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.10.tar.bz2#a5980628edf318c4142cd3f7c6b01d3b07b50387533056ea67d75a63af3a5054" warn_eol rbx

--- a/share/ruby-build/rbx-3.100
+++ b/share/ruby-build/rbx-3.100
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.100" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.100.tar.bz2#95f434cb034e732ecd075bc0b99540b54a5adfd0d8b8da7d5a0d4566bdcd8cce" warn_eol rbx

--- a/share/ruby-build/rbx-3.101
+++ b/share/ruby-build/rbx-3.101
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.101" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.101.tar.bz2#ce9861e569807c8db5de3dcbe093441a61de623d9df7c52de78891962c3f66e8" warn_eol rbx

--- a/share/ruby-build/rbx-3.102
+++ b/share/ruby-build/rbx-3.102
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.102" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.102.tar.bz2#82ecb66158d0a61dc2ed84fee8923c9fdb24d9c0ac0b6e6639e8e5e35ef82005" warn_eol rbx

--- a/share/ruby-build/rbx-3.103
+++ b/share/ruby-build/rbx-3.103
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.103" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.103.tar.bz2#5cc15e89005b1824bf6c4d62d66e4cbadafe8af29baf4cfd5a1c1ecc8df2d67a" warn_eol rbx

--- a/share/ruby-build/rbx-3.104
+++ b/share/ruby-build/rbx-3.104
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.104" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.104.tar.bz2#9ba016ce50e055d94345bb81a471408adb5b9dd04117e962bfa4ff2651af6461" warn_eol rbx

--- a/share/ruby-build/rbx-3.105
+++ b/share/ruby-build/rbx-3.105
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.105" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.105.tar.bz2#38261e40f9e1008c38ef3c0be968994430fc5ef31ecf411e4dd04fa9e2e009b3" warn_eol rbx

--- a/share/ruby-build/rbx-3.106
+++ b/share/ruby-build/rbx-3.106
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.106" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.106.tar.bz2#0c98afdc68c7ceecdc882674a1ee32aee75d76ca69aca44836ffa84a1b33afbd" warn_eol rbx

--- a/share/ruby-build/rbx-3.107
+++ b/share/ruby-build/rbx-3.107
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.107" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.107.tar.bz2#46d68cb26ce83fb503b25776770abad6a55ef03a14cd4fd05f44e17becb71589" warn_eol rbx

--- a/share/ruby-build/rbx-3.11
+++ b/share/ruby-build/rbx-3.11
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.11.tar.bz2#2e8bf15313440ec7c0315e5d3a387bf88c95518040073d78fcb7a044eaef162b" warn_eol rbx

--- a/share/ruby-build/rbx-3.12
+++ b/share/ruby-build/rbx-3.12
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.12" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.12.tar.bz2#bc955346e2dfface41c87adf432034b591eb81350905d5b503b501f36ee773c9" warn_eol rbx

--- a/share/ruby-build/rbx-3.13
+++ b/share/ruby-build/rbx-3.13
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.13" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.13.tar.bz2#a286b91150970a0116c843de5929c1e3c7a399943bd9f22f5fde25e67fa74368" warn_eol rbx

--- a/share/ruby-build/rbx-3.14
+++ b/share/ruby-build/rbx-3.14
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.14" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.14.tar.bz2#19043116e885c428041677f672f54480bba171da9d43f369d1c854cb794c8426" warn_eol rbx

--- a/share/ruby-build/rbx-3.15
+++ b/share/ruby-build/rbx-3.15
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.15" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.15.tar.bz2#86ce6c330843f1a4fa1217e37d8898e10b90673838b7a2867e4e4d6d65599cef" warn_eol rbx

--- a/share/ruby-build/rbx-3.16
+++ b/share/ruby-build/rbx-3.16
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.16" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.16.tar.bz2#1c34db3254e8304988b3c10591c11af058f371bee80fe3b559e6c16d84f4fa03" warn_eol rbx

--- a/share/ruby-build/rbx-3.17
+++ b/share/ruby-build/rbx-3.17
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.17" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.17.tar.bz2#bb76bc9613064f48d50f8323c2727002bb7dcb0ccf8813e69a366c603b7bc689" warn_eol rbx

--- a/share/ruby-build/rbx-3.18
+++ b/share/ruby-build/rbx-3.18
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.18" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.18.tar.bz2#c552a539f3f6b8f240a02cbe9926540a0c3ad95e0e341179963a43c64208ce3e" warn_eol rbx

--- a/share/ruby-build/rbx-3.19
+++ b/share/ruby-build/rbx-3.19
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.19" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.19.tar.bz2#cee948256bf288595b4ce53034f0dcd4ae2bc257acb2d43a63364dfc8e5db47c" warn_eol rbx

--- a/share/ruby-build/rbx-3.2
+++ b/share/ruby-build/rbx-3.2
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.2" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.2.tar.bz2#e9e906492900755425d29cbb650b0b5a39d1163fa692d6a33958e98a2e8ea156" warn_eol rbx

--- a/share/ruby-build/rbx-3.20
+++ b/share/ruby-build/rbx-3.20
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.20" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.20.tar.bz2#caf95bf55e5483e288b40c315ad7f2d4091823e33dcd57e9c6364c66c29a7ff2" warn_eol rbx

--- a/share/ruby-build/rbx-3.21
+++ b/share/ruby-build/rbx-3.21
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.21" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.21.tar.bz2#281195af772ef05f789404f0fb95838c5942591762191962bab22860022650ee" warn_eol rbx

--- a/share/ruby-build/rbx-3.22
+++ b/share/ruby-build/rbx-3.22
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.22" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.22.tar.bz2#90b9a69ab71cffdc4a0dd68aafebce5df1fcd79c2bc60ef78b44fccd160d341a" warn_eol rbx

--- a/share/ruby-build/rbx-3.23
+++ b/share/ruby-build/rbx-3.23
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.23" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.23.tar.bz2#bed25ca7c27629115768eb666adfcbb95d6f625e8666980e837ead5e13848b64" warn_eol rbx

--- a/share/ruby-build/rbx-3.24
+++ b/share/ruby-build/rbx-3.24
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.25" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.25.tar.bz2#9a1d1219acf34bab516e07a1b5ada3b54afd51ec25e87908fc0b6801db0c5d57" warn_eol rbx

--- a/share/ruby-build/rbx-3.25
+++ b/share/ruby-build/rbx-3.25
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.24" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.24.tar.bz2#7edf189283255d68b2a1d69e011cfebad0397743229fd50b08e21774ec8dab63" warn_eol rbx

--- a/share/ruby-build/rbx-3.26
+++ b/share/ruby-build/rbx-3.26
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.26" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.26.tar.bz2#10341c880eef73dda89cf8bcf5ae066b04683e40a3b1721d4d2733f32778819a" warn_eol rbx

--- a/share/ruby-build/rbx-3.27
+++ b/share/ruby-build/rbx-3.27
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.27" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.27.tar.bz2#4ede3d0adcfab77eb9ffb43eec1b6cbe63c32f326630b488e9c2382fa3a6db98" warn_eol rbx

--- a/share/ruby-build/rbx-3.28
+++ b/share/ruby-build/rbx-3.28
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.28" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.28.tar.bz2#7954146ee9284e038b3c524613478e2884d8a7a9df85de6c17e43177e41d842c" warn_eol rbx

--- a/share/ruby-build/rbx-3.29
+++ b/share/ruby-build/rbx-3.29
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.29" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.29.tar.bz2#6a8bf87ce26a6a05a80dd2ae40ac8c4e2c5153d4d2d913549a85d9aa32aaeee2" warn_eol rbx

--- a/share/ruby-build/rbx-3.3
+++ b/share/ruby-build/rbx-3.3
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.3" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.3.tar.bz2#3f592b1f5580f7075c7fdc72eee7c959dd4791d96d04de6a8d467529dcff72be" warn_eol rbx

--- a/share/ruby-build/rbx-3.30
+++ b/share/ruby-build/rbx-3.30
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.30" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.30.tar.bz2#5294f406679d41160abe46ec1ff14b76c4353a75756227cc691108bb57f4bd16" warn_eol rbx

--- a/share/ruby-build/rbx-3.31
+++ b/share/ruby-build/rbx-3.31
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.31" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.31.tar.bz2#1c7a7763ab7cf36ad6b2e328ff1d78fb6587721b8667f8598d15354d0704de72" warn_eol rbx

--- a/share/ruby-build/rbx-3.32
+++ b/share/ruby-build/rbx-3.32
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.32" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.32.tar.bz2#f88d6d277efe1f9774da1201ce4c8a8fd7cb2ea29620c1727a4471e3a0eed1dc" warn_eol rbx

--- a/share/ruby-build/rbx-3.33
+++ b/share/ruby-build/rbx-3.33
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.33" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.33.tar.bz2#1455940fc3a17b6efbb787c9316ff86a260187ebbaba6b32746dd27cebe14907" warn_eol rbx

--- a/share/ruby-build/rbx-3.34
+++ b/share/ruby-build/rbx-3.34
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.34" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.34.tar.bz2#90f5d5b53dbc6494b8a81ecd3569950b1d85d0c463dd537cab677fab82e2b300" warn_eol rbx

--- a/share/ruby-build/rbx-3.35
+++ b/share/ruby-build/rbx-3.35
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.35" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.35.tar.bz2#d72c8ec1a1cd6e1c77381e6d1e1d21811d71948a08f108d8a064884c379d2465" warn_eol rbx

--- a/share/ruby-build/rbx-3.36
+++ b/share/ruby-build/rbx-3.36
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.36" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.36.tar.bz2#660c6eaad9ab0ef3813942e906b14d1f02d071c6e25f60b9d6c8dfbab278b754" warn_eol rbx

--- a/share/ruby-build/rbx-3.37
+++ b/share/ruby-build/rbx-3.37
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.37" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.37.tar.bz2#85d855a0734c315d67b592675481458ddddac075426dbf6dc39a8ad34b8cb2d1" warn_eol rbx

--- a/share/ruby-build/rbx-3.38
+++ b/share/ruby-build/rbx-3.38
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.38" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.38.tar.bz2#2e038ee1e1dcee5b0d574cc446ad7bf2d98ea70ced35090f1680a90c6b9d6333" warn_eol rbx

--- a/share/ruby-build/rbx-3.39
+++ b/share/ruby-build/rbx-3.39
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.39" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.39.tar.bz2#f6f8132b44eadb4c07f8b26af16ce0a5470309ada33ef6f20ab76770a44193e0" warn_eol rbx

--- a/share/ruby-build/rbx-3.4
+++ b/share/ruby-build/rbx-3.4
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.4" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.4.tar.bz2#480a4f536bfdc7208b06bb40bef39944de7e1c770e9962f87c6900dec30155f8" warn_eol rbx

--- a/share/ruby-build/rbx-3.40
+++ b/share/ruby-build/rbx-3.40
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.40" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.40.tar.bz2#09f6590515bf6180427544fb217a34330a689784ea05b03f0a98db2a197bb20f" warn_eol rbx

--- a/share/ruby-build/rbx-3.41
+++ b/share/ruby-build/rbx-3.41
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.41" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.41.tar.bz2#b06966230e647aa0e5b64da14ba213256074c34f3bb8614be1ce81ef1434c41f" warn_eol rbx

--- a/share/ruby-build/rbx-3.42
+++ b/share/ruby-build/rbx-3.42
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.42" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.42.tar.bz2#4fc4413101100f6393894632eef522c2667a821856ac32eb99ccecab2aeeae85" warn_eol rbx

--- a/share/ruby-build/rbx-3.43
+++ b/share/ruby-build/rbx-3.43
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.43" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.43.tar.bz2#2c573257518774e464036515cc7283bc934a41566599afe94612c605844481ad" warn_eol rbx

--- a/share/ruby-build/rbx-3.44
+++ b/share/ruby-build/rbx-3.44
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.44" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.44.tar.bz2#c9e08b2e1d745798a0b32bef773e287361769c07a0eb9512377020661e2e4236" warn_eol rbx

--- a/share/ruby-build/rbx-3.45
+++ b/share/ruby-build/rbx-3.45
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.45" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.45.tar.bz2#5cadc3842c9c6d574bf5897354c384d8d688d9fa285b0d6083bdcc386bd6de96" warn_eol rbx

--- a/share/ruby-build/rbx-3.46
+++ b/share/ruby-build/rbx-3.46
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.46" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.46.tar.bz2#6bf24221ebd2c4d69e2388be1a3fa06d41009eeee00bfcdd86de8d57892d3fb2" warn_eol rbx

--- a/share/ruby-build/rbx-3.47
+++ b/share/ruby-build/rbx-3.47
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.47" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.47.tar.bz2#be734298ccad4dcadaa1f566d9655a971a4f12abc7629db045fd5c63e1685d16" warn_eol rbx

--- a/share/ruby-build/rbx-3.48
+++ b/share/ruby-build/rbx-3.48
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.48" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.48.tar.bz2#1180ea6a3de81bcd99c25b394fb05c010411bf4d3b48ee9881539b8043aeb561" warn_eol rbx

--- a/share/ruby-build/rbx-3.49
+++ b/share/ruby-build/rbx-3.49
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.49" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.49.tar.bz2#9a92d2cfede087e89f13f40e85e6c9cc9849041a0260144f44cd75aae67e3198" warn_eol rbx

--- a/share/ruby-build/rbx-3.5
+++ b/share/ruby-build/rbx-3.5
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.5" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.5.tar.bz2#13b0ce02d597f80c48ecc942b807368883e5cf3003bba2bc4957b3f1b368669e" warn_eol rbx

--- a/share/ruby-build/rbx-3.50
+++ b/share/ruby-build/rbx-3.50
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.50" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.50.tar.bz2#8da87cae447fe6bacd3417943bb1af603c2b4800bef0fc50ddd512ec89252ea8" warn_eol rbx

--- a/share/ruby-build/rbx-3.51
+++ b/share/ruby-build/rbx-3.51
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.51" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.51.tar.bz2#ded54018c6090dd0e051f7c3ffbb458ebdb5bcf77306a8b63d1bdeb73fb8c6f4" warn_eol rbx

--- a/share/ruby-build/rbx-3.52
+++ b/share/ruby-build/rbx-3.52
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.52" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.52.tar.bz2#657ed568ddc4a3155d05bc56ca6d327f960ec6098d03e1480b5c28936c70b5c5" warn_eol rbx

--- a/share/ruby-build/rbx-3.53
+++ b/share/ruby-build/rbx-3.53
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.53" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.53.tar.bz2#ec2efb7d026a41ef97cb9812961bf37803f3928f978e38f504cd2c09eae34f54" warn_eol rbx

--- a/share/ruby-build/rbx-3.54
+++ b/share/ruby-build/rbx-3.54
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.54" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.54.tar.bz2#2498a4c04feafba72d14c12e33ef881ae4bd8d3ccaa9bddcc8aec8acbad780fb" warn_eol rbx

--- a/share/ruby-build/rbx-3.55
+++ b/share/ruby-build/rbx-3.55
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.55" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.55.tar.bz2#fe7671beb3f36b987e02933afb392123b4c0a8ac15909a7b774d26101fec1ac1" warn_eol rbx

--- a/share/ruby-build/rbx-3.56
+++ b/share/ruby-build/rbx-3.56
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.56" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.56.tar.bz2#fa8170bc0eca01ebd83eb3a04240a0c7bd079ddf6ddc8b002167cff987db93b8" warn_eol rbx

--- a/share/ruby-build/rbx-3.57
+++ b/share/ruby-build/rbx-3.57
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.57" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.57.tar.bz2#c2bc550129ad306188458880240348892893d08af8e74e2dbdb5318f313762bd" warn_eol rbx

--- a/share/ruby-build/rbx-3.58
+++ b/share/ruby-build/rbx-3.58
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.58" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.58.tar.bz2#28875f1b9cb9b722323fa4217d9f3472e57a9ea6bd1fbc43a67eb47f81967cee" warn_eol rbx

--- a/share/ruby-build/rbx-3.59
+++ b/share/ruby-build/rbx-3.59
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.59" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.59.tar.bz2#feb65af7ff97ef44cab86790e3a67881cc0bc7389f01bfa10a9c2d62e9aadae7" warn_eol rbx

--- a/share/ruby-build/rbx-3.6
+++ b/share/ruby-build/rbx-3.6
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.6.tar.bz2#25b5913bba06511170e365643579ccfc193c1c4e74dbe6ea4b37dcabdcd8f6ad" warn_eol rbx

--- a/share/ruby-build/rbx-3.60
+++ b/share/ruby-build/rbx-3.60
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.60" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.60.tar.bz2#39f83fc74216391af56ea1ad13372878c0ed41fae49ee6a8cf8b0369a54c3b57" warn_eol rbx

--- a/share/ruby-build/rbx-3.61
+++ b/share/ruby-build/rbx-3.61
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.61" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.61.tar.bz2#38623cf198b1b0047b4c3404070252903b4da33c091be8708c205815d1516636" warn_eol rbx

--- a/share/ruby-build/rbx-3.62
+++ b/share/ruby-build/rbx-3.62
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.62" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.62.tar.bz2#1cc468a7967687a062c11e21bf6787cc60f6894590eabe3fc9be5e9af36a022f" warn_eol rbx

--- a/share/ruby-build/rbx-3.63
+++ b/share/ruby-build/rbx-3.63
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.63" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.63.tar.bz2#3003298b9d53620ad84d71a63be2a37b53dfdfe6c2fced9280a7f3b219f365d4" warn_eol rbx

--- a/share/ruby-build/rbx-3.64
+++ b/share/ruby-build/rbx-3.64
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.64" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.64.tar.bz2#43e2efd91074b52dc1d691e1424dbbb2e91bc9406b595dbb4753e9dd6001eedb" warn_eol rbx

--- a/share/ruby-build/rbx-3.65
+++ b/share/ruby-build/rbx-3.65
@@ -1,3 +1,2 @@
-require_llvm 3.6
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.65" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.65.tar.bz2#a4290b6cd1f332c90405bd421163658a2d91abf27c83ad3afe7dbbbd3628829a" warn_eol rbx

--- a/share/ruby-build/rbx-3.66
+++ b/share/ruby-build/rbx-3.66
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.66" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.66.tar.bz2#4bb237a1da1d52bc830bbe704bd4b995bbc07e50b558e460aff54d6bc309975e" warn_eol rbx

--- a/share/ruby-build/rbx-3.67
+++ b/share/ruby-build/rbx-3.67
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.67" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.67.tar.bz2#a5eedd6169f80df528ac73cf2ed9183e2f5a82a57ca0b2ae3962c26238427b87" warn_eol rbx

--- a/share/ruby-build/rbx-3.68
+++ b/share/ruby-build/rbx-3.68
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.68" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.68.tar.bz2#44f423a8557aa8fa383573638a94faaf3f9c587a771be267c60ed0c78784f567" warn_eol rbx

--- a/share/ruby-build/rbx-3.69
+++ b/share/ruby-build/rbx-3.69
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.69" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.69.tar.bz2#2dcde5cb7ba1e1664f6bf902cd866d2564985536a0908caeac2e4099b6b255b2" warn_eol rbx

--- a/share/ruby-build/rbx-3.7
+++ b/share/ruby-build/rbx-3.7
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.7.tar.bz2#fafcdc518b5b2440960d023203bedca133be4af62e1ef8be9ff37a2842438257" warn_eol rbx

--- a/share/ruby-build/rbx-3.70
+++ b/share/ruby-build/rbx-3.70
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.70" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.70.tar.bz2#e5b22ff6f19d7ac75d94e7503ae74c0bf9a3d249ce0e80480402cf7cbd2fea19" warn_eol rbx

--- a/share/ruby-build/rbx-3.71
+++ b/share/ruby-build/rbx-3.71
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.71" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.71.tar.bz2#77bfac38feea0f7d1ebecd7be5b6fac9cefe44d00ee5932ee7ba9d1f078080b8" warn_eol rbx

--- a/share/ruby-build/rbx-3.72
+++ b/share/ruby-build/rbx-3.72
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.72" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.72.tar.bz2#7dfd678536d49947e08a327eb3b96a00c49f6b4a3ee5d4b548f4840efef0726c" warn_eol rbx

--- a/share/ruby-build/rbx-3.73
+++ b/share/ruby-build/rbx-3.73
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.73" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.73.tar.bz2#4fea98d26df5a00185d5d92684ec04cf6a22ca8cf6e9b47c3895ba5e6f14ea1a" warn_eol rbx

--- a/share/ruby-build/rbx-3.74
+++ b/share/ruby-build/rbx-3.74
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.74" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.74.tar.bz2#8dae2c4e4b2361cdeafb39035f8b1b1bfe6387104f43ae6026cae3234793b8e5" warn_eol rbx

--- a/share/ruby-build/rbx-3.75
+++ b/share/ruby-build/rbx-3.75
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.75" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.75.tar.bz2#04cd1bc8fa021d569aac38cf98aeeb97f8324815f82d7ea1a0c963898c79e137" warn_eol rbx

--- a/share/ruby-build/rbx-3.76
+++ b/share/ruby-build/rbx-3.76
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.76" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.76.tar.bz2#1606d229ea611f3c271f0b579c839cea6a1b4b07ddea7b0c4d2d794146781589" warn_eol rbx

--- a/share/ruby-build/rbx-3.77
+++ b/share/ruby-build/rbx-3.77
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.77" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.77.tar.bz2#badaeb4129c64979fb37322cc1913effde17010db5f57398ab7409f3fb84360e" warn_eol rbx

--- a/share/ruby-build/rbx-3.78
+++ b/share/ruby-build/rbx-3.78
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.78" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.78.tar.bz2#d285d798226fa6d80db7fd5afc2ceb2860546378772beccab154b8b7612446c9" warn_eol rbx

--- a/share/ruby-build/rbx-3.79
+++ b/share/ruby-build/rbx-3.79
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.79" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.79.tar.bz2#514c5032a23bfc1ca2defce646cc3a740aa053dab37e0cb4fbba1d4f11a9c33a" warn_eol rbx

--- a/share/ruby-build/rbx-3.8
+++ b/share/ruby-build/rbx-3.8
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.8.tar.bz2#9a74316b1adf7535c4529741bd3b7e660b7fbdb01ab1c5e6deeed0fae09b811d" warn_eol rbx

--- a/share/ruby-build/rbx-3.80
+++ b/share/ruby-build/rbx-3.80
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.80" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.80.tar.bz2#8cda9123efac9c2bbe374368c4767ada7e28299a7c4c706c562b3d133f96c19e" warn_eol rbx

--- a/share/ruby-build/rbx-3.81
+++ b/share/ruby-build/rbx-3.81
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.81" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.81.tar.bz2#d8fffa145f1132bc2d1f17d9194f1b8fc6dffa0f3ff6c29b44e99378daeea807" warn_eol rbx

--- a/share/ruby-build/rbx-3.82
+++ b/share/ruby-build/rbx-3.82
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.82" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.82.tar.bz2#53abb85219980d7307a762660e1d509cd74beccbcf4d46979ddd0749e77a1401" warn_eol rbx

--- a/share/ruby-build/rbx-3.83
+++ b/share/ruby-build/rbx-3.83
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.83" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.83.tar.bz2#323d44321478aca7ccb8c5a76addc00df4aa90ec89a69a764e92fe77896669aa" warn_eol rbx

--- a/share/ruby-build/rbx-3.84
+++ b/share/ruby-build/rbx-3.84
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.84" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.84.tar.bz2#87eeaf24efd64bb06c4409814410a9154287dd889a976b70c474ef88992b279d" warn_eol rbx

--- a/share/ruby-build/rbx-3.85
+++ b/share/ruby-build/rbx-3.85
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.85" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.85.tar.bz2#18a55be0de6323847f946af43cedcc44277e62124c8140523b34776265a5c6e1" warn_eol rbx

--- a/share/ruby-build/rbx-3.86
+++ b/share/ruby-build/rbx-3.86
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.86" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.86.tar.bz2#cfb0650b937d109cf52c982f185ef247cc7a184dbb5f16c625d4827cef11f6fb" warn_eol rbx

--- a/share/ruby-build/rbx-3.87
+++ b/share/ruby-build/rbx-3.87
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.87" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.87.tar.bz2#53eb602a8635aef334142832ba3b81ee7ca58706643f5136f019cdae6f4431c2" warn_eol rbx

--- a/share/ruby-build/rbx-3.88
+++ b/share/ruby-build/rbx-3.88
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.88" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.88.tar.bz2#e1c11578256b072870cfe929edfcb5965f076ef7543a92c7d0e6cf4c22787fae" warn_eol rbx

--- a/share/ruby-build/rbx-3.89
+++ b/share/ruby-build/rbx-3.89
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.89" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.89.tar.bz2#6e48ecd3253137c9d958e762fe9f5e512b597ffbd7f44ddabc716f8d33ea7d71" warn_eol rbx

--- a/share/ruby-build/rbx-3.9
+++ b/share/ruby-build/rbx-3.9
@@ -1,3 +1,2 @@
-require_llvm 3.5
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.9.tar.bz2#de5a2238d90387143b8b63a52b7f036d408d7a84387347e56099d811c423bdf6" warn_eol rbx

--- a/share/ruby-build/rbx-3.90
+++ b/share/ruby-build/rbx-3.90
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.90" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.90.tar.bz2#f888910670ff2a9f913a66b18447ee3fab6a4ee424015e46e8c9e0dbb9c600d8" warn_eol rbx

--- a/share/ruby-build/rbx-3.91
+++ b/share/ruby-build/rbx-3.91
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.91" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.91.tar.bz2#9be8f94a322cd27c84f51e8075635ee7193e407ea0b37d6e297bea01dd2aa0a6" warn_eol rbx

--- a/share/ruby-build/rbx-3.92
+++ b/share/ruby-build/rbx-3.92
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.92" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.92.tar.bz2#a15196a33c3628aa5baff0613102973fe0e489583b2614f9dacc02ad33efe87b" warn_eol rbx

--- a/share/ruby-build/rbx-3.93
+++ b/share/ruby-build/rbx-3.93
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.93" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.93.tar.bz2#851a93d68727f41603dbafa498ffe37bcdf2e6c697ba07c7804062f6a07200a9" warn_eol rbx

--- a/share/ruby-build/rbx-3.94
+++ b/share/ruby-build/rbx-3.94
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.94" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.94.tar.bz2#bf82ab49248f0011ba89a36e1d6f45d37703398d03b0c379184e3276130f0861" warn_eol rbx

--- a/share/ruby-build/rbx-3.95
+++ b/share/ruby-build/rbx-3.95
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.95" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.95.tar.bz2#cb2f42645e5408c8017fe80975179ddc38357192193f16070120ee38a2891801" warn_eol rbx

--- a/share/ruby-build/rbx-3.96
+++ b/share/ruby-build/rbx-3.96
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.96" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.96.tar.bz2#78e077f9faa115da58c616f6f660875f85f44f6a3708560b61c294c53aec8f5c" warn_eol rbx

--- a/share/ruby-build/rbx-3.97
+++ b/share/ruby-build/rbx-3.97
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.97" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.97.tar.bz2#a47549474734cd64fb6d122966cfeb8bf46adba5cde2d1b85a9fa753f2668118" warn_eol rbx

--- a/share/ruby-build/rbx-3.98
+++ b/share/ruby-build/rbx-3.98
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.98" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.98.tar.bz2#e8230eed22818893ba4771f0c409104ccccf5b4b4102c9289d3c85a000d13f36" warn_eol rbx

--- a/share/ruby-build/rbx-3.99
+++ b/share/ruby-build/rbx-3.99
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-3.99" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.99.tar.bz2#56ed8edf91add5f497a68e5b11165db6640eb2d4effbb6453ab4b5e6b847b178" warn_eol rbx

--- a/share/ruby-build/rbx-4.0
+++ b/share/ruby-build/rbx-4.0
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.0.tar.bz2#6e58d8141c953dd60028538215fba486892550ea5d7cb580685d7044a276f731" warn_eol rbx

--- a/share/ruby-build/rbx-4.1
+++ b/share/ruby-build/rbx-4.1
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.1" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.1.tar.bz2#7c613286ee3f5ea908c2262b801f74c4732d203ea979bed3f584881e9adfa433" warn_eol rbx

--- a/share/ruby-build/rbx-4.10
+++ b/share/ruby-build/rbx-4.10
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.10.tar.bz2#2d719ed23162ba3c815c60aa9b516ed001987d723a9127a46943d83e88659620" warn_eol rbx

--- a/share/ruby-build/rbx-4.11
+++ b/share/ruby-build/rbx-4.11
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.11.tar.bz2#737138e8d09f83ac5e3e3c28bc9245e943f8bf1eb1386231cfd34f4f9df5cbda" warn_eol rbx

--- a/share/ruby-build/rbx-4.12
+++ b/share/ruby-build/rbx-4.12
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.12" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.12.tar.bz2#5f60e3f9f09b8660f5a9a4c99769b4f52e2081325824e068c06b2474beaa467a" warn_eol rbx

--- a/share/ruby-build/rbx-4.13
+++ b/share/ruby-build/rbx-4.13
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.13" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.13.tar.bz2#5c5b86d83e6403d80c52b1be6e38e6e582f823e53821757ca8e07606b15459b5" warn_eol rbx

--- a/share/ruby-build/rbx-4.14
+++ b/share/ruby-build/rbx-4.14
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.14" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.14.tar.bz2#8a4c1a4894faaa25625d7204605aca6d211028c1f6a74e4c6b46348a53669531" warn_eol rbx

--- a/share/ruby-build/rbx-4.15
+++ b/share/ruby-build/rbx-4.15
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.15" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.15.tar.bz2#2ecae57e09cc642d4aa2a081aee8a657b0aa29bd76266b888edfb03865a96286" warn_eol rbx

--- a/share/ruby-build/rbx-4.16
+++ b/share/ruby-build/rbx-4.16
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.16" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.16.tar.bz2#598d0f10645dcdf79d0b2302d7e76aff14755d57dced7939aa96ef2c7e454e0c" warn_eol rbx

--- a/share/ruby-build/rbx-4.18
+++ b/share/ruby-build/rbx-4.18
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.18" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.18.tar.bz2#4498d27dc77b20fa864b66bd2183c227398594a2178d92e6b3a135b991dec05f" warn_eol rbx

--- a/share/ruby-build/rbx-4.19
+++ b/share/ruby-build/rbx-4.19
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.19" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.19.tar.bz2#6b3a63edf2f04937ce92c1a94e68cf51680621dda3d9139a864999e78b620ace" warn_eol rbx

--- a/share/ruby-build/rbx-4.2
+++ b/share/ruby-build/rbx-4.2
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.2" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.2.tar.bz2#b9307a8e8f3348d066a0f5b9ab097b3428117f9c6d428ce6110f521c42b2227d" warn_eol rbx

--- a/share/ruby-build/rbx-4.20
+++ b/share/ruby-build/rbx-4.20
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.20" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.20.tar.bz2#2499826151950d8d657fe71b5666d58cf93b0c97b56dabc1e7ec35d263df9bbf" warn_eol rbx

--- a/share/ruby-build/rbx-4.3
+++ b/share/ruby-build/rbx-4.3
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.3" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.3.tar.bz2#9112096efad03fcab391392555c6226849bb318fe0b5645399d4e071c3f2f097" warn_eol rbx

--- a/share/ruby-build/rbx-4.4
+++ b/share/ruby-build/rbx-4.4
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.4" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.4.tar.bz2#1a7207564e11998866c2f99d75f6f03dd41567dae6433d37b312761883ba11c8" warn_eol rbx

--- a/share/ruby-build/rbx-4.5
+++ b/share/ruby-build/rbx-4.5
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.5" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.5.tar.bz2#1fe2261f41cd6edb44ca1ce03290e5631d0d2751cecf4d7999fa496bb68349dc" warn_eol rbx

--- a/share/ruby-build/rbx-4.6
+++ b/share/ruby-build/rbx-4.6
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.6.tar.bz2#57e93b206b9d9c630af03ef9cea9d18cba247f869f3d3d1db95afa6854011d2e" warn_eol rbx

--- a/share/ruby-build/rbx-4.7
+++ b/share/ruby-build/rbx-4.7
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.7.tar.bz2#52e105477c3d184aaee87c5bc0bae1c2218b757e069e0cff4c3ef788fa2305e8" warn_eol rbx

--- a/share/ruby-build/rbx-4.8
+++ b/share/ruby-build/rbx-4.8
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.8.tar.bz2#b99960bb89bcb9197ad8f1350cae715dd92029b9f89c8eaee1450f80fd38fc8e" warn_eol rbx

--- a/share/ruby-build/rbx-4.9
+++ b/share/ruby-build/rbx-4.9
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-4.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.9.tar.bz2#b8c183433a5788dc790643d14ac6c182742456f20686389291b3f0cdcceeaaa5" warn_eol rbx

--- a/share/ruby-build/rbx-5.0
+++ b/share/ruby-build/rbx-5.0
@@ -1,3 +1,2 @@
-require_llvm 3.7
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "rubinius-5.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-5.0.tar.bz2#c9e90e3ef2fb80714b09895611152024fecbb3f13955298fa63e57b1785e8ff0" warn_eol rbx


### PR DESCRIPTION
This was used by Rubinius over the years to ensure that a correct LLVM version was selected from the ones available on the system, but for recent Rubinius + LLVM 3.7 this function was a no-op anyway, and since Rubinius isn't an actively maintained project anymore, I don't feel strongly for keeping ruby-build workarounds that only help outdated Rubinius versions.

@brixen: Any concerns?