### PR TITLE
Remove strict `openssl@1.1` requirement from TruffleRuby, jruby-dev definitions

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1068,6 +1068,7 @@ needs_openssl_102_300() {
   (( version < 102 || version >= 400 ))
 }
 
+# Kept for backward compatibility with 3rd-party Ruby definitions.
 use_homebrew_openssl() {
   local ssldir
   ssldir="$(brew --prefix openssl@1.1 2>/dev/null || true)"

--- a/script/update-truffleruby
+++ b/script/update-truffleruby
@@ -36,12 +36,10 @@ EOS
 add_platform "linux-aarch64"
 cat >> "$file" <<EOS
 Darwin-x86_64)
-  use_homebrew_openssl
 EOS
 add_platform "macos-amd64"
 cat >> "$file" <<EOS
 Darwin-arm64)
-  use_homebrew_openssl
 EOS
 add_platform "macos-aarch64"
 cat >> "$file" <<EOS

--- a/script/update-truffleruby-graalvm
+++ b/script/update-truffleruby-graalvm
@@ -36,12 +36,10 @@ EOS
 add_platform "linux-aarch64"
 cat >> "$file" <<EOS
 Darwin-x86_64)
-  use_homebrew_openssl
 EOS
 add_platform "macos-amd64"
 cat >> "$file" <<EOS
 Darwin-arm64)
-  use_homebrew_openssl
 EOS
 add_platform "macos-aarch64"
 cat >> "$file" <<EOS

