### PR TITLE
Use the TruffleRuby JVM Standalones for truffleruby+graalvm-dev

### DIFF
--- a/share/ruby-build/truffleruby+graalvm-dev
+++ b/share/ruby-build/truffleruby+graalvm-dev
@@ -1,18 +1,18 @@
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-community-java21-linux-amd64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-java-dev-linux-amd64.tar.gz" truffleruby
   ;;
 Linux-aarch64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-community-java21-linux-aarch64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-java-dev-linux-aarch64.tar.gz" truffleruby
   ;;
 Darwin-x86_64)
   use_homebrew_openssl
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-community-java21-darwin-amd64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-java-dev-macos-amd64.tar.gz" truffleruby
   ;;
 Darwin-arm64)
   use_homebrew_openssl
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/graalvm-community-java21-darwin-aarch64-dev.tar.gz" truffleruby_graalvm
+  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-java-dev-macos-aarch64.tar.gz" truffleruby
   ;;
 *)
   colorize 1 "Unsupported platform: $platform"


### PR DESCRIPTION
* In TruffleRuby 23.1+, the GraalVM Updater (`gu`) is no longer available in GraalVM, instead JVM Standalones and Maven artifacts are provided to replace `gu`.
* See https://github.com/oracle/graal/issues/6855