### PR TITLE
Pass ruby configuration flags on the command line

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -221,9 +221,12 @@ cleanup() {
 
 trap cleanup SIGINT
 
+build_args=(${KEEP:+--keep} ${VERBOSE:+--verbose} ${HAS_PATCH:+--patch} "$DEFINITION" "$PREFIX")
+[ ${#EXTRA_ARGUMENTS[@]} -eq 0 ] || build_args+=(-- "${EXTRA_ARGUMENTS[@]}")
+
 # Invoke `ruby-build` and record the exit status in $STATUS.
 STATUS=0
-ruby-build $KEEP $VERBOSE $HAS_PATCH "$DEFINITION" "$PREFIX" || STATUS="$?"
+ruby-build "${build_args[@]}" || STATUS="$?"
 
 # Display a more helpful message if the definition wasn't found.
 if [ "$STATUS" == "2" ]; then

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1268,6 +1268,7 @@ unset KEEP_BUILD_PATH
 unset HAS_PATCH
 unset IPV4
 unset IPV6
+unset EARLY_EXIT
 
 RUBY_BUILD_INSTALL_PREFIX="$(abs_dirname "$0")/.."
 
@@ -1279,17 +1280,13 @@ parse_options "$@"
 for option in "${OPTIONS[@]}"; do
   case "$option" in
   "h" | "help" )
-    version
-    echo
-    usage 0
+    EARLY_EXIT=help
     ;;
   "definitions" )
-    list_definitions
-    exit 0
+    EARLY_EXIT=list_definitions
     ;;
   "l" | "list")
-    list_maintained_versions
-    exit 0
+    EARLY_EXIT=list_maintained_versions
     ;;
   "k" | "keep" )
     KEEP_BUILD_PATH=true
@@ -1307,18 +1304,57 @@ for option in "${OPTIONS[@]}"; do
     IPV6=true
     ;;
   "version" )
-    version
-    exit 0
+    EARLY_EXIT=version
+    ;;
+  * )
+    printf "ruby-build: invalid flag '%s'\n" "$option" >&2
+    EARLY_EXIT=usage_error
     ;;
   esac
 done
 
-[ "${#ARGUMENTS[@]}" -eq 2 ] || usage 1 >&2
-
 DEFINITION_PATH="${ARGUMENTS[0]}"
-if [ -z "$DEFINITION_PATH" ]; then
+PREFIX_PATH="${ARGUMENTS[1]}"
+
+if [ -z "$EARLY_EXIT" ] && [ -z "$DEFINITION_PATH" ]; then
+  echo "ruby-build: missing definition argument" >&2
+  EARLY_EXIT=usage_error
+fi
+
+if [ -z "$EARLY_EXIT" ] && [ -z "$PREFIX_PATH" ]; then
+  echo "ruby-build: missing prefix argument" >&2
+  EARLY_EXIT=usage_error
+fi
+
+if [ "${#ARGUMENTS[@]}" -gt 2 ]; then
+  echo "ruby-build: expected at most 2 arguments, got [${ARGUMENTS[*]}]" >&2
+  EARLY_EXIT=usage_error
+fi
+
+case "$EARLY_EXIT" in
+help )
+  version
+  echo
+  usage 0
+  ;;
+version | list_definitions | list_maintained_versions )
+  "$EARLY_EXIT"
+  exit 0
+  ;;
+usage_error )
+  echo >&2
   usage 1 >&2
-elif [ ! -f "$DEFINITION_PATH" ]; then
+  ;;
+'' )
+  ;;
+* )
+  echo "unimplemented EARLY_EXIT: $EARLY_EXIT" >&2
+  exit 1
+  ;;
+esac
+
+# expand the <definition> argument to full path of the definition file
+if [ ! -f "$DEFINITION_PATH" ]; then
   for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
     if [ -f "${DEFINITION_DIR}/${DEFINITION_PATH}" ]; then
       DEFINITION_PATH="${DEFINITION_DIR}/${DEFINITION_PATH}"
@@ -1332,10 +1368,8 @@ elif [ ! -f "$DEFINITION_PATH" ]; then
   fi
 fi
 
-PREFIX_PATH="${ARGUMENTS[1]}"
-if [ -z "$PREFIX_PATH" ]; then
-  usage 1 >&2
-elif [ "${PREFIX_PATH#/}" = "$PREFIX_PATH" ]; then
+# normalize the <prefix> argument
+if [ "${PREFIX_PATH#/}" = "$PREFIX_PATH" ]; then
   PREFIX_PATH="${PWD}/${PREFIX_PATH}"
 fi
 
