### PR TITLE
Remove `require_gcc` implementation

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -886,110 +886,14 @@ require_java() {
   return 1
 }
 
-# keep for backwards compatibility
+# Kept for backward compatibility with JRuby <= 9.1.17 definitions.
 require_java7() {
   require_java 7
 }
 
+# Kept for backward compatibility with 3rd-party Ruby definitions.
 require_gcc() {
-  local gcc="$(locate_gcc || true)"
-
-  if [ -z "$gcc" ]; then
-    { echo
-      colorize 1 "ERROR"
-      echo ": This package must be compiled with GCC, but ruby-build couldn't"
-      echo "find a suitable \`gcc\` executable on your system. Please install GCC"
-      echo "and try again."
-      echo
-
-      if is_mac; then
-        colorize 1 "DETAILS"
-        echo ": Apple no longer includes the official GCC compiler with Xcode"
-        echo "as of version 4.2. Instead, the \`gcc\` executable is a symlink to"
-        echo "\`llvm-gcc\`, a modified version of GCC which outputs LLVM bytecode."
-        echo
-        echo "For most programs the \`llvm-gcc\` compiler works fine. However,"
-        echo "versions of Ruby older than 1.9.3-p125 are incompatible with"
-        echo "\`llvm-gcc\`. To build older versions of Ruby you must have the official"
-        echo "GCC compiler installed on your system."
-        echo
-
-        colorize 1 "TO FIX THE PROBLEM"
-        if type brew &>/dev/null; then
-          echo ": Install Homebrew's GCC package with this"
-          echo -n "command: "
-          colorize 4 "brew install gcc@4.9"
-        else
-          echo ": Install the official GCC compiler using these"
-          echo -n "packages: "
-          colorize 4 "https://github.com/kennethreitz/osx-gcc-installer/downloads"
-        fi
-
-        echo
-        echo
-        echo "You will need to install the official GCC compiler to build older"
-        echo "versions of Ruby even if you have installed Apple's Command Line Tools"
-        echo "for Xcode package. The Command Line Tools for Xcode package only"
-        echo "includes \`llvm-gcc\`."
-      fi
-    } >&3
-    return 1
-  fi
-
-  export CC="$gcc"
-  if is_mac -ge 1010; then
-    export MACOSX_DEPLOYMENT_TARGET=10.9
-  fi
-}
-
-locate_gcc() {
-  local gcc gccs
-  IFS=: gccs=($(gccs_in_path))
-  IFS="$OLDIFS"
-
-  verify_gcc "$CC" ||
-  verify_gcc "$(command -v gcc || true)" || {
-    for gcc in "${gccs[@]}"; do
-      verify_gcc "$gcc" && break || true
-    done
-  }
-
-  return 1
-}
-
-gccs_in_path() {
-  local gcc path paths
-  local gccs=()
-  IFS=: paths=($PATH)
-  IFS="$OLDIFS"
-
-  shopt -s nullglob
-  for path in "${paths[@]}"; do
-    for gcc in "$path"/gcc-*; do
-      gccs["${#gccs[@]}"]="$gcc"
-    done
-  done
-  shopt -u nullglob
-
-  printf :%s "${gccs[@]}"
-}
-
-verify_gcc() {
-  local gcc="$1"
-  if [ -z "$gcc" ]; then
-    return 1
-  fi
-
-  local version="$("$gcc" --version 2>/dev/null || true)"
-  if [ -z "$version" ]; then
-    return 1
-  fi
-
-  if echo "$version" | grep LLVM >/dev/null; then
-    return 1
-  fi
-
-  echo "$gcc"
+  local stub=1
 }
 
 require_llvm() {
@@ -1487,19 +1391,6 @@ rm -f "$tmp_executable"
 if [ -n "$noexec" ]; then
   echo "ruby-build: TMPDIR=$TMP cannot hold executables (partition possibly mounted with \`noexec\`)" >&2
   exit 1
-fi
-
-# Apply following work around, if gcc is not installed.
-if [ -z "$(locate_gcc)" ]; then
-  # Work around warnings building Ruby 2.0 on Clang 2.x:
-  # pass -Wno-error=shorten-64-to-32 if the compiler accepts it.
-  #
-  # When we set CFLAGS, Ruby won't apply its default flags, though. Since clang
-  # builds 1.9.x and 2.x only, where -O3 is default, we can safely set that flag.
-  # Ensure it's the first flag since later flags take precedence.
-  if "${CC:-cc}" -x c /dev/null -E -Wno-error=shorten-64-to-32 &>/dev/null; then
-    RUBY_CFLAGS="-O3 -Wno-error=shorten-64-to-32 $RUBY_CFLAGS"
-  fi
 fi
 
 if [ -z "$MAKE" ]; then

--- a/share/ruby-build/1.8.5-p113
+++ b/share/ruby-build/1.8.5-p113
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.5-p113" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p113.tar.bz2#216600f9ad07648c501766a25069009c5c543010821da2ad916dd2ca808efd01" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p114
+++ b/share/ruby-build/1.8.5-p114
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.5-p114" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p114.tar.bz2#c503ae8eb47db72f78fb7a79fe1874ffef40a7094f7e803bacbf994a924244d9" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p115
+++ b/share/ruby-build/1.8.5-p115
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.5-p115" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p115.tar.bz2#3b5b799d6445b4ec8bc8b2944c6797dbd031b22e1756c9ae8b08c1f5d6cdc398" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p231
+++ b/share/ruby-build/1.8.5-p231
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.5-p231" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p231.tar.bz2#b31a8db0a3b538c28bca1c9b08a07eb55a39547fdaad00c045f073851019639c" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.5-p52
+++ b/share/ruby-build/1.8.5-p52
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.5-p52" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.5-p52.tar.bz2#17e4bde8e6fc93866774e66c556fe581104f5cdf162a07430a9e976e46915500" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6
+++ b/share/ruby-build/1.8.6
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2#0fc6ad0b31d8ec3997db2a56a2ac1c235283a3607abb876300fc711b3f8e3dd7" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p110
+++ b/share/ruby-build/1.8.6-p110
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p110" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p110.tar.bz2#88a8a63dae9219fa38faa6c308dbfc9ac9e9c15f6d8f6848c452b9c920183169" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p111
+++ b/share/ruby-build/1.8.6-p111
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p111" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p111.tar.bz2#85c694678313818a5083bcfd66ae389fc053b506d93b5ad46f3764981c120fbb" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p114
+++ b/share/ruby-build/1.8.6-p114
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p114" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p114.tar.bz2#4ac0d0271324c54525210f775e5fcc9a37e3d8a10b96d68cdfeeb361c6f64a63" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p230
+++ b/share/ruby-build/1.8.6-p230
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p230" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p230.tar.bz2#603708301fc3fd7ef1c47bb4a24d7799c26e28db08d69cda240adcbdbff514d7" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p286
+++ b/share/ruby-build/1.8.6-p286
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p286" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p286.tar.bz2#d800552900e1157bbeaae39a4c253683b2444820a5d1ba0a207a13cc469168b7" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p287
+++ b/share/ruby-build/1.8.6-p287
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p287" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p287.tar.bz2#ac15a1cb78c50ec9cc7e831616a143586bdd566bc865c6b769a0c47b3b3936ce" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p36
+++ b/share/ruby-build/1.8.6-p36
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p36" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p36.tar.bz2#a9b9715235580e1ba9248aeef5f9a8d329824b04d1b0af2a30ab74d3123c801c" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p368
+++ b/share/ruby-build/1.8.6-p368
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p368" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p368.tar.bz2#1bd398a125040261f8e9e74289277c82063aae174ada9f300d2bea0a42ccdcc1" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p369
+++ b/share/ruby-build/1.8.6-p369
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p369" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p369.tar.bz2#fb6974ab8a0de52511e846eacf113432b5227a867e3c9741d65775f162e13715" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p383
+++ b/share/ruby-build/1.8.6-p383
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p383" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.bz2#c39dd7e211cb7245d08d9a7a3d4fe0c7b9f796a4bed9f92fed500ad58bb53d1a" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p388
+++ b/share/ruby-build/1.8.6-p388
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p388" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p388.tar.bz2#8536b18413f2475698fa275b356daff6ceab5232bc503496f4afbee64e8b4abc" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p398
+++ b/share/ruby-build/1.8.6-p398
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p398" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p398.tar.bz2#9890c5eb899f19d5bca7b9b04bba597d14ec6627e992ee376143147c19e3990d" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p399
+++ b/share/ruby-build/1.8.6-p399
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p399" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p399.tar.bz2#20ca08aeefa21ca2581a9791f8f9ace3addc92bd978cf36f2f95c109085a50a7" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p420
+++ b/share/ruby-build/1.8.6-p420
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.6-p420" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.bz2#5ed3e6b9ebcb51baf59b8263788ec9ec8a65fbb82286d952dd3eb66e22d9a09f" warn_eol auto_tcltk standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.7
+++ b/share/ruby-build/1.8.7
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7.tar.bz2#65f2a862ba5e88bac7a78cff15bcb88d7534e741b51a1ffb79a0136c7041359a" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p160
+++ b/share/ruby-build/1.8.7-p160
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p160" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p160.tar.bz2#e524a086212d2142c03eb6b82cd602adcac9dcf8bf60049e89aa4ca69864984d" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p17
+++ b/share/ruby-build/1.8.7-p17
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p17" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p17.tar.bz2#f205c586764ffbd944b4ec6439bd08286e3e7b27bc9448e74949e76c63f6016b" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p173
+++ b/share/ruby-build/1.8.7-p173
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p173" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p173.tar.bz2#7cec49bc4afb82188ca4bdb5a0400ec7ede6bf0937af9dd6acaca4e54b8aa760" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p174
+++ b/share/ruby-build/1.8.7-p174
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p174" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p174.tar.bz2#203978b6db1cc77a79ff03d141d162f6f17d86c3574f76de9eae9d0c8cb920bc" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p22
+++ b/share/ruby-build/1.8.7-p22
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p22" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p22.tar.bz2#477968408e27d067ef56f552d7fc2a9e6f5cae2d1a72f17cd838ebf5e0d30149" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p248
+++ b/share/ruby-build/1.8.7-p248
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p248" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p248.tar.bz2#3d238c4cf0988797d33169ab05829f1a483194e7cacae4232f3a0e2cc01b6bfc" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p249
+++ b/share/ruby-build/1.8.7-p249
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p249" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.bz2#8b89448fc79df6862660e9f77e884f06c76da28f078d8edd2f17567a615f3af5" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p299
+++ b/share/ruby-build/1.8.7-p299
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p299" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p299.tar.bz2#3d8a1e4204f1fb69c9e9ffd637c7f7661a062fc2246c559f25fda5312cfd65d8" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p301
+++ b/share/ruby-build/1.8.7-p301
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p301" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p301.tar.bz2#6ddd929722d177240c52e9fafa637dae4d7f8a30825faabb33b1c5391b004029" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p302
+++ b/share/ruby-build/1.8.7-p302
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p302" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.bz2#3537cc81cc2378a2bc319cd16c4237ddee14a2839cfd1515b27dce108d061a68" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p330
+++ b/share/ruby-build/1.8.7-p330
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p330" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p330.tar.bz2#486c73b023b564c07e062e2e61114e81de970913b04fac6798d0fbe8b7723790" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p334
+++ b/share/ruby-build/1.8.7-p334
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p334" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.bz2#3e7f1a15fb2c205ac9eb0da804983b83bf8c0ffeb2f146d1eb9e0579ea2507da" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p352
+++ b/share/ruby-build/1.8.7-p352
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p352" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.bz2#9df4e9108387f7d24a6ab8950984d0c0f8cdbc1dad63194e744f1a176d1c5576" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p357
+++ b/share/ruby-build/1.8.7-p357
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p357" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.bz2#5c64b63a597b4cb545887364e1fd1e0601a7aeb545e576e74a6d8e88a2765a37" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p358
+++ b/share/ruby-build/1.8.7-p358
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p358" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.bz2#309ccd427e47ef41a70f96462bd3c2ef2e7911ce1b22432ab502f5bc6e949c1b" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p370
+++ b/share/ruby-build/1.8.7-p370
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p370" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.bz2#6359b03a1c8ba16630a96fcb5f972c7af15bd33b752e324cd87964224ab1fe31" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p371
+++ b/share/ruby-build/1.8.7-p371
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p371" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.bz2#2dd0e463cd82039beb75c9b9f4ee20bef5f5b5ff68527008e5aee61cfb3b55e1" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p373
+++ b/share/ruby-build/1.8.7-p373
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p373" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p373.tar.bz2#720029cb528a2d5a132bbff7f47413f0b731ecc558f68f613d319fa9442afcb5" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p374
+++ b/share/ruby-build/1.8.7-p374
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p374" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.bz2#b4e34703137f7bfb8761c4ea474f7438d6ccf440b3d35f39cc5e4d4e239c07e3" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p375
+++ b/share/ruby-build/1.8.7-p375
@@ -1,3 +1,2 @@
-require_gcc
 install_git "ruby-1.8.7-p375" "https://github.com/ruby/ruby.git" "dabc90361d1b71fcac4f606eb1eb1fa25c047fd9" warn_eol autoconf auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p71
+++ b/share/ruby-build/1.8.7-p71
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p71" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p71.tar.bz2#ce74802744b9dfcd77bdd365a1543d050a56d9b366ed5e7a9bf2df25028fd411" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p72
+++ b/share/ruby-build/1.8.7-p72
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-p72" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p72.tar.bz2#a8f8a28e286dd76747d8e97ea5cfe7a315eb896906ab8c8606d687d9f6f6146e" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview1
+++ b/share/ruby-build/1.8.7-preview1
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-preview1" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview1.tar.bz2#e432ab1ab9b4570c0b7fe5c0c2730de0fda4c49a47811ea3a9170a311cf110b9" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview2
+++ b/share/ruby-build/1.8.7-preview2
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-preview2" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview2.tar.bz2#d02c1d22bff5c8365aa4adb25387950c0b58206a18cb18afcc4f2bd9401997e5" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview3
+++ b/share/ruby-build/1.8.7-preview3
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-preview3" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview3.tar.bz2#a73649f8c595cae34dc74e0d6c8b74998cc708d26d7d7300b16254d876dc7fe0" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-preview4
+++ b/share/ruby-build/1.8.7-preview4
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-1.8.7-preview4" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-preview4.tar.bz2#9f81d584a5b1bda92d933c48a336edd0ce6818eaa3a4e95cab59a73c85a7b285" warn_eol auto_tcltk standard
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.9.0-0
+++ b/share/ruby-build/1.9.0-0
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.0-0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-0.tar.bz2#7995fdb2879cbb67b1ae4b5bbdf5460f70221598086f4e48e15fa5f48f2866e3" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-1
+++ b/share/ruby-build/1.9.0-1
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.0-1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-1.tar.bz2#88427424d6249c7544ddc53b31d871f1a6dce1dbded402cacc6306feb8d97f3b" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-2
+++ b/share/ruby-build/1.9.0-2
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.0-2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-2.tar.bz2#913d2bfd03e4285f61e3d343925ab8286ebfc5f7f4a7c861de7a160219cd1351" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-3
+++ b/share/ruby-build/1.9.0-3
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.0-3" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-3.tar.bz2#d5ca832db445e3251113c4027f2528d17e32ed9508d2dd507c469e546ad180db" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-4
+++ b/share/ruby-build/1.9.0-4
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.0-4" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-4.tar.bz2#09a91a60fba308a45ab8d3e691ec5ab279b36b646e75ad68d1d45679bdc4cbce" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.0-5
+++ b/share/ruby-build/1.9.0-5
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.0-5" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.0-5.tar.bz2#6641148785a8bd3b352c2f990e5b20c1bd244f61275150139671b9b84610d996" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p0
+++ b/share/ruby-build/1.9.1-p0
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p0.tar.bz2#de7d33aeabdba123404c21230142299ac1de88c944c9f3215b816e824dd33321" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p129
+++ b/share/ruby-build/1.9.1-p129
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p129" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p129.tar.bz2#cb730f035aec0e3ac104d23d27a79aa9625fdeb115dae2295de65355f449ce27" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p243
+++ b/share/ruby-build/1.9.1-p243
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p243" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p243.tar.bz2#39c9850841c0dd5d368f96b854f97c19b21eb28a02200f8b4e151f608092e687" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p376
+++ b/share/ruby-build/1.9.1-p376
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p376" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p376.tar.bz2#79164e647e23bb7c705195e0075ce6020c30dd5ec4f8c8a12a100fe0eb0d6783" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p378" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.bz2#649e623f77190990d990089a819bc4ee60e21816f682ec37cee98d43adb46e51" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p429
+++ b/share/ruby-build/1.9.1-p429
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p429.tar.bz2#e0b9471d77354628a8041068f45734eb2d99f5b5df08fe5a76d785d989a47bfb" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p430
+++ b/share/ruby-build/1.9.1-p430
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p430" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.bz2#8d5cc11d819e476fb651db783f714cc4100922f47447f7acdce87ed769cf9d97" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p431
+++ b/share/ruby-build/1.9.1-p431
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p431" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p431.tar.bz2#81a46c947cd0c3ab99bc727e1465dab334432df7fbbfd0acfc08cf7111eb0c6c" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-preview1
+++ b/share/ruby-build/1.9.1-preview1
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-preview1.tar.bz2#dc39000537d7c7528ef26af8e1c3a6215b30b6c579c615eaec7013513410456a" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-preview2
+++ b/share/ruby-build/1.9.1-preview2
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-preview2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-preview2.tar.bz2#2c419dc325c6a75fb7b961496c0dd54f2729e6e01730589c4fb06e34ddd7a7cc" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-rc1
+++ b/share/ruby-build/1.9.1-rc1
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc1.tar.bz2#35acfb6b8d9dd9159ef308ac763c629092cda2e8c9f41254e72a7b9fa454c27f" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-rc2
+++ b/share/ruby-build/1.9.1-rc2
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-rc2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-rc2.tar.bz2#acb5061123fa7170597e713ef773e21ddd9dd167f27aaae2c5440b5ec12df2ec" warn_eol standard
 install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.2-p0
+++ b/share/ruby-build/1.9.2-p0
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.bz2#e9710990ed8c2e794123aba509010471915fb13c27dae0118831d2001a9c8d3b" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p136
+++ b/share/ruby-build/1.9.2-p136
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p136" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p136.tar.bz2#33092509aad118f07f0483a3db1d4c5adaccf4bb0324cd43f44e3bd3dd1858cb" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p180
+++ b/share/ruby-build/1.9.2-p180
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.bz2#06520c4d4b4512d08000f7dfff11d1fabc1d458c3c289c76a2f1ddb7f5a03f4d" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.bz2#403b3093fbe8a08dc69c269753b8c6e7bd8f87fb79a7dd7d676913efe7642487" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p318
+++ b/share/ruby-build/1.9.2-p318
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.bz2#9fcd60aaa118c35ec41c7e9974f1d771b1e632315661fd60f907c21357b082ce" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p320
+++ b/share/ruby-build/1.9.2-p320
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.bz2#6777f865cfa21ffdc167fcc4a7da05cb13aab1bd9e59bfcda82c4b32f75e6b51" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p326
+++ b/share/ruby-build/1.9.2-p326
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_git "ruby-1.9.2-p326" "https://github.com/ruby/ruby.git" "2b93dbd8e7e3d71dc4cb4c7e381974176b134c5b" warn_eol autoconf standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p330
+++ b/share/ruby-build/1.9.2-p330
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p330" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.bz2#6d3487ea8a86ad0fa78a8535078ff3c7a91ca9f99eff0a6a08e66c6e6bf2040f" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-preview1
+++ b/share/ruby-build/1.9.2-preview1
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-preview1.tar.bz2#0681204e52207153250da80b3cc46812f94107807458a7d64b17554b6df71120" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-preview3
+++ b/share/ruby-build/1.9.2-preview3
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-preview3" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-preview3.tar.bz2#94aee45432fb1a4ce6c3c9c74d17d2efc4fe4ad278997a850d55e5ca901cf256" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-rc1
+++ b/share/ruby-build/1.9.2-rc1
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-rc1.tar.bz2#c2a680aa5472c8d04a71625afa2b0f75c030d3655a3063fe364cfda8b33c1480" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-rc2
+++ b/share/ruby-build/1.9.2-rc2
@@ -1,4 +1,3 @@
-require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-rc2" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-rc2.tar.bz2#692ebae991b104482dc9f0d220c1afb6b690a338b3b815aaa4f62954d2fa1b4a" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,4 +1,3 @@
-require_gcc
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.bz2#ca8ba4e564fc5f98b210a5784e43dfffef9471222849e46f8e848b37e9f38acf" warn_eol standard

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,3 @@
-require_gcc
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2#a15d7924d74a45ffe48d5421c5fc4ff83b7009676054fa5952b890711afef6fc" warn_eol standard

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,4 +1,3 @@
-require_gcc
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.bz2#951a8810086abca0e200f81767a518ee2730d6dc9b0cc2c7e3587dcfc3bf5fc8" warn_eol standard

--- a/share/ruby-build/ree-1.8.7-2011.03
+++ b/share/ruby-build/ree-1.8.7-2011.03
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-enterprise-1.8.7-2011.03" "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition/ruby-enterprise-1.8.7-2011.03.tar.gz#0c0ddbc43b3aef49686db27e761e55a23437f12e1f00b6fe55d94724637bff6b" warn_eol ree_installer
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2011.12
+++ b/share/ruby-build/ree-1.8.7-2011.12
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-enterprise-1.8.7-2011.12" "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition/ruby-enterprise-1.8.7-2011.12.tar.gz#9a8efc4befc136e17a1360de549aac9e79283c7238a13215350720e4393c5da2" warn_eol ree_installer
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2012.01
+++ b/share/ruby-build/ree-1.8.7-2012.01
@@ -1,3 +1,2 @@
-require_gcc
 install_package "ruby-enterprise-1.8.7-2012.01" "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition/ruby-enterprise-1.8.7-2012.01.tar.gz#c0c4779fc473fc9843c0008acfbae2e2bdf3472b454c7fe6ff0ac4139a691e65" warn_eol ree_installer
 install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2012.02
+++ b/share/ruby-build/ree-1.8.7-2012.02
@@ -1,2 +1,1 @@
-require_gcc
 install_package "ruby-enterprise-1.8.7-2012.02" "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rubyenterpriseedition/ruby-enterprise-1.8.7-2012.02.tar.gz#ecf4a6d4c96b547b3bf4b6be14e082ddaa781e83ad7f69437cd3169fb7576e42" warn_eol ree_installer

--- a/test/compiler.bats
+++ b/test/compiler.bats
@@ -7,58 +7,6 @@ export -n CFLAGS
 export -n CC
 export -n RUBY_CONFIGURE_OPTS
 
-@test "require_gcc on OS X 10.9" {
-  stub_repeated uname '-s : echo Darwin'
-  stub sw_vers '-productVersion : echo 10.9.5'
-  stub_repeated gcc '--version : echo 4.2.1'
-
-  run_inline_definition <<DEF
-require_gcc
-echo CC=\$CC
-echo MACOSX_DEPLOYMENT_TARGET=\${MACOSX_DEPLOYMENT_TARGET-no}
-DEF
-  assert_success
-  assert_output <<OUT
-CC=${TMP}/bin/gcc
-MACOSX_DEPLOYMENT_TARGET=no
-OUT
-
-  unstub uname
-  unstub sw_vers
-  unstub gcc
-}
-
-@test "require_gcc on OS X 10.10" {
-  stub_repeated uname '-s : echo Darwin'
-  stub sw_vers '-productVersion : echo 10.10'
-  stub_repeated gcc '--version : echo 4.2.1'
-
-  run_inline_definition <<DEF
-require_gcc
-echo CC=\$CC
-echo MACOSX_DEPLOYMENT_TARGET=\${MACOSX_DEPLOYMENT_TARGET-no}
-DEF
-  assert_success
-  assert_output <<OUT
-CC=${TMP}/bin/gcc
-MACOSX_DEPLOYMENT_TARGET=10.9
-OUT
-
-  unstub uname
-  unstub sw_vers
-  unstub gcc
-}
-
-@test "require_gcc silences warnings" {
-  stub gcc '--version : echo warning >&2; echo 4.2.1' '--version : echo warning >&2; echo 4.2.1'
-
-  run_inline_definition <<DEF
-require_gcc
-echo \$CC
-DEF
-  assert_success "${TMP}/bin/gcc"
-}
-
 @test "CC=clang by default on OS X 10.10" {
   mkdir -p "$INSTALL_ROOT"
   cd "$INSTALL_ROOT"


### PR DESCRIPTION
This was only used in Ruby versions < 1.9.3, which are now EOL.

This also removes a 11-years old workaround for building Ruby 2.0 with clang: 06d7994bcf0a32673e4e73027ee953063f034d5e. I'm guessing that the workaround isn't necessary anymore with modern Rubies and compilers, and in hopefully rare cases when it is, users can supply RUBY_CFLAGS themselves.