### PR TITLE
Fix fixing JRuby shebangs on macOS

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -793,7 +793,7 @@ install_jruby_launcher() {
 
 fix_jruby_shebangs() {
   for file in "${PREFIX_PATH}/bin"/*; do
-    if [ "$(head -c 20 "$file" | tr -d '\0')" = "#!/usr/bin/env jruby" ]; then
+    if [ "$(head -c 20 "$file" | LC_CTYPE=C tr -d '\0')" = "#!/usr/bin/env jruby" ]; then
       sed -i.bak "1 s:.*:#\!${PREFIX_PATH}\/bin\/jruby:" "$file"
       rm "$file".bak
     fi


### PR DESCRIPTION
LC_CTYPE is "utf-8" on macOS, which instructs utilities like `tr` to expect Unicode input. However, in case of binary files, which we here explicitly guard against, the utility will fail because of invalid input encoding.

The solution is to set LC_CTYPE=C which effectively removes the expectation around input encoding and allows `tr` to process the input byte-by-byte.

Fixes https://github.com/rbenv/ruby-build/issues/2279