### PR TITLE
Add RUBY_BUILD_TARBALL_OVERRIDE to override the ruby tarball URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ The build process may be configured through the following environment variables:
 | `RUBY_BUILD_CURL_OPTS`          | Additional options to pass to `curl` for downloading.                                            |
 | `RUBY_BUILD_WGET_OPTS`          | Additional options to pass to `wget` for downloading.                                            |
 | `RUBY_BUILD_MIRROR_URL`         | Custom mirror URL root.                                                                          |
-| `RUBY_BUILD_MIRROR_PACKAGE_URL` | Custom complete mirror URL (e.g. http://mirror.example.com/package-1.0.0.tar.gz).                  |
+| `RUBY_BUILD_MIRROR_PACKAGE_URL` | Custom complete mirror URL (e.g. http://mirror.example.com/package-1.0.0.tar.gz).                |
 | `RUBY_BUILD_SKIP_MIRROR`        | Bypass the download mirror and fetch all package files from their original URLs.                 |
 | `RUBY_BUILD_ROOT`               | Custom build definition directory. (Default: `share/ruby-build`)                                 |
+| `RUBY_BUILD_TARBALL_OVERRIDE`   | Override the URL to fetch the ruby tarball from, optionally followed by `#checksum`.             |
 | `RUBY_BUILD_DEFINITIONS`        | Additional paths to search for build definitions. (Colon-separated list)                         |
 | `CC`                            | Path to the C compiler.                                                                          |
 | `RUBY_CFLAGS`                   | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -381,6 +381,10 @@ fetch_tarball() {
   local checksum
   local extracted_dir
 
+  if is_ruby_package "$1" && [ -n "$RUBY_BUILD_TARBALL_OVERRIDE" ]; then
+    package_url="$RUBY_BUILD_TARBALL_OVERRIDE"
+  fi
+
   if [ "$package_url" != "${package_url/\#}" ]; then
     checksum="${package_url#*#}"
     package_url="${package_url%%#*}"
@@ -1257,14 +1261,23 @@ isolated_gem_install() {
 
 apply_ruby_patch() {
   local patchfile
-  case "$1" in
-  ruby-* | jruby-* | rubinius-* | truffleruby-* )
+  if is_ruby_package "$1"; then
     patchfile="$(mktemp "${TMP}/ruby-patch.XXXXXX")"
     cat "${2:--}" >"$patchfile"
 
     local striplevel=0
     grep -q '^--- a/' "$patchfile" && striplevel=1
     patch -p$striplevel --force -i "$patchfile"
+  fi
+}
+
+is_ruby_package() {
+  case "$1" in
+  ruby-* | jruby-* | rubinius-* | truffleruby[+-]* | mruby-* | picoruby-* )
+    return 0
+    ;;
+  *)
+    return 1
     ;;
   esac
 }


### PR DESCRIPTION
* And add RUBY_BUILD_IGNORE_CHECKSUM when it is expected the alternative URL has different contents.

This is useful for instance when testing a truffleruby release which is not published yet.
Then I need to use a custom URL, like:
```
RUBY_BUILD_MIRROR_PACKAGE_URL=https://github.com/my/url.tar.gz ruby-build truffleruby-23.1.0 ~/.rubies/truffleruby-test
```
I also want this to try dev builds at a different URL, hence this change.
(and those might have a different checksum too, see below)

And finally I would also like a way to skip the checksum check, for instance when trying a variant of a release which therefore has a different URL and contents but yet I want to reuse the existing definition.
For example this can be useful if I want to try the CE build instead of GFTC build of truffleruby 23.1.0, like this:
```
RUBY_BUILD_IGNORE_CHECKSUM=1 RUBY_BUILD_MIRROR_PACKAGE_URL=https://github.com/oracle/truffleruby/releases/download/graal-23.1.0/truffleruby-community-23.1.0-linux-amd64.tar.gz ruby-build truffleruby-23.1.0 ~/.rubies/truffleruby-test
```