--- a/share/ruby-build/jruby-dev
+++ b/share/ruby-build/jruby-dev
@@ -3,7 +3,6 @@ Linux)
   install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-ubuntu-20.04.tar.gz" jruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-macos-latest.tar.gz" jruby
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-20.1.0
+++ b/share/ruby-build/truffleruby+graalvm-20.1.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby+graalvm-20.1.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java8-linux-amd64-20.1.0.tar.gz#4fac212b37cd548831fd6587dd4d59dc068068815aa20323b47fde9529d6bb6e" truffleruby_graalvm
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-20.1.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java8-darwin-amd64-20.1.0.tar.gz#3b9fd8ce84c9162a188fde88907c66990db22af0ff6ae2c04430113253a9a634" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-20.2.0
+++ b/share/ruby-build/truffleruby+graalvm-20.2.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby+graalvm-20.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java8-linux-amd64-20.2.0.tar.gz#60951c774c708caeebd1fa3886c05aa1260d81c7595ede0c9c3e689be7fcc4e8" truffleruby_graalvm
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-20.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.2.0/graalvm-ce-java8-darwin-amd64-20.2.0.tar.gz#a1f524788354cfd2434566f0de972372f4a7743919bae49a9d508f2080385e7b" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-20.3.0
+++ b/share/ruby-build/truffleruby+graalvm-20.3.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby+graalvm-20.3.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java8-linux-amd64-20.3.0.tar.gz#455cadf810780161b74da9e23b529426398ce40843603cacbc11edbd2310aba4" truffleruby_graalvm
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-20.3.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java8-darwin-amd64-20.3.0.tar.gz#01e84c44032f8932ed04b2b829e0454973145bf55ddeeeed0ce71220c2213ae7" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-21.0.0
+++ b/share/ruby-build/truffleruby+graalvm-21.0.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby+graalvm-21.0.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0/graalvm-ce-java8-linux-amd64-21.0.0.tar.gz#326c5a9ba2f6a6b28023c1fef9c4c6fb6acf9cd87b0fcb6916e0527633bd01a3" truffleruby_graalvm
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-21.0.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0/graalvm-ce-java8-darwin-amd64-21.0.0.tar.gz#9192d8370b544c0efd36ef744f5933bd2d694d0cc9cb5e7f53d3b7e58f433b3e" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-21.1.0
+++ b/share/ruby-build/truffleruby+graalvm-21.1.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby+graalvm-21.1.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-amd64-21.1.0.tar.gz#39252954d2cb16dbc8ce4269f8b93a326a0efffdce04625615e827fe5b5e4ab7" truffleruby_graalvm
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-21.1.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-darwin-amd64-21.1.0.tar.gz#b53cd5a085fea39cb27fc0e3974f00140c8bb774fb2854d72db99e1be405ae2b" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-21.2.0
+++ b/share/ruby-build/truffleruby+graalvm-21.2.0
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-21.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-aarch64-21.2.0.tar.gz#bbdf38d5e6871f7e3b2470ab9b9bb760667d4524ee2a20eadfaf13636a2d018c" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-21.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-darwin-amd64-21.2.0.tar.gz#f62cdc44a031731aa221426724a55eb09c79d6b2e9275ae3ca7003da5884ca36" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-21.3.0
+++ b/share/ruby-build/truffleruby+graalvm-21.3.0
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-21.3.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-linux-aarch64-21.3.0.tar.gz#1134fce3823a52bd9d65f77a698c6aaf30a70e65ad399266b25a1e4fcded5243" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-21.3.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-darwin-amd64-21.3.0.tar.gz#6c2bf7f6e5fab901e8a2284a0dbec6ce214bde65aa80cfeb90bfef8eabb5f862" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-22.0.0.2
+++ b/share/ruby-build/truffleruby+graalvm-22.0.0.2
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-22.0.0.2" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-linux-aarch64-22.0.0.2.tar.gz#1cc0263d95f642dada4e290dca7f49c0456cefa7b690b67e3e5c159b537b2c58" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.0.0.2" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-darwin-amd64-22.0.0.2.tar.gz#8280159b8a66c51a839c8079d885928a7f759d5da0632f3af7300df2b63a6323" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-22.1.0
+++ b/share/ruby-build/truffleruby+graalvm-22.1.0
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-22.1.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.1.0/graalvm-ce-java11-linux-aarch64-22.1.0.tar.gz#050a4d471247d91935f7f485e92d678f0163e1d6209e26e8fe75d7c924f73e71" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.1.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.1.0/graalvm-ce-java11-darwin-amd64-22.1.0.tar.gz#c4c9df94ca47b83b582758b87d39042732ba0193fc63f1ab93f6818005a1fe6b" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-22.2.0
+++ b/share/ruby-build/truffleruby+graalvm-22.2.0
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-22.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java11-linux-aarch64-22.2.0.tar.gz#1ab64b35ed2478160bc6725d13ff5a2b9e31676b59ea3aaa9aca7a3a3db47132" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java11-darwin-amd64-22.2.0.tar.gz#3c6aca6faefa9e1f73de45fc56cc07d6f7864f63ce0b95148002dadb8f78cd86" truffleruby_graalvm
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.2.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java11-darwin-aarch64-22.2.0.tar.gz#ee513cec2ef7b34ae6fbb8a3015c227ab2a24bfb2771c16152f15a1846df01f4" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-22.3.0
+++ b/share/ruby-build/truffleruby+graalvm-22.3.0
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-22.3.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java11-linux-aarch64-22.3.0.tar.gz#c6646149dad486a0b02c5fc10649786240f275efda65aa14a25d01d2f5bafe15" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.3.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java11-darwin-amd64-22.3.0.tar.gz#b8b39d6a3e3a9ed6348c2776ff071fc64ca90f98999ee846e6ca7e5fdc746a8b" truffleruby_graalvm
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.3.0" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java11-darwin-aarch64-22.3.0.tar.gz#c9657e902c2ba674931c3cf233a38c4de3d5186ae5d70452f9df75ac0c4cacff" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-22.3.1
+++ b/share/ruby-build/truffleruby+graalvm-22.3.1
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-22.3.1" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.1/graalvm-ce-java11-linux-aarch64-22.3.1.tar.gz#b46a3f9c82ac70990a62282b1fbe4474e784d9ba453839a428f88e94d21f8abc" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.3.1" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.1/graalvm-ce-java11-darwin-amd64-22.3.1.tar.gz#325afad5f1c4a07a458c95e7c444cff63514a6afa6f2655c12b4f494dccf2228" truffleruby_graalvm
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-22.3.1" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.1/graalvm-ce-java11-darwin-aarch64-22.3.1.tar.gz#c59f32289d92671bea46a34f4227fef484a4aa9eeece159e59a486205aaa6c31" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-23.0.0
+++ b/share/ruby-build/truffleruby+graalvm-23.0.0
@@ -10,11 +10,9 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-23.0.0" "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.7_linux-aarch64_bin.tar.gz#73256df1af0507f8cb230bafe506e4dcaba2b3e6d8bb1324bf5a02198890ef97" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-23.0.0" "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.7_macos-x64_bin.tar.gz#905255762546c69e3bb8d815a5d20e2e3cfa5332b868ab90af7aa0afe21e74ea" truffleruby_graalvm
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-23.0.0" "https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.7_macos-aarch64_bin.tar.gz#cb45f6585ef02134a6a6ffb6de20db96197486ffef8821ad97b11fe2fc0c23b8" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-23.0.0-preview1
+++ b/share/ruby-build/truffleruby+graalvm-23.0.0-preview1
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/graalvm-ruby-community-23.0.0-preview1-jdk17-linux-aarch64.tar.gz#b8b6f6493219b5435eea87305cdb14b8f5af7b8d45097840afaf314428756748" truffleruby_graalvm
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/graalvm-ruby-community-23.0.0-preview1-jdk17-darwin-amd64.tar.gz#dd7370352697325e0cfa25d069a64903103601bfacc7c7e1c515409e9cf74386" truffleruby_graalvm
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/graalvm-ruby-community-23.0.0-preview1-jdk17-darwin-aarch64.tar.gz#bfe1c1227d3648bbdaf4e40716e12729c5f1f66a40983d3ca3d2f814f570d4e0" truffleruby_graalvm
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-23.1.0
+++ b/share/ruby-build/truffleruby+graalvm-23.1.0
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-23.1.0" "https://github.com/oracle/truffleruby/releases/download/graal-23.1.0/truffleruby-jvm-23.1.0-linux-aarch64.tar.gz#691550c167cb37d4b15f9b56337b86ec481407a22e9408597b06703794c16f57" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-23.1.0" "https://github.com/oracle/truffleruby/releases/download/graal-23.1.0/truffleruby-jvm-23.1.0-macos-amd64.tar.gz#1a573c85e384b80efc4974cba6f6da68961589708110e1d2b7ac9c2029e7447e" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-23.1.0" "https://github.com/oracle/truffleruby/releases/download/graal-23.1.0/truffleruby-jvm-23.1.0-macos-aarch64.tar.gz#1309c448dfdd98b7d77457e6a864e95be0c6acfbd0d9d9cd361eca46b96266de" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby+graalvm-dev
+++ b/share/ruby-build/truffleruby+graalvm-dev
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-jvm-dev-linux-aarch64.tar.gz" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-jvm-dev-macos-amd64.tar.gz" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-jvm-dev-macos-aarch64.tar.gz" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc10
+++ b/share/ruby-build/truffleruby-1.0.0-rc10
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc10" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc10/truffleruby-1.0.0-rc10-linux-amd64.tar.gz#a3271572f202edf4d3d67ffd49508ccf80597a98219e2d3c217df43cbdfded2d" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc10" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc10/truffleruby-1.0.0-rc10-macos-amd64.tar.gz#b5a467ef7562b8806829dc7ea3fab6135e533350fe4f076c6c5fe5c8d0bd1283" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc11
+++ b/share/ruby-build/truffleruby-1.0.0-rc11
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc11" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc11/truffleruby-1.0.0-rc11-linux-amd64.tar.gz#268c38f01331db4cbeae584aea4e9336b6a01aa1fcc621dda1232dcaac89da45" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc11" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc11/truffleruby-1.0.0-rc11-macos-amd64.tar.gz#c8c86fe7a77cacd690ddb64c66fbd92ff1f08788e40494cb4662b3d4731b02a6" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc12
+++ b/share/ruby-build/truffleruby-1.0.0-rc12
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc12" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc12/truffleruby-1.0.0-rc12-linux-amd64.tar.gz#f84b7fe9e2376962889dbc92c17997954e4e8b8db3e64b07e4220102f47f4aa5" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc12" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc12/truffleruby-1.0.0-rc12-macos-amd64.tar.gz#3796e42978408826360464234809c71a84e1017227fef688c865b3e636ff3402" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc13
+++ b/share/ruby-build/truffleruby-1.0.0-rc13
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc13" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc13/truffleruby-1.0.0-rc13-linux-amd64.tar.gz#26936811d08eed742b3ccf04ae7cc894abc0ba4e5c2cbfd3d43163d620f446e4" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc13" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc13/truffleruby-1.0.0-rc13-macos-amd64.tar.gz#c3dd003ee97c69da2697e2c09e538e13252f2c409b07b4bde4e5acbdbbf5314c" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc14
+++ b/share/ruby-build/truffleruby-1.0.0-rc14
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc14" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc14/truffleruby-1.0.0-rc14-linux-amd64.tar.gz#e944421c3057e9fdc1d9c00cb53b4e1abe7d88fd922a2124f6b9eb49a85bfb6f" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc14" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc14/truffleruby-1.0.0-rc14-macos-amd64.tar.gz#344ae35a57de1439be451d37066b678ed884bdd1fee0e5e685f00de24ff5d9dc" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc15
+++ b/share/ruby-build/truffleruby-1.0.0-rc15
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc15" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc15/truffleruby-1.0.0-rc15-linux-amd64.tar.gz#cad2538bda6230d290d67f9ee0c6ef06cb9d149e6f84f1b847e94da7d33ca99f" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc15" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc15/truffleruby-1.0.0-rc15-macos-amd64.tar.gz#8b664a836ec080ddee043ae78de4d2c362ae840706dc045ede6c40af8533a6f2" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc16
+++ b/share/ruby-build/truffleruby-1.0.0-rc16
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc16" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc16/truffleruby-1.0.0-rc16-linux-amd64.tar.gz#58fee4266b68cfe4e90f46a005693955370a760ccaf28224c9fcbd59241ff4b5" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc16" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc16/truffleruby-1.0.0-rc16-macos-amd64.tar.gz#86d385feab785abb8e9f84ac76900eec69082f15918c4d9edb478c00dcd8330b" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc2
+++ b/share/ruby-build/truffleruby-1.0.0-rc2
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-linux-amd64.tar.gz#2b7d999646dcfb895e49a41606a0b53ca055f291fb0cc33002944655fc3e2acb" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc2" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc2/truffleruby-1.0.0-rc2-macos-amd64.tar.gz#308a5bf727914803cc0f794fd1aea89fd5f80ce00a97120372be9c58a930b82c" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc3
+++ b/share/ruby-build/truffleruby-1.0.0-rc3
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-linux-amd64.tar.gz#d54bf05866d50e4fe589a7e8f30935062245292eb338098d143cbd67f33c823a" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc3" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc3/truffleruby-1.0.0-rc3-macos-amd64.tar.gz#8b6805df62e6e11982d1ec035269a51c325626c5d38ac8e10d28ae17eefee041" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc5
+++ b/share/ruby-build/truffleruby-1.0.0-rc5
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-linux-amd64.tar.gz#c40cf6f8b2d664aa22a2b230af0e5889a9bf7ec07de9fb84454f5ab05d43c90c" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc5" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc5/truffleruby-1.0.0-rc5-macos-amd64.tar.gz#d05798f9bd302eb6e03daa608e2a65fc01abc9cddcd6f60150e625fb84c1199c" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc6
+++ b/share/ruby-build/truffleruby-1.0.0-rc6
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc6" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc6/truffleruby-1.0.0-rc6-linux-amd64.tar.gz#a2514b1f992d9359de86a7e4faa5c14ad6b418e88fd7cf6e67cd9b2fdb1ae85d" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc6" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc6/truffleruby-1.0.0-rc6-macos-amd64.tar.gz#de2af4e1115fa96245d143fa323234cc78cd6ab3e29d68cee4bb74064c97a124" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc7
+++ b/share/ruby-build/truffleruby-1.0.0-rc7
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc7" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc7/truffleruby-1.0.0-rc7-linux-amd64.tar.gz#be83d50f6c60c5ebe5800d9d326a44af13b934fd9cc2def6614cc0558176543f" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc7" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc7/truffleruby-1.0.0-rc7-macos-amd64.tar.gz#a189793967c4eac9cd114c613ed3aeb8d5060685035ceba2ab99c3de39bb97a3" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc8
+++ b/share/ruby-build/truffleruby-1.0.0-rc8
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc8" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc8/truffleruby-1.0.0-rc8-linux-amd64.tar.gz#080e066272184a72dc8019841ad0bca015cfa4ab979c6605c30346fcc0604597" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc8" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc8/truffleruby-1.0.0-rc8-macos-amd64.tar.gz#e627b43cdd5e8f1711704c6a2f5a1503957df7b226fd722771c54ea6c217457a" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-1.0.0-rc9
+++ b/share/ruby-build/truffleruby-1.0.0-rc9
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-1.0.0-rc9" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc9/truffleruby-1.0.0-rc9-linux-amd64.tar.gz#cccbe87360385f99f14eca94e834599caf89b93eaaa3934f1e63b403cc7a63e5" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-1.0.0-rc9" "https://github.com/oracle/truffleruby/releases/download/vm-1.0.0-rc9/truffleruby-1.0.0-rc9-macos-amd64.tar.gz#7cf61d001e0d3e5b3f053ecc8e5923adc30af3e580df7cc3625ad0cd95db0b85" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-19.0.0
+++ b/share/ruby-build/truffleruby-19.0.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-19.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.0.0/truffleruby-19.0.0-linux-amd64.tar.gz#42b37f6e36a04bdd7319f7ad46f9790e7f8234a910c12229625afb0931b1d2d9" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-19.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.0.0/truffleruby-19.0.0-macos-amd64.tar.gz#962003deaae6eff3150a9682287636445088bedf667bf62c635646659878ec49" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-19.1.0
+++ b/share/ruby-build/truffleruby-19.1.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-19.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.1.0/truffleruby-19.1.0-linux-amd64.tar.gz#5fc68b22ee95259f62edaf3d80af9073461ced0931b61e50e2147a42724a9ada" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-19.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.1.0/truffleruby-19.1.0-macos-amd64.tar.gz#9cb8e8374dd21928bf822394810988e37f1a7c804cf407fb2b2a0a50e9302f3b" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-19.2.0
+++ b/share/ruby-build/truffleruby-19.2.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-19.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0/truffleruby-19.2.0-linux-amd64.tar.gz#9dd36f703b862cb5d6ffb93be7b5f9ad92992fa93664fdadfd487af0c9c3f40a" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-19.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0/truffleruby-19.2.0-macos-amd64.tar.gz#7f717cb86bd93e0c191f7a7ec39aaa66bad0b9e76348efc4c9104983290c1ffb" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-19.2.0.1
+++ b/share/ruby-build/truffleruby-19.2.0.1
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-19.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0.1/truffleruby-19.2.0.1-linux-amd64.tar.gz#38facb48768340efe638579b67a5e3f4cd8fa091006f7e098a654ddf3ec1bbac" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-19.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-19.2.0.1/truffleruby-19.2.0.1-macos-amd64.tar.gz#3a1bef2706ea9dc430f45ec0d7bf798ef09526f39d5102d88ef6a1b74bea3c12" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-19.3.0
+++ b/share/ruby-build/truffleruby-19.3.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-19.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.0/truffleruby-19.3.0-linux-amd64.tar.gz#1fe9100a5272c5f82990a6ad4da08422f8a25d1b8d028fa89d32affa8d7e376f" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-19.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.0/truffleruby-19.3.0-macos-amd64.tar.gz#b2958301dbe0d2ed6dd430ccfb4c06f414a575e2fa6dbd38f6cf7ef63f679550" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-19.3.0.2
+++ b/share/ruby-build/truffleruby-19.3.0.2
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-19.3.0.2" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.0.2/truffleruby-19.3.0.2-linux-amd64.tar.gz#9b57a4a88e49bf29e63b53471ed002129ae22551c9da3ee120dadfe54ab6ac1a" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-19.3.0.2" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.0.2/truffleruby-19.3.0.2-macos-amd64.tar.gz#fb35cd0612c1d71c63d8bc5d954b1899a9ac13bbca82bfd2b4ec28e2a3d6a297" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-19.3.1
+++ b/share/ruby-build/truffleruby-19.3.1
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-19.3.1" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.1/truffleruby-19.3.1-linux-amd64.tar.gz#f442dfbfd22fe9f981f1cdd297ce0a5186dfcb696c02d685554bd9a95b299e1b" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-19.3.1" "https://github.com/oracle/truffleruby/releases/download/vm-19.3.1/truffleruby-19.3.1-macos-amd64.tar.gz#73035713af1d40030718d6ed4ef92db0a3dbd7edec8efe8c95d559defa78bb1e" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-20.0.0
+++ b/share/ruby-build/truffleruby-20.0.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-20.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.0.0/truffleruby-20.0.0-linux-amd64.tar.gz#48331324185773bf38d34a945b410d58a71ea7d206015cea1d4da5ce51cfef30" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-20.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.0.0/truffleruby-20.0.0-macos-amd64.tar.gz#3ea8519f946c3807dc1e7deb9a0bbdaddef43713abc6352b0127ac085e2ff1eb" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-20.1.0
+++ b/share/ruby-build/truffleruby-20.1.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-20.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.1.0/truffleruby-20.1.0-linux-amd64.tar.gz#aefae79abba2b21371754b103fba73d1b042f1ebc4a1b61fc0ca87eb016ee9c3" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-20.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.1.0/truffleruby-20.1.0-macos-amd64.tar.gz#5742d2dcc79abd362f4c6b81d51e7e4d60da925cb5d9399f01a6b00ad31b24cf" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-20.2.0
+++ b/share/ruby-build/truffleruby-20.2.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-20.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.2.0/truffleruby-20.2.0-linux-amd64.tar.gz#324e22f510b217c3649d125abda1690b15df474a026efa76e6d5d3e35a771248" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-20.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.2.0/truffleruby-20.2.0-macos-amd64.tar.gz#ac1e6867e357a44d0bb72b0bb44ea50c3900b0574e81e6e48d2317b6b45a6ffd" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-20.3.0
+++ b/share/ruby-build/truffleruby-20.3.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-20.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.3.0/truffleruby-20.3.0-linux-amd64.tar.gz#6d02d6713ca484809de7d26b98721bd7a633cb0373ff4a031a84ae664486ddc6" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-20.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-20.3.0/truffleruby-20.3.0-macos-amd64.tar.gz#c57474462b279e0c6a36896071aa21027a26fa52e0aaf1f85d26c43480af0831" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-21.0.0
+++ b/share/ruby-build/truffleruby-21.0.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-21.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.0.0/truffleruby-21.0.0-linux-amd64.tar.gz#33fb48276c682371939e1146f08e762703ec3d970408614c5380f2b9af37c0df" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-21.0.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.0.0/truffleruby-21.0.0-macos-amd64.tar.gz#4886d75f4dd2888f9330a690a7acf755eaf04dbc0c73463952155eb1d3046ee9" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-21.1.0
+++ b/share/ruby-build/truffleruby-21.1.0
@@ -3,7 +3,6 @@ Linux)
   install_package "truffleruby-21.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.1.0/truffleruby-21.1.0-linux-amd64.tar.gz#e3ed5bffb8af040d174817b267581a9dfa7f18a7dc79d1c5e7a6a4670ad318fb" truffleruby
   ;;
 Darwin)
