### PR TITLE
Automatically link to Homebrew openssl

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1023,6 +1023,8 @@ use_freebsd_libffi() {
   fi
 }
 
+# macOS prevents linking to its system OpenSSL/LibreSSL installation, so
+# it's basically useless for Ruby purposes.
 has_broken_mac_openssl() {
   is_mac || return 1
   local openssl_version
@@ -1030,47 +1032,103 @@ has_broken_mac_openssl() {
   [[ $openssl_version = "OpenSSL 0.9.8"?* || $openssl_version = "LibreSSL"* ]]
 }
 
+# Detect the OpenSSL version that a compiler can reasonably link to.
 system_openssl_version() {
-  local version_text
-  version_text=$(printf '#include <openssl/opensslv.h>\nOPENSSL_VERSION_TEXT\n' | cc -xc -E - 2>/dev/null || true)
-  if [[ $version_text == *"OpenSSL "* ]]; then
-    local version=${version_text#*OpenSSL }
-    # shellcheck disable=SC2001
-    sed 's/[^0-9]//g' <<<"${version%% *}" | sed 's/^0*//'
-  else
-    echo "No system openssl version was found, ensure openssl headers are installed (https://github.com/rbenv/ruby-build/wiki#suggested-build-environment)" >&2
-    echo 000
+  cc -xc -E - <<EOF 2>/dev/null | sed -n 's/OpenSSL \([0-9][0-9.]*\).*/\1/p'
+#include <openssl/opensslv.h>
+OPENSSL_VERSION_TEXT
+EOF
+}
+
+# List all Homebrew-installed OpenSSL versions and their filesystem prefixes.
+homebrew_openssl_versions() {
+  local formula version prefix
+  # https://github.com/orgs/Homebrew/discussions/4845
+  brew list 2>/dev/null | grep '^openssl@' | while read -r formula; do
+    prefix="$(brew --prefix "$formula" 2>/dev/null || true)"
+    [ -n "$prefix" ] || continue
+    version="$("$prefix"/bin/openssl version 2>/dev/null | sed -n 's/OpenSSL \([0-9][0-9.]*\).*/\1/p')"
+    [ -z "$version" ] || printf '%s %s %s\n' "$formula" "$version" "$prefix"
+  done
+}
+
+# Normalizes "X.Y.Z" into a comparable numeric value. Does not support prereleases.
+# See also osx_version, require_java
+normalize_semver() {
+  local ver
+  IFS=. read -d "" -r -a ver <<<"$1" || true
+  IFS="$OLDIFS"
+  # 3.1.23 -> 300_123
+  echo $(( ver[0]*100000 + ver[1]*100 + ver[2] ))
+}
+
+# Checks if system OpenSSL does NOT satisfy the version requirement
+# between lower and upper bounds. This is used by build definitions to
+# conditionally install per-ruby OpenSSL.
+#
+# If a compatible Homebrew-installed OpenSSL version is found during
+# checking, Ruby will be linked to it and the check will return false.
+needs_openssl() {
+  [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-openssl-dir=* ]] || return 1
+
+  local system_version
+  if ! has_broken_mac_openssl; then
+    system_version="$(system_openssl_version)"
   fi
+
+  # With no arguments, any system OpenSSL satisfies the check.
+  if [ $# -lt 2 ]; then
+    [ -z "$system_version" ] || return 1
+    return 0
+  fi
+
+  local lower_bound upper_bound
+  lower_bound="$(normalize_semver "${2%-*}")"
+  upper_bound="${2#*-}"
+  upper_bound="$(normalize_semver "${upper_bound//.x/.99}")"
+  system_version="$(normalize_semver "$system_version")"
+
+  # Return early if system openssl satisfies the requirement.
+  (( system_version < lower_bound || system_version >= upper_bound )) || return 1
+
+  # Look for the latest Homebrew-installed OpenSSL that satisfies the requirement
+  local brew_installs
+  brew_installs="$(homebrew_openssl_versions)"
+  [ -n "$brew_installs" ] || return 0
+
+  # Link to the highest-matching Homebrew OpenSSL
+  local versions homebrew_version formula version prefix
+  # shellcheck disable=SC2207
+  versions=( $(awk '{print $2}' <<<"$brew_installs" | sort_versions) )
+  local index="${#versions[@]}"
+  while [ $((index--)) -ge 0 ]; do
+    homebrew_version="$(normalize_semver "${versions[index]}")"
+    (( homebrew_version >= lower_bound && homebrew_version < upper_bound )) || continue
+    while read -r formula version prefix; do
+      [ "$version" = "${versions[index]}" ] || continue
+      echo "ruby-build: using $formula from homebrew"
+      package_option ruby configure --with-openssl-dir="$prefix"
+      return 1
+    done <<<"$brew_installs"
+  done
 }
 
-# openssl gem 1.1.1
+# Kept for backward compatibility with 3rd-party Ruby definitions.
 needs_openssl_096_102() {
-  [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" == *--with-openssl-dir=* ]] && return 1
-  has_broken_mac_openssl && return 0
-
-  local version
-  version="$(system_openssl_version)"
-  (( version < 96 || version >= 110 ))
+  # openssl gem 1.1.1
+  needs_openssl "$1" "0.9.6-1.0.x"
 }
 
-# openssl gem 2.2.1
+# Kept for backward compatibility with 3rd-party Ruby definitions.
 needs_openssl_101_111() {
-  [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" == *--with-openssl-dir=* ]] && return 1
-  has_broken_mac_openssl && return 0
-
-  local version
-  version="$(system_openssl_version)"
-  (( version < 101 || version >= 300 ))
+  # openssl gem 2.2.1
+  needs_openssl "$1" "1.0.1-1.x.x"
 }
 
-# openssl gem 3.0.0
+# Kept for backward compatibility with 3rd-party Ruby definitions.
 needs_openssl_102_300() {
-  [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" == *--with-openssl-dir=* ]] && return 1
-  has_broken_mac_openssl && return 0
-
-  local version
-  version="$(system_openssl_version)"
-  (( version < 102 || version >= 400 ))
+  # openssl gem 3.0.0
+  needs_openssl "$1" "1.0.2-3.x.x"
 }
 
 # Kept for backward compatibility with 3rd-party Ruby definitions.

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -197,7 +197,12 @@ install_package_using() {
 
   for arg in "${@:$(( package_type_nargs + 1 ))}"; do
     if [ "$last_arg" = "--if" ]; then
-      "$arg" || return 0
+      if [[ $arg == *:* ]]; then
+        # Support colon-separated sub-argument, e.g. `needs_openssl:1.1`
+        "${arg%:*}" "$package_name" "${arg#*:}" || return 0
+      else
+        "$arg" "$package_name" || return 0
+      fi
     elif [ "$arg" != "--if" ]; then
       make_args["${#make_args[@]}"]="$arg"
     fi

--- a/share/ruby-build/1.9.3-dev
+++ b/share/ruby-build/1.9.3-dev
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_git "ruby-1.9.3-dev" "https://github.com/ruby/ruby.git" "ruby_1_9_3" warn_eol autoconf standard

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,4 +1,4 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.bz2#ca8ba4e564fc5f98b210a5784e43dfffef9471222849e46f8e848b37e9f38acf" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p105
+++ b/share/ruby-build/1.9.3-p105
@@ -1,5 +1,5 @@
 [ -n "$CC" ] || export CC=cc
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p105" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p105.tar.bz2#8a149dee6498553fe5d25618ccce8002ca076affca57c857503235d00a35f9d1" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,5 +1,5 @@
 [ -n "$CC" ] || export CC=cc
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.bz2#c67a59443052b5a9219eb4cee3892bdfbc6f250f0c8e214e02256a4cc7ef5526" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p194
+++ b/share/ruby-build/1.9.3-p194
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p194" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p194.tar.bz2#a9d1ea9eaea075c60048369a63b35b3b5a06a30aa214a3d990e0bb71212db8fa" warn_eol standard

--- a/share/ruby-build/1.9.3-p286
+++ b/share/ruby-build/1.9.3-p286
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p286" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p286.tar.bz2#5281656c7a0ae48b64f28d845a96b4dfa16ba1357a911265752787585fb5ea64" warn_eol standard

--- a/share/ruby-build/1.9.3-p327
+++ b/share/ruby-build/1.9.3-p327
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p327" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.bz2#d989465242f9b11a8a3aa8cbd2c75a9b3a8c0ec2f14a087a0c7b51abf164e488" warn_eol standard

--- a/share/ruby-build/1.9.3-p362
+++ b/share/ruby-build/1.9.3-p362
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p362" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p362.tar.bz2#9ed456711a4c0fb2969d9144a81a706d2d506070a35a6d5bc98bb5c8407f9985" warn_eol standard

--- a/share/ruby-build/1.9.3-p374
+++ b/share/ruby-build/1.9.3-p374
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p374" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p374.tar.bz2#712944f691b79f22f655547826400c26b13bc8c9e7bdc73a4abea45d5e766d85" warn_eol standard

--- a/share/ruby-build/1.9.3-p385
+++ b/share/ruby-build/1.9.3-p385
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p385" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p385.tar.bz2#f991ee50414dc795696bad0fc5c7b0b94d93b9b38fed943326d20ce4e9dda42b" warn_eol standard

--- a/share/ruby-build/1.9.3-p392
+++ b/share/ruby-build/1.9.3-p392
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p392" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.bz2#5a7334dfdf62966879bf539b8a9f0b889df6f3b3824fb52a9303c3c3d3a58391" warn_eol standard

--- a/share/ruby-build/1.9.3-p426
+++ b/share/ruby-build/1.9.3-p426
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p426" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p426.tar.bz2#54ac09a5579562ce6d3ba04413d24b5486d3bd3c0632968c7bd49cb76725186a" warn_eol standard

--- a/share/ruby-build/1.9.3-p429
+++ b/share/ruby-build/1.9.3-p429
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p429" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.bz2#9d8949c24cf6fe810b65fb466076708b842a3b0bac7799f79b7b6a8791dc2a70" warn_eol standard

--- a/share/ruby-build/1.9.3-p448
+++ b/share/ruby-build/1.9.3-p448
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p448" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.bz2#a7372230357bfff8e4525fb8019046da521561fe66b02c25d8efc10c9877bc91" warn_eol standard

--- a/share/ruby-build/1.9.3-p484
+++ b/share/ruby-build/1.9.3-p484
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p484" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.bz2#0fdc6e860d0023ba7b94c7a0cf1f7d32908b65b526246de9dfd5bb39d0d7922b" warn_eol standard

--- a/share/ruby-build/1.9.3-p545
+++ b/share/ruby-build/1.9.3-p545
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p545" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p545.tar.bz2#2533de9f56d62f11c06a02dd32b5ab6d22a8f268c94b8e1e1ade6536adfd1aab" warn_eol standard

--- a/share/ruby-build/1.9.3-p547
+++ b/share/ruby-build/1.9.3-p547
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p547" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p547.tar.bz2#ef588ed3ff53009b4c1833c83187ae252dd6c20db45e21a326cd4a16a102ef4c" warn_eol standard

--- a/share/ruby-build/1.9.3-p550
+++ b/share/ruby-build/1.9.3-p550
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p550" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p550.tar.bz2#d3da003896db47fb10ba4d2e0285eea7fe8cdc785b86c02ebad5bc9cdeaa4748" warn_eol standard

--- a/share/ruby-build/1.9.3-p551
+++ b/share/ruby-build/1.9.3-p551
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p551" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.bz2#b0c5e37e3431d58613a160504b39542ec687d473de1d4da983dabcf3c5de771e" warn_eol standard

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,4 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.bz2#a15d7924d74a45ffe48d5421c5fc4ff83b7009676054fa5952b890711afef6fc" warn_eol standard
 install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-rc1
+++ b/share/ruby-build/1.9.3-rc1
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-rc1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-rc1.tar.bz2#951a8810086abca0e200f81767a518ee2730d6dc9b0cc2c7e3587dcfc3bf5fc8" warn_eol standard

--- a/share/ruby-build/2.0.0-dev
+++ b/share/ruby-build/2.0.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_git "ruby-2.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_0_0" warn_eol autoconf standard verify_openssl

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.bz2#c680d392ccc4901c32067576f5b474ee186def2fcd3fcbfa485739168093295f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.bz2#0be32aef7a7ab6e3708cc1d65cd3e0a99fa801597194bbedd5799c11d652eb5b" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.bz2#08e3d4b85b8a1118a8e81261f59dd8b4ddcfd70b6ae554e0ec5ceb99c3185e8a" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p353
+++ b/share/ruby-build/2.0.0-p353
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.bz2#3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p451
+++ b/share/ruby-build/2.0.0-p451
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2#5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p481
+++ b/share/ruby-build/2.0.0-p481
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.bz2#0762dad7e96d8091bdf33b3e3176c2066fbf3dc09dfe85fbf40e74e83c63d8e2" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p576
+++ b/share/ruby-build/2.0.0-p576
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2#8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p594
+++ b/share/ruby-build/2.0.0-p594
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2#e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p598
+++ b/share/ruby-build/2.0.0-p598
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2#67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p643
+++ b/share/ruby-build/2.0.0-p643
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.bz2#1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p645
+++ b/share/ruby-build/2.0.0-p645
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.bz2#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p647
+++ b/share/ruby-build/2.0.0-p647
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.bz2#3c3782e313d1ec3ed06c104eafd133cc54ff5183b991786ece9e957fd6cf1cb9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-p648
+++ b/share/ruby-build/2.0.0-p648
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2#087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.bz2#79e5605003bf6766fbd123ce00a0027df716ba6d28494c35185909f7e61a5bdf" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.bz2#cea98c000a113f10cb7d55753c759da1f1baa7ca9b3edf75fc19fa5f44bf71a0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.bz2#4033ddadd0b44eecfcb7686231ebd109ee6f22bf09797a7e15882b9df0b1ee81" warn_eol standard verify_openssl

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2#d55f897bb04283c5fa80223d96d990fe8ecb598508dd59443b356cbba1f66145" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0-dev
+++ b/share/ruby-build/2.1.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_git "ruby-2.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_1" warn_eol autoconf standard verify_openssl

--- a/share/ruby-build/2.1.0-preview1
+++ b/share/ruby-build/2.1.0-preview1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.bz2#860b90d28b214393fd9d77ac2ad65b384d8249cd59b658c668cf0c7bad1db341" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.bz2#780fddf0e3c8a219057d578e83367ecfac5e945054b9f132b3b93ded4802d1ce" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.bz2#af828bc0fe6aee5ffad0f8f10b48ee25964f54d5118570937ac7cf1c1df0edd3" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.10
+++ b/share/ruby-build/2.1.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.10" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2#a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.3
+++ b/share/ruby-build/2.1.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.4
+++ b/share/ruby-build/2.1.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.5
+++ b/share/ruby-build/2.1.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.8
+++ b/share/ruby-build/2.1.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" warn_eol standard verify_openssl

--- a/share/ruby-build/2.1.9
+++ b/share/ruby-build/2.1.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.0
+++ b/share/ruby-build/2.2.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2#1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.0-dev
+++ b/share/ruby-build/2.2.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.2.0-preview1
+++ b/share/ruby-build/2.2.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview1.tar.bz2#a3614c389de06b1636d8b919f2cd07e85311486bda2cb226a5549657a3610af5" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.0-preview2
+++ b/share/ruby-build/2.2.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.bz2#9e49583f3fad3888fefc85b719fdb210a88ef54d80f9eac439b7ca4232fa7f0b" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.0-rc1
+++ b/share/ruby-build/2.2.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-rc1.tar.bz2#e6a1f8d45ea749bdc92eb1269b77ec475bc600b66039ff90d77db8f50820a896" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.1
+++ b/share/ruby-build/2.2.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.bz2#4e5676073246b7ade207be3e80a930567a88100513591a0f19fc38e247370065" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.10
+++ b/share/ruby-build/2.2.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.10" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.bz2#a54204d2728283c9eff0cf81d654f245fa5b3447d0824f1a6bc3b2c5c827381e" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.2
+++ b/share/ruby-build/2.2.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.bz2#f3b8ffa6089820ee5bdc289567d365e5748d4170e8aa246d2ea6576f24796535" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.3
+++ b/share/ruby-build/2.2.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.bz2#c745cb98b29127d7f19f1bf9e0a63c384736f4d303b83c4f4bda3c2ee3c5e41f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.4
+++ b/share/ruby-build/2.2.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.4" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2#31203696adbfdda6f2874a2de31f7c5a1f3bcb6628f4d1a241de21b158cd5c76" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.5
+++ b/share/ruby-build/2.2.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.5" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2#22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.6
+++ b/share/ruby-build/2.2.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.6" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.bz2#e845ba41ea3525aafaa4094212f1eadc57392732232b67b4394a7e0f046dddf7" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.7
+++ b/share/ruby-build/2.2.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.7" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.bz2#80486c5991783185afeceeb315060a3dafc3889a2912e145b1a8457d7b005c5b" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.8
+++ b/share/ruby-build/2.2.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.8" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2#b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e" warn_eol standard verify_openssl

--- a/share/ruby-build/2.2.9
+++ b/share/ruby-build/2.2.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.2.9" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2#5e3cfcc3b69638e165f72f67b1321fa05aff62b0f9e9b32042a5a79614e7c70a" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.0
+++ b/share/ruby-build/2.3.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.0-dev
+++ b/share/ruby-build/2.3.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.3.0-preview1
+++ b/share/ruby-build/2.3.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.bz2#42b9c9e1740a5abe2855d11803524370bd95744c8dcb0068572ed5c969ac7f0f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.0-preview2
+++ b/share/ruby-build/2.3.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.bz2#e9b0464e50b2e5c31546e6b8ca8cad71fe2d2146ccf88b7419bbe9626af741cb" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.1
+++ b/share/ruby-build/2.3.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.2
+++ b/share/ruby-build/2.3.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.3
+++ b/share/ruby-build/2.3.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.4
+++ b/share/ruby-build/2.3.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.5
+++ b/share/ruby-build/2.3.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.6
+++ b/share/ruby-build/2.3.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.7
+++ b/share/ruby-build/2.3.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" warn_eol standard verify_openssl

--- a/share/ruby-build/2.3.8
+++ b/share/ruby-build/2.3.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" warn_eol standard verify_openssl

--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.4.0-preview1
+++ b/share/ruby-build/2.4.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2#17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649" warn_eol standard verify_openssl

--- a/share/ruby-build/2.4.0-preview2
+++ b/share/ruby-build/2.4.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2#2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d" warn_eol standard verify_openssl

--- a/share/ruby-build/2.4.0-preview3
+++ b/share/ruby-build/2.4.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.4.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2#305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52" warn_eol standard verify_openssl

--- a/share/ruby-build/2.4.0-rc1
+++ b/share/ruby-build/2.4.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "ruby-2.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-rc1.tar.bz2#3b156b20f9df0dd62cbeeb8e57e66ea872d2a5b55fabdef1889650122bcc2ea7" warn_eol standard verify_openssl

--- a/share/ruby-build/2.4.1
+++ b/share/ruby-build/2.4.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.10
+++ b/share/ruby-build/2.4.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.10" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.tar.bz2#6ea3ce7fd0064524ae06dbdcd99741c990901dfc9c66d8139a02f907d30b95a8" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.2
+++ b/share/ruby-build/2.4.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.5
+++ b/share/ruby-build/2.4.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.6
+++ b/share/ruby-build/2.4.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.7
+++ b/share/ruby-build/2.4.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.8
+++ b/share/ruby-build/2.4.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.4.9
+++ b/share/ruby-build/2.4.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.0
+++ b/share/ruby-build/2.5.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.5.0-preview1
+++ b/share/ruby-build/2.5.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2#1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446" warn_eol standard verify_openssl

--- a/share/ruby-build/2.5.0-rc1
+++ b/share/ruby-build/2.5.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" warn_eol standard verify_openssl

--- a/share/ruby-build/2.5.1
+++ b/share/ruby-build/2.5.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.2
+++ b/share/ruby-build/2.5.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.3
+++ b/share/ruby-build/2.5.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.4
+++ b/share/ruby-build/2.5.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.5
+++ b/share/ruby-build/2.5.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.6
+++ b/share/ruby-build/2.5.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.7
+++ b/share/ruby-build/2.5.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.8
+++ b/share/ruby-build/2.5.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.8" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2#41fc93731ad3f3aa597d657f77ed68fa86b5e93c04dfbf7e542a8780702233f0" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.5.9
+++ b/share/ruby-build/2.5.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.5.9" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.bz2#bebbe3fe7899acd3ca2f213de38158709555e88a13f85ba5dc95239654bcfeeb" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.0
+++ b/share/ruby-build/2.6.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.0-dev
+++ b/share/ruby-build/2.6.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_git "ruby-2.6.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.6.0-preview1
+++ b/share/ruby-build/2.6.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" warn_eol standard verify_openssl

--- a/share/ruby-build/2.6.0-preview2
+++ b/share/ruby-build/2.6.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" warn_eol standard verify_openssl

--- a/share/ruby-build/2.6.0-preview3
+++ b/share/ruby-build/2.6.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview3.tar.bz2#1f09a2ac1ab26721923cbf4b9302a66d36bb302dc45e72112b41d6fccc5b5931" warn_eol standard verify_openssl

--- a/share/ruby-build/2.6.0-rc1
+++ b/share/ruby-build/2.6.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc1.tar.bz2#b4e9c0e8801946e9f0baba30948955f4341e9e04f363c206b7bd774208053eb5" warn_eol standard verify_openssl

--- a/share/ruby-build/2.6.0-rc2
+++ b/share/ruby-build/2.6.0-rc2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2#b3d03e471e3136f43bb948013d4f4974abb63d478e8ff7ec2741b22750a3ec50" warn_eol standard verify_openssl

--- a/share/ruby-build/2.6.1
+++ b/share/ruby-build/2.6.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.10
+++ b/share/ruby-build/2.6.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.10" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.bz2#399e1f13e7fedc3c6ae2ff541bbf26c44dfb63b07b6c186fdd15b4e526e27e9c" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.2
+++ b/share/ruby-build/2.6.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.3
+++ b/share/ruby-build/2.6.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.4
+++ b/share/ruby-build/2.6.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.5
+++ b/share/ruby-build/2.6.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.6
+++ b/share/ruby-build/2.6.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.6" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2#f08b779079ecd1498e6a2548c39a86144c6c784dcec6f7e8a93208682eb8306e" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.7
+++ b/share/ruby-build/2.6.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.7" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.7.tar.bz2#775a5d47b73ce3ee5d600f993badd7b640a2caca138573326db6632858517710" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.8
+++ b/share/ruby-build/2.6.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.8" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.bz2#dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.6.9
+++ b/share/ruby-build/2.6.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.6.9" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.bz2#a0639060c4519572e51828eb742f09dd40f154c820f6007246de7a2090e3ee45" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0
+++ b/share/ruby-build/2.7.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-dev
+++ b/share/ruby-build/2.7.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_git "ruby-2.7.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/2.7.0-preview1
+++ b/share/ruby-build/2.7.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview2
+++ b/share/ruby-build/2.7.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-preview3
+++ b/share/ruby-build/2.7.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2#df2ddee659873e6fc30a8590ecffa49cf3a4ef81fa922b0d09f821b69ee88bc3" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-rc1
+++ b/share/ruby-build/2.7.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc1.tar.bz2#1c5a02b63fa9fca37c41681bbbf20c55818a32315958c0a6c8f505943bfcb2d2" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.0-rc2
+++ b/share/ruby-build/2.7.0-rc2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc2.tar.bz2#8f94ea7ba79b6e95225fb4a7870e882081182c3d12d58c4cad2a7d2e7865cf8e" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.1
+++ b/share/ruby-build/2.7.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.2
+++ b/share/ruby-build/2.7.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.3
+++ b/share/ruby-build/2.7.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.4
+++ b/share/ruby-build/2.7.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.5
+++ b/share/ruby-build/2.7.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.6
+++ b/share/ruby-build/2.7.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.7
+++ b/share/ruby-build/2.7.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.8
+++ b/share/ruby-build/2.7.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-2.7.8" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz#c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0
+++ b/share/ruby-build/3.0.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz#a13ed141a1c18eb967aac1e33f4d6ad5f21be1ac543c344e0d6feeee54af8e28" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-dev
+++ b/share/ruby-build/3.0.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_git "ruby-3.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_0" autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.0.0-preview1
+++ b/share/ruby-build/3.0.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview1.tar.bz2#013bdc6e859d76d67a6fcd990d401ed57e6e25896bab96d1d0648a877f556dbb" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-preview2
+++ b/share/ruby-build/3.0.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview2.tar.gz#9de8661565c2b1007d91a580e9a7e02d23f1e8fc8df371feb15a2727aa05fd9a" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-rc1
+++ b/share/ruby-build/3.0.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-rc1.tar.gz#e1270f38b969ce7b124f0a4c217e33eda643f75c7cb20debc62c17535406e37f" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.1
+++ b/share/ruby-build/3.0.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.1.tar.gz#369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.2
+++ b/share/ruby-build/3.0.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.2.tar.gz#5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.3
+++ b/share/ruby-build/3.0.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.3" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.3.tar.gz#3586861cb2df56970287f0fd83f274bd92058872d830d15570b36def7f1a92ac" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.4
+++ b/share/ruby-build/3.0.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.4" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.4.tar.gz#70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.5
+++ b/share/ruby-build/3.0.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.5" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz#9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776" enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.6
+++ b/share/ruby-build/3.0.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
 install_package "ruby-3.0.6" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz#6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e" enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.0
+++ b/share/ruby-build/3.1.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.0-dev
+++ b/share/ruby-build/3.1.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.1.0-preview1
+++ b/share/ruby-build/3.1.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.1
+++ b/share/ruby-build/3.1.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.2
+++ b/share/ruby-build/3.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.3
+++ b/share/ruby-build/3.1.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" enable_shared standard verify_openssl

--- a/share/ruby-build/3.1.4
+++ b/share/ruby-build/3.1.4
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0
+++ b/share/ruby-build/3.2.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz#daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-dev
+++ b/share/ruby-build/3.2.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.2.0-preview1
+++ b/share/ruby-build/3.2.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-preview2
+++ b/share/ruby-build/3.2.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.0-rc1
+++ b/share/ruby-build/3.2.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.1
+++ b/share/ruby-build/3.2.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz#13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd" enable_shared standard verify_openssl

--- a/share/ruby-build/3.2.2
+++ b/share/ruby-build/3.2.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" enable_shared standard verify_openssl

--- a/share/ruby-build/3.3.0-dev
+++ b/share/ruby-build/3.3.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_build standard_install_with_bundled_gems verify_openssl

--- a/share/ruby-build/3.3.0-preview1
+++ b/share/ruby-build/3.3.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview1.tar.gz#c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed" enable_shared standard verify_openssl

--- a/share/ruby-build/3.3.0-preview2
+++ b/share/ruby-build/3.3.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl_102_300
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview2.tar.gz#30ce8b0fe11b37b5ac088f5a5765744b935eac45bb89a9e381731533144f5991" enable_shared standard verify_openssl

--- a/share/ruby-build/rbx-2.10
+++ b/share/ruby-build/rbx-2.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.10.tar.bz2#c8047557a3d8513e4b10c661014e22901a24ec0aad71f0f1ffd3a8b31d58e694" warn_eol rbx

--- a/share/ruby-build/rbx-2.11
+++ b/share/ruby-build/rbx-2.11
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.11.tar.bz2#5a9ce5c86a4a566a088f379cf2889aa14d8fcd8b2295d5571f61bf43a9548b97" warn_eol rbx

--- a/share/ruby-build/rbx-2.5.8
+++ b/share/ruby-build/rbx-2.5.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.5.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.5.8.tar.bz2#d6b411732aa035865f2855845abe5405119560f0979062672d576601de89e59a" warn_eol rbx

--- a/share/ruby-build/rbx-2.6
+++ b/share/ruby-build/rbx-2.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.6.tar.bz2#f63bbcca7d1bc71b4c20a3bd5748430be001f3a39b14a903d3d4ca39a657cfe0" warn_eol rbx

--- a/share/ruby-build/rbx-2.7
+++ b/share/ruby-build/rbx-2.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.7.tar.bz2#6f121cccbbd5ad0183024bf2405ca627982d1890307c059c754a1847e19eadd1" warn_eol rbx

--- a/share/ruby-build/rbx-2.71828182
+++ b/share/ruby-build/rbx-2.71828182
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.71828182" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.71828182.tar.bz2" warn_eol rbx

--- a/share/ruby-build/rbx-2.8
+++ b/share/ruby-build/rbx-2.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.8.tar.bz2#93e798b4c79800d0543d8d78aa1066b4285af209ed9908c35e54260c13bc7e9d" warn_eol rbx

--- a/share/ruby-build/rbx-2.9
+++ b/share/ruby-build/rbx-2.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-2.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-2.9.tar.bz2#9f8ad067ce494d201dae359d132ddac275d0bd13315dc8fdd094c9aa661ce8b1" warn_eol rbx

--- a/share/ruby-build/rbx-3.0
+++ b/share/ruby-build/rbx-3.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.0.tar.bz2#fd4c9687af6e29939100610a231f13951ed763a9028c85878505f313857c43ca" warn_eol rbx

--- a/share/ruby-build/rbx-3.1
+++ b/share/ruby-build/rbx-3.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.1" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.1.tar.bz2#33e1b3b8e489a86f94de819fc478640150a4b1794c6a6ffe93d717fda6b610d8" warn_eol rbx

--- a/share/ruby-build/rbx-3.10
+++ b/share/ruby-build/rbx-3.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.10.tar.bz2#a5980628edf318c4142cd3f7c6b01d3b07b50387533056ea67d75a63af3a5054" warn_eol rbx

--- a/share/ruby-build/rbx-3.100
+++ b/share/ruby-build/rbx-3.100
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.100" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.100.tar.bz2#95f434cb034e732ecd075bc0b99540b54a5adfd0d8b8da7d5a0d4566bdcd8cce" warn_eol rbx

--- a/share/ruby-build/rbx-3.101
+++ b/share/ruby-build/rbx-3.101
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.101" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.101.tar.bz2#ce9861e569807c8db5de3dcbe093441a61de623d9df7c52de78891962c3f66e8" warn_eol rbx

--- a/share/ruby-build/rbx-3.102
+++ b/share/ruby-build/rbx-3.102
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.102" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.102.tar.bz2#82ecb66158d0a61dc2ed84fee8923c9fdb24d9c0ac0b6e6639e8e5e35ef82005" warn_eol rbx

--- a/share/ruby-build/rbx-3.103
+++ b/share/ruby-build/rbx-3.103
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.103" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.103.tar.bz2#5cc15e89005b1824bf6c4d62d66e4cbadafe8af29baf4cfd5a1c1ecc8df2d67a" warn_eol rbx

--- a/share/ruby-build/rbx-3.104
+++ b/share/ruby-build/rbx-3.104
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.104" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.104.tar.bz2#9ba016ce50e055d94345bb81a471408adb5b9dd04117e962bfa4ff2651af6461" warn_eol rbx

--- a/share/ruby-build/rbx-3.105
+++ b/share/ruby-build/rbx-3.105
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.105" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.105.tar.bz2#38261e40f9e1008c38ef3c0be968994430fc5ef31ecf411e4dd04fa9e2e009b3" warn_eol rbx

--- a/share/ruby-build/rbx-3.106
+++ b/share/ruby-build/rbx-3.106
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.106" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.106.tar.bz2#0c98afdc68c7ceecdc882674a1ee32aee75d76ca69aca44836ffa84a1b33afbd" warn_eol rbx

--- a/share/ruby-build/rbx-3.107
+++ b/share/ruby-build/rbx-3.107
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.107" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.107.tar.bz2#46d68cb26ce83fb503b25776770abad6a55ef03a14cd4fd05f44e17becb71589" warn_eol rbx

--- a/share/ruby-build/rbx-3.11
+++ b/share/ruby-build/rbx-3.11
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.11.tar.bz2#2e8bf15313440ec7c0315e5d3a387bf88c95518040073d78fcb7a044eaef162b" warn_eol rbx

--- a/share/ruby-build/rbx-3.12
+++ b/share/ruby-build/rbx-3.12
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.12" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.12.tar.bz2#bc955346e2dfface41c87adf432034b591eb81350905d5b503b501f36ee773c9" warn_eol rbx

--- a/share/ruby-build/rbx-3.13
+++ b/share/ruby-build/rbx-3.13
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.13" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.13.tar.bz2#a286b91150970a0116c843de5929c1e3c7a399943bd9f22f5fde25e67fa74368" warn_eol rbx

--- a/share/ruby-build/rbx-3.14
+++ b/share/ruby-build/rbx-3.14
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.14" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.14.tar.bz2#19043116e885c428041677f672f54480bba171da9d43f369d1c854cb794c8426" warn_eol rbx

--- a/share/ruby-build/rbx-3.15
+++ b/share/ruby-build/rbx-3.15
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.15" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.15.tar.bz2#86ce6c330843f1a4fa1217e37d8898e10b90673838b7a2867e4e4d6d65599cef" warn_eol rbx

--- a/share/ruby-build/rbx-3.16
+++ b/share/ruby-build/rbx-3.16
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.16" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.16.tar.bz2#1c34db3254e8304988b3c10591c11af058f371bee80fe3b559e6c16d84f4fa03" warn_eol rbx

--- a/share/ruby-build/rbx-3.17
+++ b/share/ruby-build/rbx-3.17
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.17" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.17.tar.bz2#bb76bc9613064f48d50f8323c2727002bb7dcb0ccf8813e69a366c603b7bc689" warn_eol rbx

--- a/share/ruby-build/rbx-3.18
+++ b/share/ruby-build/rbx-3.18
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.18" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.18.tar.bz2#c552a539f3f6b8f240a02cbe9926540a0c3ad95e0e341179963a43c64208ce3e" warn_eol rbx

--- a/share/ruby-build/rbx-3.19
+++ b/share/ruby-build/rbx-3.19
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.19" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.19.tar.bz2#cee948256bf288595b4ce53034f0dcd4ae2bc257acb2d43a63364dfc8e5db47c" warn_eol rbx

--- a/share/ruby-build/rbx-3.2
+++ b/share/ruby-build/rbx-3.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.2" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.2.tar.bz2#e9e906492900755425d29cbb650b0b5a39d1163fa692d6a33958e98a2e8ea156" warn_eol rbx

--- a/share/ruby-build/rbx-3.20
+++ b/share/ruby-build/rbx-3.20
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.20" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.20.tar.bz2#caf95bf55e5483e288b40c315ad7f2d4091823e33dcd57e9c6364c66c29a7ff2" warn_eol rbx

--- a/share/ruby-build/rbx-3.21
+++ b/share/ruby-build/rbx-3.21
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.21" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.21.tar.bz2#281195af772ef05f789404f0fb95838c5942591762191962bab22860022650ee" warn_eol rbx

--- a/share/ruby-build/rbx-3.22
+++ b/share/ruby-build/rbx-3.22
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.22" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.22.tar.bz2#90b9a69ab71cffdc4a0dd68aafebce5df1fcd79c2bc60ef78b44fccd160d341a" warn_eol rbx

--- a/share/ruby-build/rbx-3.23
+++ b/share/ruby-build/rbx-3.23
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.23" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.23.tar.bz2#bed25ca7c27629115768eb666adfcbb95d6f625e8666980e837ead5e13848b64" warn_eol rbx

--- a/share/ruby-build/rbx-3.24
+++ b/share/ruby-build/rbx-3.24
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.25" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.25.tar.bz2#9a1d1219acf34bab516e07a1b5ada3b54afd51ec25e87908fc0b6801db0c5d57" warn_eol rbx

--- a/share/ruby-build/rbx-3.25
+++ b/share/ruby-build/rbx-3.25
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.24" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.24.tar.bz2#7edf189283255d68b2a1d69e011cfebad0397743229fd50b08e21774ec8dab63" warn_eol rbx

--- a/share/ruby-build/rbx-3.26
+++ b/share/ruby-build/rbx-3.26
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.26" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.26.tar.bz2#10341c880eef73dda89cf8bcf5ae066b04683e40a3b1721d4d2733f32778819a" warn_eol rbx

--- a/share/ruby-build/rbx-3.27
+++ b/share/ruby-build/rbx-3.27
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.27" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.27.tar.bz2#4ede3d0adcfab77eb9ffb43eec1b6cbe63c32f326630b488e9c2382fa3a6db98" warn_eol rbx

--- a/share/ruby-build/rbx-3.28
+++ b/share/ruby-build/rbx-3.28
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.28" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.28.tar.bz2#7954146ee9284e038b3c524613478e2884d8a7a9df85de6c17e43177e41d842c" warn_eol rbx

--- a/share/ruby-build/rbx-3.29
+++ b/share/ruby-build/rbx-3.29
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.29" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.29.tar.bz2#6a8bf87ce26a6a05a80dd2ae40ac8c4e2c5153d4d2d913549a85d9aa32aaeee2" warn_eol rbx

--- a/share/ruby-build/rbx-3.3
+++ b/share/ruby-build/rbx-3.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.3" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.3.tar.bz2#3f592b1f5580f7075c7fdc72eee7c959dd4791d96d04de6a8d467529dcff72be" warn_eol rbx

--- a/share/ruby-build/rbx-3.30
+++ b/share/ruby-build/rbx-3.30
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.30" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.30.tar.bz2#5294f406679d41160abe46ec1ff14b76c4353a75756227cc691108bb57f4bd16" warn_eol rbx

--- a/share/ruby-build/rbx-3.31
+++ b/share/ruby-build/rbx-3.31
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.31" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.31.tar.bz2#1c7a7763ab7cf36ad6b2e328ff1d78fb6587721b8667f8598d15354d0704de72" warn_eol rbx

--- a/share/ruby-build/rbx-3.32
+++ b/share/ruby-build/rbx-3.32
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.32" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.32.tar.bz2#f88d6d277efe1f9774da1201ce4c8a8fd7cb2ea29620c1727a4471e3a0eed1dc" warn_eol rbx

--- a/share/ruby-build/rbx-3.33
+++ b/share/ruby-build/rbx-3.33
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.33" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.33.tar.bz2#1455940fc3a17b6efbb787c9316ff86a260187ebbaba6b32746dd27cebe14907" warn_eol rbx

--- a/share/ruby-build/rbx-3.34
+++ b/share/ruby-build/rbx-3.34
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.34" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.34.tar.bz2#90f5d5b53dbc6494b8a81ecd3569950b1d85d0c463dd537cab677fab82e2b300" warn_eol rbx

--- a/share/ruby-build/rbx-3.35
+++ b/share/ruby-build/rbx-3.35
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.35" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.35.tar.bz2#d72c8ec1a1cd6e1c77381e6d1e1d21811d71948a08f108d8a064884c379d2465" warn_eol rbx

--- a/share/ruby-build/rbx-3.36
+++ b/share/ruby-build/rbx-3.36
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.36" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.36.tar.bz2#660c6eaad9ab0ef3813942e906b14d1f02d071c6e25f60b9d6c8dfbab278b754" warn_eol rbx

--- a/share/ruby-build/rbx-3.37
+++ b/share/ruby-build/rbx-3.37
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.37" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.37.tar.bz2#85d855a0734c315d67b592675481458ddddac075426dbf6dc39a8ad34b8cb2d1" warn_eol rbx

--- a/share/ruby-build/rbx-3.38
+++ b/share/ruby-build/rbx-3.38
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.38" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.38.tar.bz2#2e038ee1e1dcee5b0d574cc446ad7bf2d98ea70ced35090f1680a90c6b9d6333" warn_eol rbx

--- a/share/ruby-build/rbx-3.39
+++ b/share/ruby-build/rbx-3.39
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.39" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.39.tar.bz2#f6f8132b44eadb4c07f8b26af16ce0a5470309ada33ef6f20ab76770a44193e0" warn_eol rbx

--- a/share/ruby-build/rbx-3.4
+++ b/share/ruby-build/rbx-3.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.4" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.4.tar.bz2#480a4f536bfdc7208b06bb40bef39944de7e1c770e9962f87c6900dec30155f8" warn_eol rbx

--- a/share/ruby-build/rbx-3.40
+++ b/share/ruby-build/rbx-3.40
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.40" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.40.tar.bz2#09f6590515bf6180427544fb217a34330a689784ea05b03f0a98db2a197bb20f" warn_eol rbx

--- a/share/ruby-build/rbx-3.41
+++ b/share/ruby-build/rbx-3.41
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.41" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.41.tar.bz2#b06966230e647aa0e5b64da14ba213256074c34f3bb8614be1ce81ef1434c41f" warn_eol rbx

--- a/share/ruby-build/rbx-3.42
+++ b/share/ruby-build/rbx-3.42
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.42" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.42.tar.bz2#4fc4413101100f6393894632eef522c2667a821856ac32eb99ccecab2aeeae85" warn_eol rbx

--- a/share/ruby-build/rbx-3.43
+++ b/share/ruby-build/rbx-3.43
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.43" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.43.tar.bz2#2c573257518774e464036515cc7283bc934a41566599afe94612c605844481ad" warn_eol rbx

--- a/share/ruby-build/rbx-3.44
+++ b/share/ruby-build/rbx-3.44
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.44" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.44.tar.bz2#c9e08b2e1d745798a0b32bef773e287361769c07a0eb9512377020661e2e4236" warn_eol rbx

--- a/share/ruby-build/rbx-3.45
+++ b/share/ruby-build/rbx-3.45
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.45" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.45.tar.bz2#5cadc3842c9c6d574bf5897354c384d8d688d9fa285b0d6083bdcc386bd6de96" warn_eol rbx

--- a/share/ruby-build/rbx-3.46
+++ b/share/ruby-build/rbx-3.46
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.46" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.46.tar.bz2#6bf24221ebd2c4d69e2388be1a3fa06d41009eeee00bfcdd86de8d57892d3fb2" warn_eol rbx

--- a/share/ruby-build/rbx-3.47
+++ b/share/ruby-build/rbx-3.47
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.47" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.47.tar.bz2#be734298ccad4dcadaa1f566d9655a971a4f12abc7629db045fd5c63e1685d16" warn_eol rbx

--- a/share/ruby-build/rbx-3.48
+++ b/share/ruby-build/rbx-3.48
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.48" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.48.tar.bz2#1180ea6a3de81bcd99c25b394fb05c010411bf4d3b48ee9881539b8043aeb561" warn_eol rbx

--- a/share/ruby-build/rbx-3.49
+++ b/share/ruby-build/rbx-3.49
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.49" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.49.tar.bz2#9a92d2cfede087e89f13f40e85e6c9cc9849041a0260144f44cd75aae67e3198" warn_eol rbx

--- a/share/ruby-build/rbx-3.5
+++ b/share/ruby-build/rbx-3.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.5" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.5.tar.bz2#13b0ce02d597f80c48ecc942b807368883e5cf3003bba2bc4957b3f1b368669e" warn_eol rbx

--- a/share/ruby-build/rbx-3.50
+++ b/share/ruby-build/rbx-3.50
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.50" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.50.tar.bz2#8da87cae447fe6bacd3417943bb1af603c2b4800bef0fc50ddd512ec89252ea8" warn_eol rbx

--- a/share/ruby-build/rbx-3.51
+++ b/share/ruby-build/rbx-3.51
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.51" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.51.tar.bz2#ded54018c6090dd0e051f7c3ffbb458ebdb5bcf77306a8b63d1bdeb73fb8c6f4" warn_eol rbx

--- a/share/ruby-build/rbx-3.52
+++ b/share/ruby-build/rbx-3.52
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.52" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.52.tar.bz2#657ed568ddc4a3155d05bc56ca6d327f960ec6098d03e1480b5c28936c70b5c5" warn_eol rbx

--- a/share/ruby-build/rbx-3.53
+++ b/share/ruby-build/rbx-3.53
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.53" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.53.tar.bz2#ec2efb7d026a41ef97cb9812961bf37803f3928f978e38f504cd2c09eae34f54" warn_eol rbx

--- a/share/ruby-build/rbx-3.54
+++ b/share/ruby-build/rbx-3.54
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.54" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.54.tar.bz2#2498a4c04feafba72d14c12e33ef881ae4bd8d3ccaa9bddcc8aec8acbad780fb" warn_eol rbx

--- a/share/ruby-build/rbx-3.55
+++ b/share/ruby-build/rbx-3.55
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.55" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.55.tar.bz2#fe7671beb3f36b987e02933afb392123b4c0a8ac15909a7b774d26101fec1ac1" warn_eol rbx

--- a/share/ruby-build/rbx-3.56
+++ b/share/ruby-build/rbx-3.56
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.56" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.56.tar.bz2#fa8170bc0eca01ebd83eb3a04240a0c7bd079ddf6ddc8b002167cff987db93b8" warn_eol rbx

--- a/share/ruby-build/rbx-3.57
+++ b/share/ruby-build/rbx-3.57
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.57" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.57.tar.bz2#c2bc550129ad306188458880240348892893d08af8e74e2dbdb5318f313762bd" warn_eol rbx

--- a/share/ruby-build/rbx-3.58
+++ b/share/ruby-build/rbx-3.58
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.58" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.58.tar.bz2#28875f1b9cb9b722323fa4217d9f3472e57a9ea6bd1fbc43a67eb47f81967cee" warn_eol rbx

--- a/share/ruby-build/rbx-3.59
+++ b/share/ruby-build/rbx-3.59
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.59" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.59.tar.bz2#feb65af7ff97ef44cab86790e3a67881cc0bc7389f01bfa10a9c2d62e9aadae7" warn_eol rbx

--- a/share/ruby-build/rbx-3.6
+++ b/share/ruby-build/rbx-3.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.6.tar.bz2#25b5913bba06511170e365643579ccfc193c1c4e74dbe6ea4b37dcabdcd8f6ad" warn_eol rbx

--- a/share/ruby-build/rbx-3.60
+++ b/share/ruby-build/rbx-3.60
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.60" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.60.tar.bz2#39f83fc74216391af56ea1ad13372878c0ed41fae49ee6a8cf8b0369a54c3b57" warn_eol rbx

--- a/share/ruby-build/rbx-3.61
+++ b/share/ruby-build/rbx-3.61
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.61" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.61.tar.bz2#38623cf198b1b0047b4c3404070252903b4da33c091be8708c205815d1516636" warn_eol rbx

--- a/share/ruby-build/rbx-3.62
+++ b/share/ruby-build/rbx-3.62
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.62" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.62.tar.bz2#1cc468a7967687a062c11e21bf6787cc60f6894590eabe3fc9be5e9af36a022f" warn_eol rbx

--- a/share/ruby-build/rbx-3.63
+++ b/share/ruby-build/rbx-3.63
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.63" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.63.tar.bz2#3003298b9d53620ad84d71a63be2a37b53dfdfe6c2fced9280a7f3b219f365d4" warn_eol rbx

--- a/share/ruby-build/rbx-3.64
+++ b/share/ruby-build/rbx-3.64
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.64" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.64.tar.bz2#43e2efd91074b52dc1d691e1424dbbb2e91bc9406b595dbb4753e9dd6001eedb" warn_eol rbx

--- a/share/ruby-build/rbx-3.65
+++ b/share/ruby-build/rbx-3.65
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.65" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.65.tar.bz2#a4290b6cd1f332c90405bd421163658a2d91abf27c83ad3afe7dbbbd3628829a" warn_eol rbx

--- a/share/ruby-build/rbx-3.66
+++ b/share/ruby-build/rbx-3.66
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.66" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.66.tar.bz2#4bb237a1da1d52bc830bbe704bd4b995bbc07e50b558e460aff54d6bc309975e" warn_eol rbx

--- a/share/ruby-build/rbx-3.67
+++ b/share/ruby-build/rbx-3.67
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.67" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.67.tar.bz2#a5eedd6169f80df528ac73cf2ed9183e2f5a82a57ca0b2ae3962c26238427b87" warn_eol rbx

--- a/share/ruby-build/rbx-3.68
+++ b/share/ruby-build/rbx-3.68
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.68" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.68.tar.bz2#44f423a8557aa8fa383573638a94faaf3f9c587a771be267c60ed0c78784f567" warn_eol rbx

--- a/share/ruby-build/rbx-3.69
+++ b/share/ruby-build/rbx-3.69
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.69" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.69.tar.bz2#2dcde5cb7ba1e1664f6bf902cd866d2564985536a0908caeac2e4099b6b255b2" warn_eol rbx

--- a/share/ruby-build/rbx-3.7
+++ b/share/ruby-build/rbx-3.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.7.tar.bz2#fafcdc518b5b2440960d023203bedca133be4af62e1ef8be9ff37a2842438257" warn_eol rbx

--- a/share/ruby-build/rbx-3.70
+++ b/share/ruby-build/rbx-3.70
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.70" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.70.tar.bz2#e5b22ff6f19d7ac75d94e7503ae74c0bf9a3d249ce0e80480402cf7cbd2fea19" warn_eol rbx

--- a/share/ruby-build/rbx-3.71
+++ b/share/ruby-build/rbx-3.71
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.71" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.71.tar.bz2#77bfac38feea0f7d1ebecd7be5b6fac9cefe44d00ee5932ee7ba9d1f078080b8" warn_eol rbx

--- a/share/ruby-build/rbx-3.72
+++ b/share/ruby-build/rbx-3.72
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.72" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.72.tar.bz2#7dfd678536d49947e08a327eb3b96a00c49f6b4a3ee5d4b548f4840efef0726c" warn_eol rbx

--- a/share/ruby-build/rbx-3.73
+++ b/share/ruby-build/rbx-3.73
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.73" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.73.tar.bz2#4fea98d26df5a00185d5d92684ec04cf6a22ca8cf6e9b47c3895ba5e6f14ea1a" warn_eol rbx

--- a/share/ruby-build/rbx-3.74
+++ b/share/ruby-build/rbx-3.74
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.74" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.74.tar.bz2#8dae2c4e4b2361cdeafb39035f8b1b1bfe6387104f43ae6026cae3234793b8e5" warn_eol rbx

--- a/share/ruby-build/rbx-3.75
+++ b/share/ruby-build/rbx-3.75
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.75" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.75.tar.bz2#04cd1bc8fa021d569aac38cf98aeeb97f8324815f82d7ea1a0c963898c79e137" warn_eol rbx

--- a/share/ruby-build/rbx-3.76
+++ b/share/ruby-build/rbx-3.76
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.76" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.76.tar.bz2#1606d229ea611f3c271f0b579c839cea6a1b4b07ddea7b0c4d2d794146781589" warn_eol rbx

--- a/share/ruby-build/rbx-3.77
+++ b/share/ruby-build/rbx-3.77
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.77" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.77.tar.bz2#badaeb4129c64979fb37322cc1913effde17010db5f57398ab7409f3fb84360e" warn_eol rbx

--- a/share/ruby-build/rbx-3.78
+++ b/share/ruby-build/rbx-3.78
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.78" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.78.tar.bz2#d285d798226fa6d80db7fd5afc2ceb2860546378772beccab154b8b7612446c9" warn_eol rbx

--- a/share/ruby-build/rbx-3.79
+++ b/share/ruby-build/rbx-3.79
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.79" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.79.tar.bz2#514c5032a23bfc1ca2defce646cc3a740aa053dab37e0cb4fbba1d4f11a9c33a" warn_eol rbx

--- a/share/ruby-build/rbx-3.8
+++ b/share/ruby-build/rbx-3.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.8.tar.bz2#9a74316b1adf7535c4529741bd3b7e660b7fbdb01ab1c5e6deeed0fae09b811d" warn_eol rbx

--- a/share/ruby-build/rbx-3.80
+++ b/share/ruby-build/rbx-3.80
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.80" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.80.tar.bz2#8cda9123efac9c2bbe374368c4767ada7e28299a7c4c706c562b3d133f96c19e" warn_eol rbx

--- a/share/ruby-build/rbx-3.81
+++ b/share/ruby-build/rbx-3.81
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.81" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.81.tar.bz2#d8fffa145f1132bc2d1f17d9194f1b8fc6dffa0f3ff6c29b44e99378daeea807" warn_eol rbx

--- a/share/ruby-build/rbx-3.82
+++ b/share/ruby-build/rbx-3.82
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.82" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.82.tar.bz2#53abb85219980d7307a762660e1d509cd74beccbcf4d46979ddd0749e77a1401" warn_eol rbx

--- a/share/ruby-build/rbx-3.83
+++ b/share/ruby-build/rbx-3.83
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.83" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.83.tar.bz2#323d44321478aca7ccb8c5a76addc00df4aa90ec89a69a764e92fe77896669aa" warn_eol rbx

--- a/share/ruby-build/rbx-3.84
+++ b/share/ruby-build/rbx-3.84
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.84" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.84.tar.bz2#87eeaf24efd64bb06c4409814410a9154287dd889a976b70c474ef88992b279d" warn_eol rbx

--- a/share/ruby-build/rbx-3.85
+++ b/share/ruby-build/rbx-3.85
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.85" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.85.tar.bz2#18a55be0de6323847f946af43cedcc44277e62124c8140523b34776265a5c6e1" warn_eol rbx

--- a/share/ruby-build/rbx-3.86
+++ b/share/ruby-build/rbx-3.86
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.86" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.86.tar.bz2#cfb0650b937d109cf52c982f185ef247cc7a184dbb5f16c625d4827cef11f6fb" warn_eol rbx

--- a/share/ruby-build/rbx-3.87
+++ b/share/ruby-build/rbx-3.87
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.87" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.87.tar.bz2#53eb602a8635aef334142832ba3b81ee7ca58706643f5136f019cdae6f4431c2" warn_eol rbx

--- a/share/ruby-build/rbx-3.88
+++ b/share/ruby-build/rbx-3.88
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.88" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.88.tar.bz2#e1c11578256b072870cfe929edfcb5965f076ef7543a92c7d0e6cf4c22787fae" warn_eol rbx

--- a/share/ruby-build/rbx-3.89
+++ b/share/ruby-build/rbx-3.89
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.89" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.89.tar.bz2#6e48ecd3253137c9d958e762fe9f5e512b597ffbd7f44ddabc716f8d33ea7d71" warn_eol rbx

--- a/share/ruby-build/rbx-3.9
+++ b/share/ruby-build/rbx-3.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.9.tar.bz2#de5a2238d90387143b8b63a52b7f036d408d7a84387347e56099d811c423bdf6" warn_eol rbx

--- a/share/ruby-build/rbx-3.90
+++ b/share/ruby-build/rbx-3.90
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.90" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.90.tar.bz2#f888910670ff2a9f913a66b18447ee3fab6a4ee424015e46e8c9e0dbb9c600d8" warn_eol rbx

--- a/share/ruby-build/rbx-3.91
+++ b/share/ruby-build/rbx-3.91
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.91" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.91.tar.bz2#9be8f94a322cd27c84f51e8075635ee7193e407ea0b37d6e297bea01dd2aa0a6" warn_eol rbx

--- a/share/ruby-build/rbx-3.92
+++ b/share/ruby-build/rbx-3.92
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.92" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.92.tar.bz2#a15196a33c3628aa5baff0613102973fe0e489583b2614f9dacc02ad33efe87b" warn_eol rbx

--- a/share/ruby-build/rbx-3.93
+++ b/share/ruby-build/rbx-3.93
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.93" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.93.tar.bz2#851a93d68727f41603dbafa498ffe37bcdf2e6c697ba07c7804062f6a07200a9" warn_eol rbx

--- a/share/ruby-build/rbx-3.94
+++ b/share/ruby-build/rbx-3.94
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.94" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.94.tar.bz2#bf82ab49248f0011ba89a36e1d6f45d37703398d03b0c379184e3276130f0861" warn_eol rbx

--- a/share/ruby-build/rbx-3.95
+++ b/share/ruby-build/rbx-3.95
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.95" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.95.tar.bz2#cb2f42645e5408c8017fe80975179ddc38357192193f16070120ee38a2891801" warn_eol rbx

--- a/share/ruby-build/rbx-3.96
+++ b/share/ruby-build/rbx-3.96
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.96" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.96.tar.bz2#78e077f9faa115da58c616f6f660875f85f44f6a3708560b61c294c53aec8f5c" warn_eol rbx

--- a/share/ruby-build/rbx-3.97
+++ b/share/ruby-build/rbx-3.97
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.97" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.97.tar.bz2#a47549474734cd64fb6d122966cfeb8bf46adba5cde2d1b85a9fa753f2668118" warn_eol rbx

--- a/share/ruby-build/rbx-3.98
+++ b/share/ruby-build/rbx-3.98
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.98" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.98.tar.bz2#e8230eed22818893ba4771f0c409104ccccf5b4b4102c9289d3c85a000d13f36" warn_eol rbx

--- a/share/ruby-build/rbx-3.99
+++ b/share/ruby-build/rbx-3.99
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-3.99" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.99.tar.bz2#56ed8edf91add5f497a68e5b11165db6640eb2d4effbb6453ab4b5e6b847b178" warn_eol rbx

--- a/share/ruby-build/rbx-4.0
+++ b/share/ruby-build/rbx-4.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.0.tar.bz2#6e58d8141c953dd60028538215fba486892550ea5d7cb580685d7044a276f731" warn_eol rbx

--- a/share/ruby-build/rbx-4.1
+++ b/share/ruby-build/rbx-4.1
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.1" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.1.tar.bz2#7c613286ee3f5ea908c2262b801f74c4732d203ea979bed3f584881e9adfa433" warn_eol rbx

--- a/share/ruby-build/rbx-4.10
+++ b/share/ruby-build/rbx-4.10
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.10" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.10.tar.bz2#2d719ed23162ba3c815c60aa9b516ed001987d723a9127a46943d83e88659620" warn_eol rbx

--- a/share/ruby-build/rbx-4.11
+++ b/share/ruby-build/rbx-4.11
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.11" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.11.tar.bz2#737138e8d09f83ac5e3e3c28bc9245e943f8bf1eb1386231cfd34f4f9df5cbda" warn_eol rbx

--- a/share/ruby-build/rbx-4.12
+++ b/share/ruby-build/rbx-4.12
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.12" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.12.tar.bz2#5f60e3f9f09b8660f5a9a4c99769b4f52e2081325824e068c06b2474beaa467a" warn_eol rbx

--- a/share/ruby-build/rbx-4.13
+++ b/share/ruby-build/rbx-4.13
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.13" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.13.tar.bz2#5c5b86d83e6403d80c52b1be6e38e6e582f823e53821757ca8e07606b15459b5" warn_eol rbx

--- a/share/ruby-build/rbx-4.14
+++ b/share/ruby-build/rbx-4.14
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.14" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.14.tar.bz2#8a4c1a4894faaa25625d7204605aca6d211028c1f6a74e4c6b46348a53669531" warn_eol rbx

--- a/share/ruby-build/rbx-4.15
+++ b/share/ruby-build/rbx-4.15
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.15" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.15.tar.bz2#2ecae57e09cc642d4aa2a081aee8a657b0aa29bd76266b888edfb03865a96286" warn_eol rbx

--- a/share/ruby-build/rbx-4.16
+++ b/share/ruby-build/rbx-4.16
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.16" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.16.tar.bz2#598d0f10645dcdf79d0b2302d7e76aff14755d57dced7939aa96ef2c7e454e0c" warn_eol rbx

--- a/share/ruby-build/rbx-4.18
+++ b/share/ruby-build/rbx-4.18
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.18" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.18.tar.bz2#4498d27dc77b20fa864b66bd2183c227398594a2178d92e6b3a135b991dec05f" warn_eol rbx

--- a/share/ruby-build/rbx-4.19
+++ b/share/ruby-build/rbx-4.19
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.19" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.19.tar.bz2#6b3a63edf2f04937ce92c1a94e68cf51680621dda3d9139a864999e78b620ace" warn_eol rbx

--- a/share/ruby-build/rbx-4.2
+++ b/share/ruby-build/rbx-4.2
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.2" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.2.tar.bz2#b9307a8e8f3348d066a0f5b9ab097b3428117f9c6d428ce6110f521c42b2227d" warn_eol rbx

--- a/share/ruby-build/rbx-4.20
+++ b/share/ruby-build/rbx-4.20
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.20" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.20.tar.bz2#2499826151950d8d657fe71b5666d58cf93b0c97b56dabc1e7ec35d263df9bbf" warn_eol rbx

--- a/share/ruby-build/rbx-4.3
+++ b/share/ruby-build/rbx-4.3
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.3" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.3.tar.bz2#9112096efad03fcab391392555c6226849bb318fe0b5645399d4e071c3f2f097" warn_eol rbx

--- a/share/ruby-build/rbx-4.4
+++ b/share/ruby-build/rbx-4.4
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.4" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.4.tar.bz2#1a7207564e11998866c2f99d75f6f03dd41567dae6433d37b312761883ba11c8" warn_eol rbx

--- a/share/ruby-build/rbx-4.5
+++ b/share/ruby-build/rbx-4.5
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.5" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.5.tar.bz2#1fe2261f41cd6edb44ca1ce03290e5631d0d2751cecf4d7999fa496bb68349dc" warn_eol rbx

--- a/share/ruby-build/rbx-4.6
+++ b/share/ruby-build/rbx-4.6
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.6" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.6.tar.bz2#57e93b206b9d9c630af03ef9cea9d18cba247f869f3d3d1db95afa6854011d2e" warn_eol rbx

--- a/share/ruby-build/rbx-4.7
+++ b/share/ruby-build/rbx-4.7
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.7" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.7.tar.bz2#52e105477c3d184aaee87c5bc0bae1c2218b757e069e0cff4c3ef788fa2305e8" warn_eol rbx

--- a/share/ruby-build/rbx-4.8
+++ b/share/ruby-build/rbx-4.8
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.8" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.8.tar.bz2#b99960bb89bcb9197ad8f1350cae715dd92029b9f89c8eaee1450f80fd38fc8e" warn_eol rbx

--- a/share/ruby-build/rbx-4.9
+++ b/share/ruby-build/rbx-4.9
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-4.9" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-4.9.tar.bz2#b8c183433a5788dc790643d14ac6c182742456f20686389291b3f0cdcceeaaa5" warn_eol rbx

--- a/share/ruby-build/rbx-5.0
+++ b/share/ruby-build/rbx-5.0
@@ -1,2 +1,2 @@
-install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl_096_102
+install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "rubinius-5.0" "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-5.0.tar.bz2#c9e90e3ef2fb80714b09895611152024fecbb3f13955298fa63e57b1785e8ff0" warn_eol rbx

--- a/test/stubs/stub
+++ b/test/stubs/stub
@@ -44,8 +44,9 @@ inspect_args() {
 }
 
 # Loop over each line in the plan.
+IFS=$'\n' read -d '' -r -a lines < "${!_STUB_PLAN}" || true
 index=0
-while IFS= read -r line; do
+for line in "${lines[@]}"; do
   index=$(($index + 1))
 
   if [[ -z "${!_STUB_END}" && -n "${!_STUB_NOINDEX}" || $index -eq "${!_STUB_INDEX}" ]]; then
@@ -93,7 +94,7 @@ while IFS= read -r line; do
       eval "${_STUB_RESULT}"=1
     fi
   fi
-done < "${!_STUB_PLAN}"
+done
 
 
 if [ -n "${!_STUB_END}" ]; then


### PR DESCRIPTION
If a build definition invokes an openssl requirement, but there is no satisfying system OpenSSL version—e.g. always a state of affairs on macOS—automatically query Homebrew-installed versions with `brew --prefix openssl@<version>` (with a range of versions between "1.1" and "3.1") and automatically link to the latest one found that Ruby is known to be compatible with.

The goal is to skip compiling a per-Ruby version of OpenSSL whenever possible, speeding up Ruby installation and reducing the number of compile dependencies for a typical user, hopefully resulting in fewer "build failed" reports in this repository.

We tried this before by always linking to `openssl@1.1`, but that was neither future-proof (today is more common to have `openssl@3` installed) nor backward compatible as it sabotaged installations of older Ruby versions. https://github.com/rbenv/ruby-build/pull/1375

Fixes https://github.com/rbenv/ruby-build/issues/2157
Followup to #1974 

* * *

Feedback wanted: this PR introduces this syntax:
```sh
install_package openssl-1.1.1 "https://..." --if "needs_openssl 1.0.2 3.x.x"
```
i.e. there is a single function `needs_openssl` that now takes arbitrary arguments. This replaces the previous set of functions named like `needs_openssl_102_300` which weren't future-proof. Now, every build definition explicitly and precisely specifies which openssl versions it wants.

I'm not in love with the new syntax, especially because quotes are necessary to keep the condition function and its arguments as a single argument in bash. But I do like the added functionality! What do you think?

Possible alternative syntaxes:
- `--if "needs_openssl 1.0.2 3.x.x"` - I don't like the quotes; it looks like the code in question will get `eval`'d from string (not true)
- `--if needs_openssl:1.0.2:3.x.x`
- `--if needs_openssl:1.0.2-3.x.x`
- `--if needs_openssl@1.0.2-3.x.x`

Keep in mind that the intent here is that this is a more generalized syntax for any `--if` condition, means that it could facilitate passing different arguments than just version numbers in the future.