### PR TITLE
Fix checking system OpenSSL version

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1034,7 +1034,7 @@ has_broken_mac_openssl() {
 
 # Detect the OpenSSL version that a compiler can reasonably link to.
 system_openssl_version() {
-  cc -xc -E - <<EOF 2>/dev/null | sed -n 's/OpenSSL \([0-9][0-9.]*\).*/\1/p'
+  cc -xc -E - <<EOF 2>/dev/null | sed -n 's/"\{0,1\}OpenSSL \([0-9][0-9.]*\).*/\1/p'
 #include <openssl/opensslv.h>
 OPENSSL_VERSION_TEXT
 EOF

--- a/test/build.bats
+++ b/test/build.bats
@@ -322,7 +322,7 @@ OUT
   stub_repeated uname '-s : echo Linux'
   stub_repeated brew false
   # shellcheck disable=SC2016
-  stub cc '-xc -E - : [[ "$(cat)" == *OPENSSL_VERSION_TEXT* ]] && printf "# <unrelated> 4.0.2\nOpenSSL 1.0.3a  1 Aug 202\n0 errors.\n"'
+  stub cc '-xc -E - : [[ "$(cat)" == *OPENSSL_VERSION_TEXT* ]] && printf "# <unrelated> 4.0.2\n\"OpenSSL 1.0.3a  1 Aug 202\"\n0 errors.\n"'
   stub_make_install
 
   mkdir -p "$INSTALL_ROOT"/openssl/ssl # OPENSSLDIR


### PR DESCRIPTION
The value of OPENSSL_VERSION_TEXT seems to be printed in double quotes.

Followup to #2275
Fixes #2291