-  use_homebrew_openssl
   install_package "truffleruby-21.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.1.0/truffleruby-21.1.0-macos-amd64.tar.gz#e2ada5a6c9dd6dcac6e1f1f04f290283182c3cf985ba9b599350b1f98f72c0d7" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-21.2.0
+++ b/share/ruby-build/truffleruby-21.2.0
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby-21.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0/truffleruby-21.2.0-linux-aarch64.tar.gz#f45f3046d604d99cc0c7b5c643fca0c16aecdfdef9cb1e5f385a255a0213cad3" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-21.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0/truffleruby-21.2.0-macos-amd64.tar.gz#c1eeb3692200c812329fa50c506dcb0ff246e7fb7780cd661fce2227fe507be1" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-21.2.0.1
+++ b/share/ruby-build/truffleruby-21.2.0.1
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby-21.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0.1/truffleruby-21.2.0.1-linux-aarch64.tar.gz#ddaf53a9921d2a5b5151300c30848519db2a3f9f146f47d4d883ccbbad6cab08" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-21.2.0.1" "https://github.com/oracle/truffleruby/releases/download/vm-21.2.0.1/truffleruby-21.2.0.1-macos-amd64.tar.gz#beee953c06a3eabe37ab227dde5dacd2d0f60e941fa93189ced77395e864f50d" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-21.3.0
+++ b/share/ruby-build/truffleruby-21.3.0
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby-21.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.3.0/truffleruby-21.3.0-linux-aarch64.tar.gz#110298de4743abf156314fb06011cb2f92c52b6ee2ef4cbb8b28ff1933672940" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-21.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-21.3.0/truffleruby-21.3.0-macos-amd64.tar.gz#3ca0c851386d872239404d41c69f1ba738332eb25da6cf89e157fa1356e68de0" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-22.0.0.2
+++ b/share/ruby-build/truffleruby-22.0.0.2
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby-22.0.0.2" "https://github.com/oracle/truffleruby/releases/download/vm-22.0.0.2/truffleruby-22.0.0.2-linux-aarch64.tar.gz#a758e3021c863d5b7a5090c16db862cf21de6d4ecccd98982fee33fb302c9246" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-22.0.0.2" "https://github.com/oracle/truffleruby/releases/download/vm-22.0.0.2/truffleruby-22.0.0.2-macos-amd64.tar.gz#f49cba9d8dcb1fc2ae95ffb6b325cad8e4697f844945521daf445020202f23b4" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-22.1.0
+++ b/share/ruby-build/truffleruby-22.1.0
@@ -7,7 +7,6 @@ Linux-aarch64)
   install_package "truffleruby-22.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.1.0/truffleruby-22.1.0-linux-aarch64.tar.gz#d2bd5875aa0359039b09f0772ad775f82988bebc757269c25729d38029ec0a63" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-22.1.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.1.0/truffleruby-22.1.0-macos-amd64.tar.gz#622815636210432c754be3b5f33d2a30ebf0ee1a1835f3a0df5f0ac7506ba7c0" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-22.2.0