@@ -1366,7 +1400,7 @@ if [ -n "$noexec" ]; then
 fi
 
 if [ -z "$MAKE" ]; then
-  if is_freebsd && [[ $1 == jruby-* ]]; then
+  if is_freebsd && [[ ${ARGUMENTS[0]} == jruby-* ]]; then
     # jruby-launcher requires gmake: https://github.com/ruby/ruby/pull/8591
     export MAKE="gmake"
   else

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1331,6 +1331,10 @@ if [ "${#ARGUMENTS[@]}" -gt 2 ]; then
   EARLY_EXIT=usage_error
 fi
 
+if [ "${#EXTRA_ARGUMENTS[@]}" -gt 0 ]; then
+  RUBY_CONFIGURE_OPTS_ARRAY=("${EXTRA_ARGUMENTS[@]}")
+fi
+
 case "$EARLY_EXIT" in
 help )
   version

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -26,10 +26,15 @@ lib() {
   parse_options() {
     OPTIONS=()
     ARGUMENTS=()
+    EXTRA_ARGUMENTS=()
     local arg option index
 
-    for arg in "$@"; do
-      if [ "${arg:0:1}" = "-" ]; then
+    while [ $# -gt 0 ]; do
+      arg="$1"
+      if [ "$arg" == "--" ]; then
+        shift 1
+        break
+      elif [ "${arg:0:1}" = "-" ]; then
         if [ "${arg:1:1}" = "-" ]; then
           OPTIONS[${#OPTIONS[*]}]="${arg:2}"
         else
@@ -40,10 +45,14 @@ lib() {
             index=$(($index+1))
           done
         fi
+        shift 1
       else
         ARGUMENTS[${#ARGUMENTS[*]}]="$arg"
+        shift 1
       fi
     done
+
+    EXTRA_ARGUMENTS=("$@")
   }
 
   if [ "$1" == "--$FUNCNAME" ]; then

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -529,6 +529,7 @@ build_package() {
 package_option() {
   local package_name="$1"
   local command_name="$2"
+  # e.g. RUBY_CONFIGURE_OPTS_ARRAY, OPENSSL_MAKE_OPTS_ARRAY
   local variable="$(capitalize "${package_name}_${command_name}")_OPTS_ARRAY"
   local array="$variable[@]"
   shift 2
@@ -650,18 +651,18 @@ build_package_ruby() {
 build_package_ree_installer() {
   build_package_auto_tcltk
 
-  local options=""
-  is_mac && options="--no-tcmalloc"
+  local options=()
+  is_mac && options+=(--no-tcmalloc)
 
   local option
-  for option in ${RUBY_CONFIGURE_OPTS_ARRAY[@]} $RUBY_CONFIGURE_OPTS; do
-    options="$options -c $option"
+  for option in "${RUBY_CONFIGURE_OPTS_ARRAY[@]}" $RUBY_CONFIGURE_OPTS; do
+    options+=(-c "$option")
   done
 
   # Work around install_useful_libraries crash with --dont-install-useful-gems
   mkdir -p "$PREFIX_PATH/lib/ruby/gems/1.8/gems"
 
-  { ./installer --auto "$PREFIX_PATH" --dont-install-useful-gems $options $CONFIGURE_OPTS
+  { ./installer --auto "$PREFIX_PATH" --dont-install-useful-gems "${options[@]}" $CONFIGURE_OPTS
   } >&4 2>&1
 }
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -35,7 +35,8 @@ tarball() {
 
   executable "$configure" <<OUT
 #!$BASH
-echo "$name: \$@" \${RUBYOPT:+RUBYOPT=\$RUBYOPT} >> build.log
+IFS=,
+echo "$name: [\$*]" \${RUBYOPT:+RUBYOPT=\$RUBYOPT} >> build.log
 OUT
 
   for file; do
@@ -48,8 +49,8 @@ OUT
 
 stub_make_install() {
   stub "$MAKE" \
-    " : echo \"$MAKE \$@\" >> build.log" \
-    "install : echo \"$MAKE \$@\" >> build.log && cat build.log >> '$INSTALL_ROOT/build.log'"
+    " : echo \"$MAKE \$(inspect_args \"\$@\")\" >> build.log" \
+    "install : echo \"$MAKE \$(inspect_args \"\$@\")\" >> build.log && cat build.log >> '$INSTALL_ROOT/build.log'"
 }
 
 assert_build_log() {
@@ -74,10 +75,10 @@ assert_build_log() {
   unstub make
 
   assert_build_log <<OUT
-yaml-0.1.6: --prefix=$INSTALL_ROOT
+yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 OUT
@@ -106,11 +107,11 @@ PATCH
   unstub patch
 
   assert_build_log <<OUT
-yaml-0.1.6: --prefix=$INSTALL_ROOT
+yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 patch -p0 --force -i $TMP/ruby-patch.XXX
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 OUT
@@ -139,11 +140,11 @@ PATCH
   unstub patch
 
   assert_build_log <<OUT
-yaml-0.1.6: --prefix=$INSTALL_ROOT
+yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 patch -p1 --force -i $TMP/ruby-patch.XXX
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 OUT
@@ -173,11 +174,11 @@ PATCH
   unstub patch
 
   assert_build_log <<OUT
-yaml-0.1.6: --prefix=$INSTALL_ROOT
+yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 patch -p1 --force -i $TMP/ruby-patch.XXX
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 OUT
@@ -203,7 +204,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT --with-libyaml-dir=$brew_libdir
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-libyaml-dir=$brew_libdir]
 make -j 2
 make install
 OUT
@@ -227,7 +228,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT --with-gmp-dir=$gmp_libdir
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-gmp-dir=$gmp_libdir]
 make -j 2
 make install
 OUT
@@ -251,7 +252,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT --with-readline-dir=$readline_libdir
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-readline-dir=$readline_libdir]
 make -j 2
 make install
 OUT
@@ -273,7 +274,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT --with-readline-dir=/custom
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-readline-dir=/custom]
 make -j 2
 make install
 OUT
@@ -296,7 +297,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 OUT
@@ -320,7 +321,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 4
 make install
 OUT
@@ -345,19 +346,20 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT --with-openssl-dir=/test
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=/test]
 make -j 1
 make install
 OUT
 }
 
-@test "setting RUBY_MAKE_INSTALL_OPTS to a multi-word string" {
+@test "using MAKE_INSTALL_OPTS" {
   cached_tarball "ruby-2.0.0"
 
   stub_repeated uname '-s : echo Linux'
   stub_make_install
 
-  export RUBY_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
+  export MAKE_INSTALL_OPTS="--globalmake"
+  export RUBY_MAKE_INSTALL_OPTS="RUBYMAKE=true with spaces"
   run_inline_definition <<DEF
 install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
@@ -367,31 +369,9 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 2
-make install DOGE="such wow"
-OUT
-}
-
-@test "setting MAKE_INSTALL_OPTS to a multi-word string" {
-  cached_tarball "ruby-2.0.0"
-
-  stub_repeated uname '-s : echo Linux'
-  stub_make_install
-
-  export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
-  run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
-DEF
-  assert_success
-
-  unstub uname
-  unstub make
-
-  assert_build_log <<OUT
-ruby-2.0.0: --prefix=$INSTALL_ROOT
-make -j 2
-make install DOGE="such wow"
+make install --globalmake RUBYMAKE=true with spaces
 OUT
 }
 
@@ -429,7 +409,7 @@ DEF
 
   assert_build_log <<OUT
 apply -p1 -i /my/patch.diff
-ruby-2.0.0: --prefix=$INSTALL_ROOT
+ruby-2.0.0: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 OUT
@@ -454,7 +434,8 @@ OUT
   executable "$package/minirake" <<OUT
 #!$BASH
 set -e
-echo \$0 "\$@" >> '$INSTALL_ROOT'/build.log
+IFS=,
+echo "\$0 [\$*]" >> '$INSTALL_ROOT'/build.log
 mkdir -p build/host/bin
 touch build/host/bin/{mruby,mirb}
 chmod +x build/host/bin/{mruby,mirb}
@@ -477,7 +458,7 @@ install_package "mruby-1.0" "http://ruby-lang.org/pub/mruby-1.0.tar.gz" mruby
 DEF
   assert_success
   assert_build_log <<OUT
-./minirake
+./minirake []
 OUT
 
   assert [ -w "$INSTALL_ROOT/bin/mruby" ]
@@ -506,7 +487,7 @@ DEF
 
   assert_build_log <<OUT
 bundle --path=vendor/bundle
-rubinius-2.0.0: --prefix=$INSTALL_ROOT RUBYOPT=-rrubygems
+rubinius-2.0.0: [--prefix=$INSTALL_ROOT] RUBYOPT=-rrubygems 
 bundle exec rake install
 OUT
 }
@@ -562,7 +543,8 @@ OUT
 @test "JRuby build" {
   executable "${RUBY_BUILD_CACHE_PATH}/jruby-1.7.9/bin/jruby" <<OUT
 #!${BASH}
-echo jruby "\$@" >> ../build.log
+IFS=,
+echo "jruby [\$*]" >> ../build.log
 OUT
   executable "${RUBY_BUILD_CACHE_PATH}/jruby-1.7.9/bin/gem" <<OUT
 #!/usr/bin/env jruby
@@ -576,8 +558,8 @@ DEF
   assert_success
 
   assert_build_log <<OUT
-jruby -e puts JRUBY_VERSION
-jruby gem install jruby-launcher
+jruby [-e,puts JRUBY_VERSION]
+jruby [gem,install,jruby-launcher]
 OUT
 
   run ls "${INSTALL_ROOT}/bin"

--- a/test/compiler.bats
+++ b/test/compiler.bats
@@ -14,7 +14,7 @@ export -n RUBY_CONFIGURE_OPTS
   stub_repeated uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
   stub_repeated brew 'false'
-  stub_repeated make 'echo make $@'
+  stub_repeated make 'echo "make $(inspect_args "$@")"'
 
   cat > ./configure <<CON
 #!${BASH}

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -26,6 +26,17 @@ stub_ruby_build() {
   unstub rbenv-rehash
 }
 
+@test "install with flags" {
+  stub_ruby_build 'echo "ruby-build $(inspect_args "$@")"'
+
+  run rbenv-install -kpv 2.1.2 -- --with-configure-opt="hello world"
+  assert_success "ruby-build --keep --verbose --patch 2.1.2 ${RBENV_ROOT}/versions/2.1.2 -- \"--with-configure-opt=hello world\""
+
+  unstub ruby-build
+  unstub rbenv-hooks
+  unstub rbenv-rehash
+}
+
 @test "suggest running rbenv global after install" {
   rm -rf "$RBENV_ROOT/version"
   stub_ruby_build 'echo ruby-build "$@"'

--- a/test/stubs/stub
+++ b/test/stubs/stub
@@ -27,6 +27,21 @@ eval "${_STUB_INDEX}"=1
 eval "${_STUB_RESULT}"=0
 [ ! -e "${!_STUB_RUN}" ] || source "${!_STUB_RUN}"
 
+# Expose this for stub scripts.
+inspect_args() {
+  local arg
+  local sep=''
+  for arg; do
+    if [[ $arg == *' '* ]]; then
+      printf '%s"%s"' "$sep" "${arg//\"/\\\"}"
+    elif [[ $arg == *'"'* ]]; then
+      printf "%s'%s'" "$sep" "$arg"
+    else
+      printf '%s%s' "$sep" "$arg"
+    fi
+    sep=" "
+  done
+}
 
 # Loop over each line in the plan.
 index=0


### PR DESCRIPTION
Previously, optional flags for the Ruby `./configure` step were passed like this:
```sh
RUBY_CONFIGURE_OPTS="--disable-install-doc --with-openssl-dir=..." ruby-build <version> <destination>
```
However, it wasn't possible to use RUBY_CONFIGURE_OPTS to pass individual values that contain spaces, even when properly quoted. That is because RUBY_CONFIGURE_OPTS ignores quoting and has bash perform normal word splitting.

Now, in addition to RUBY_CONFIGURE_OPTS, both ruby-build and `rbenv install` accept the following syntax:
```sh
ruby-build <version> <destination> -- --disable-install-doc --with-openssl-dir="/path with spaces"
```
That is, any flags after `--` are forwarded as `./configure` flags when compiling Ruby. By using the new method, it is possible to supply any value, even those with spaces, as long as quoting was properly done per the user's shell.

Fixes https://github.com/rbenv/ruby-build/issues/2264

Additionally, to help identify typos, `ruby-build` now errors out on unrecognized flags or the wrong number of positional parameters.
