### PR TITLE
Set default MAKE=make on FreeBSD

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1357,12 +1357,8 @@ if [ -n "$noexec" ]; then
 fi
 
 if [ -z "$MAKE" ]; then
-  if is_freebsd; then
-    # Workaround for Ruby bug 16331: https://bugs.ruby-lang.org/issues/16331
-    # Due to this bug, build will fail with FreeBSD's make after #1368
-    # The bug is already fixed in upstream but GNU make is still required
-    # when building older releases of Ruby. Use GNU make rather than switching
-    # depending of Ruby version.
+  if is_freebsd && echo "$1" | grep -q "^jruby-"; then
+    # jruby-launcher requires gmake
     export MAKE="gmake"
   else
     export MAKE="make"

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1357,8 +1357,8 @@ if [ -n "$noexec" ]; then
 fi
 
 if [ -z "$MAKE" ]; then
-  if is_freebsd && echo "$1" | grep -q "^jruby-"; then
-    # jruby-launcher requires gmake
+  if is_freebsd && [[ $1 == jruby-* ]]; then
+    # jruby-launcher requires gmake: https://github.com/ruby/ruby/pull/8591
     export MAKE="gmake"
   else
     export MAKE="make"

--- a/test/build.bats
+++ b/test/build.bats
@@ -404,19 +404,6 @@ OUT
   assert [ -x ./here/bin/package ]
 }
 
-@test "make on FreeBSD defaults to gmake" {
-  cached_tarball "ruby-2.0.0"
-
-  stub_repeated uname "-s : echo FreeBSD"
-  MAKE=gmake stub_make_install
-
-  MAKE= install_fixture definitions/vanilla-ruby
-  assert_success
-
-  unstub gmake
-  unstub uname
-}
-
 @test "can use RUBY_CONFIGURE to apply a patch" {
   cached_tarball "ruby-2.0.0"
 


### PR DESCRIPTION
This was set to gmake in https://github.com/rbenv/ruby-build/pull/1381 as a workaround for https://bugs.ruby-lang.org/issues/16331

YJIT builds in Ruby 3.3 previews require the use of BSD make on these platforms, and no supported version of MRI requires the use of gmake, so revert this.

JRuby continues to require gmake for jruby-launcher.