+++ b/share/ruby-build/truffleruby-22.2.0
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby-22.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.2.0/truffleruby-22.2.0-linux-aarch64.tar.gz#8c898b7d847bdff78ac587b0afe7deccbfae46ca1dbd8cf05a8d572e8a059c48" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-22.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.2.0/truffleruby-22.2.0-macos-amd64.tar.gz#c3190570643c09d5a437a4cc5f2f0e51a9a11da1d94a07a1f5abfbf9dacc0643" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby-22.2.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.2.0/truffleruby-22.2.0-macos-aarch64.tar.gz#9551ffa608c2fa4c1af74c2c5b9f88256a54c477e46ead4b70056f1f18d0e1f9" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-22.3.0
+++ b/share/ruby-build/truffleruby-22.3.0
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby-22.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.3.0/truffleruby-22.3.0-linux-aarch64.tar.gz#d05d882a6057f2cb2e46bf209dad7182af9096600b44be0270cca6a0d5fc683c" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-22.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.3.0/truffleruby-22.3.0-macos-amd64.tar.gz#b6243d0ef963f8f8e9b7c01dba7b318e64e3b83da8934913a4bfdcfb36c95d92" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby-22.3.0" "https://github.com/oracle/truffleruby/releases/download/vm-22.3.0/truffleruby-22.3.0-macos-aarch64.tar.gz#cebf48f9bddb4b0829313f12aa94bbeb41aff4c121f723e290709098296a68eb" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-22.3.1
+++ b/share/ruby-build/truffleruby-22.3.1
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby-22.3.1" "https://github.com/oracle/truffleruby/releases/download/vm-22.3.1/truffleruby-22.3.1-linux-aarch64.tar.gz#6dbb9f14974be8cdd61b67b48579d4adebd625a3e90924332ebb6d319475fe1c" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-22.3.1" "https://github.com/oracle/truffleruby/releases/download/vm-22.3.1/truffleruby-22.3.1-macos-amd64.tar.gz#2830041ec4a2104e147ac01545e9b5a92b311701e71efa70695227153d6c4269" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby-22.3.1" "https://github.com/oracle/truffleruby/releases/download/vm-22.3.1/truffleruby-22.3.1-macos-aarch64.tar.gz#561031086a351d3d48cf5a42e849a8c8ecd0ef1a02f2fe803712b2cbff9e7d94" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-23.0.0
+++ b/share/ruby-build/truffleruby-23.0.0
@@ -10,11 +10,9 @@ Linux-aarch64)
   install_package "truffleruby-23.0.0" "https://gds.oracle.com/api/20220101/artifacts/FD40BA2367C226B6E0531518000AE71A/content#b75b6ddab76bda5d9cbff2fb53f5c5559fa6c5e11b845986b02c3cd4d3b98b3a" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-23.0.0" "https://gds.oracle.com/api/20220101/artifacts/FD4AB182EA51EDFDE0531518000AF13E/content#793afdc8c2bd35e6c229e833da0105f34e48e5dc872eb3e8d03d81f516e16191" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby-23.0.0" "https://gds.oracle.com/api/20220101/artifacts/FD40BBF6750C366CE0531518000ABEAF/content#3e6fa0d4a76d9d7d701fe1ea1b75a5d3eab29e77d21bf9454a67b0aa31c63bb6" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-23.0.0-preview1
