### PR TITLE
Use builds from ruby/truffleruby-dev-builder for truffleruby-dev on macos-arm64

### DIFF
--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -12,7 +12,7 @@ Darwin-x86_64)
   ;;
 Darwin-arm64)
   use_homebrew_openssl
-  install_package "truffleruby-head" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-dev-macos-aarch64.tar.gz" truffleruby
+  install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-macos-13-arm64.tar.gz" truffleruby
   ;;
 *)
   colorize 1 "Unsupported platform: $platform"


### PR DESCRIPTION
* macos-arm64 runners recently became available for ruby/truffleruby-dev-builder.
* Those builds are more frequently updated than on graalvm-ce-dev-builds.

cc @nirvdrum 