### PR TITLE
Unmark Ruby 2.7 as soon-to-be-EOL since it's already EOL

### DIFF
--- a/share/ruby-build/2.7.0
+++ b/share/ruby-build/2.7.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.1
+++ b/share/ruby-build/2.7.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.2
+++ b/share/ruby-build/2.7.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.3
+++ b/share/ruby-build/2.7.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.4
+++ b/share/ruby-build/2.7.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.5
+++ b/share/ruby-build/2.7.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.6
+++ b/share/ruby-build/2.7.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_eol enable_shared standard verify_openssl

--- a/share/ruby-build/2.7.7
+++ b/share/ruby-build/2.7.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl_101_111
-install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_unsupported warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_eol enable_shared standard verify_openssl


### PR DESCRIPTION
Followup to #2180