+++ b/share/ruby-build/truffleruby-23.0.0-preview1
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/truffleruby-23.0.0-preview1-linux-aarch64.tar.gz#05f326cc1d97ab93a0b88e5b3ea9f039b160f4f514f2e9c05585df76894c9e30" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/truffleruby-23.0.0-preview1-macos-amd64.tar.gz#012b2802dc66b2f99ab60134d6f0afd5a20f3d8e380daa4db39ce84253be07cd" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby-23.0.0-preview1" "https://github.com/oracle/truffleruby/releases/download/vm-23.0.0-preview1/truffleruby-23.0.0-preview1-macos-aarch64.tar.gz#e99ab643dbe6e45b58a548b2ba4a0264c409f32f5711503b8a5da61d12072b03" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-23.1.0
+++ b/share/ruby-build/truffleruby-23.1.0
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby-23.1.0" "https://github.com/oracle/truffleruby/releases/download/graal-23.1.0/truffleruby-23.1.0-linux-aarch64.tar.gz#e0667a9885f7d76c2a14e24164524851eef8d6509fc76c3cb01134186e091c90" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-23.1.0" "https://github.com/oracle/truffleruby/releases/download/graal-23.1.0/truffleruby-23.1.0-macos-amd64.tar.gz#2301f8aaa06eab5b08f73bfad774338e2feb0551d1f0063da834fdb30281aeb5" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby-23.1.0" "https://github.com/oracle/truffleruby/releases/download/graal-23.1.0/truffleruby-23.1.0-macos-aarch64.tar.gz#55ce43057ed5eedc7b27660d1594859d356bf6f9fb781253bd6df1ebfa17b7e9" truffleruby
   ;;
 *)

--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -7,11 +7,9 @@ Linux-aarch64)
   install_package "truffleruby-head" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-dev-linux-aarch64.tar.gz" truffleruby
   ;;
 Darwin-x86_64)
-  use_homebrew_openssl
   install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-macos-latest.tar.gz" truffleruby
   ;;
 Darwin-arm64)
-  use_homebrew_openssl
   install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-macos-13-arm64.tar.gz" truffleruby
   ;;
 *)


### PR DESCRIPTION
TruffleRuby build definitions used to explicitly rely on `brew --prefix openssl@1.1` on macOS and abort installation if that was not found. However, this check didn't take into account that the user might have set OPENSSL_PREFIX in their environment, or that they have another `openssl@*` version installed via Homebrew. This change removes the `use_homebrew_openssl` check and allows TruffleRuby to [perform its own OpenSSL detection](https://github.com/oracle/truffleruby/blob/vm-23.1.0/lib/truffle/truffle/openssl-prefix.rb#L14-L17).

From https://github.com/rbenv/ruby-build/pull/2275#issuecomment-1768437610