### PR TITLE
Remove Topaz, Maglev

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -737,25 +737,6 @@ build_package_picoruby() {
   } >&4 2>&1
 }
 
-build_package_topaz() {
-  build_package_copy
-  { # shellcheck disable=SC2164
-    cd "${PREFIX_PATH}/bin"
-    echo "Creating symlink for ruby*"
-    ln -fs topaz ruby
-  } >&4 2>&1
-}
-
-topaz_architecture() {
-  case "$(uname -s)" in
-  "Darwin") echo "osx64";;
-  "Linux") [[ "$(uname -m)" = "x86_64" ]] && echo "linux64" || echo "linux32";;
-  *)
-    echo "no nightly builds available" >&2
-    exit 1;;
-  esac
-}
-
 build_package_jruby() {
   build_package_copy
   # shellcheck disable=SC2164

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -737,23 +737,6 @@ build_package_picoruby() {
   } >&4 2>&1
 }
 
-build_package_maglev() {
-  build_package_copy
-
-  { # shellcheck disable=SC2164
-    cd "${PREFIX_PATH}"
-    ./install.sh
-    # shellcheck disable=SC2164
-    cd "${PREFIX_PATH}/bin"
-    echo "Creating symlink for ruby*"
-    ln -fs maglev-ruby ruby
-    echo "Creating symlink for irb*"
-    ln -fs maglev-irb irb
-  } >&4 2>&1
-  echo
-  echo "Run 'maglev start' to start up the stone before using 'ruby' or 'irb'"
-}
-
 build_package_topaz() {
   build_package_copy
   { # shellcheck disable=SC2164

--- a/share/ruby-build/maglev-1.0.0
+++ b/share/ruby-build/maglev-1.0.0
@@ -1,1 +1,0 @@
-install_package "MagLev-1.0.0" "http://seaside.gemtalksystems.com/maglev/MagLev-1.0.0.tar.gz#73401e9e69a336c2ca8369cc72e0d7f3ed867283252c385aea12ef44648c39be" warn_eol maglev

--- a/share/ruby-build/maglev-1.1.0-dev
+++ b/share/ruby-build/maglev-1.1.0-dev
@@ -1,1 +1,0 @@
-install_git "maglev-1.1.0-dev" "https://github.com/MagLev/maglev.git" "master" warn_eol maglev

--- a/share/ruby-build/maglev-2.0.0-dev
+++ b/share/ruby-build/maglev-2.0.0-dev
@@ -1,1 +1,0 @@
-install_git "maglev-2.0.0-dev" "https://github.com/MagLev/maglev.git" "master" warn_eol maglev


### PR DESCRIPTION
Neither project has seen releases in the last 10 years, so I'm making a call that there is no strong reason for ruby-build to support them.

Ref. #278 https://github.com/rbenv/ruby-build/pull/1420