### PR TITLE
Instruct Ruby to fail the build if openssl or psych are missing

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -673,6 +673,11 @@ build_package_standard_build() {
         package_option ruby configure --with-openssl-dir="/usr/local"
       fi
     fi
+    if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-ext* &&
+          "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--without-ext* ]]; then
+      # Fail the `make` step if any of these extensions were not compiled.
+      package_option ruby configure --with-ext=openssl,psych,+
+    fi
   fi
 
   ( if [ "${CFLAGS+defined}" ] || [ "${!PACKAGE_CFLAGS+defined}" ]; then
@@ -1214,48 +1219,9 @@ build_package_openssl() {
   fi
 }
 
-# Post-install check that the openssl extension was built.
-# TODO: explore replacing this implementation with scanning the `make` log
-# for the "Following extensions are not compiled" block.
+# Kept for backward compatibility with 3rd-party definitions.
 build_package_verify_openssl() {
-  local msg
-  msg="->$(print_command "$RUBY_BIN" -e "<SCRIPT>")"
-
-  colorize 36 "$msg"
-  echo
-
-  # shellcheck disable=SC2016
-  "$RUBY_BIN" -e '
-    manager = ARGV[0]
-    packages = {
-      "apt-get" => Hash.new {|h,k| "lib#{k}-dev" }.update(
-        "openssl" => "libssl-dev",
-        "zlib" => "zlib1g-dev"
-      ),
-      "yum" => Hash.new {|h,k| "#{k}-devel" }.update(
-        "yaml" => "libyaml-devel"
-      )
-    }
-    ext_name = Hash.new {|h,k| k }.update("yaml" => "psych")
-
-    failed = %w[openssl readline zlib yaml].reject do |lib|
-      begin
-        require lib
-      rescue LoadError => e
-        $stderr.puts "Loading the Ruby #{lib} extension failed (#{e})"
-        $stderr.puts "See the extension log at #{Dir.pwd}/ext/#{ext_name[lib]}/mkmf.log"
-      end
-    end
-
-    if failed.size > 0
-      $stderr.puts "ERROR: Ruby install aborted due to missing extensions"
-      $stderr.print "Try running `%s install -y %s` to fetch missing dependencies.\n\n" % [
-        manager,
-        failed.map { |lib| packages.fetch(manager)[lib] }.join(" ")
-      ] unless manager.empty?
-      exit 1
-    end
-  ' "$(basename "$(type -p yum apt-get | head -1)")"
+  true
 }
 
 # Kept for backward compatibility with 3rd-party definitions.

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -692,9 +692,20 @@ build_package_standard_build() {
       "${!PACKAGE_CONFIGURE_OPTS_ARRAY}" $CONFIGURE_OPTS ${!PACKAGE_CONFIGURE_OPTS}
   ) || return $?
 
+  local status=0
   # make -j <num_cpu_cores>
   # shellcheck disable=SC2086
-  capture_command "$MAKE" "${!PACKAGE_MAKE_OPTS_ARRAY}" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS}
+  capture_command "$MAKE" "${!PACKAGE_MAKE_OPTS_ARRAY}" $MAKE_OPTS ${!PACKAGE_MAKE_OPTS} || status=$?
+
+  if [[ $status -ne 0 && -z $VERBOSE ]]; then
+    # Surface any extension building problems from `make` log to stderr.
+    # https://github.com/ruby/ruby/blob/HEAD/ext/extmk.rb
+    sed -n '/Following extensions are not compiled/,/Fix the problems/p' "$LOG_PATH" | \
+      sed '/remove these directories and try again/d' | \
+      sed "s:\\([[:space:]]*Check\\) \\(ext/.*\\):\\1 ${PWD}/\\2:" >&2
+  fi
+
+  return $status
 }
 
 build_package_standard_install() {

--- a/script/update-cruby
+++ b/script/update-cruby
@@ -26,5 +26,5 @@ fi
 
 cat > "$file" <<EOS
 !TODO! copy openssl line from other release with the same major.minor version
-install_package "ruby-${version}" "${url}#${sha256}" enable_shared standard verify_openssl
+install_package "ruby-${version}" "${url}#${sha256}" enable_shared standard
 EOS

--- a/share/ruby-build/2.0.0-dev
+++ b/share/ruby-build/2.0.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_git "ruby-2.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_0_0" warn_eol autoconf standard verify_openssl
+install_git "ruby-2.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_0_0" warn_eol autoconf standard

--- a/share/ruby-build/2.0.0-p0
+++ b/share/ruby-build/2.0.0-p0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.bz2#c680d392ccc4901c32067576f5b474ee186def2fcd3fcbfa485739168093295f" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p0" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p0.tar.bz2#c680d392ccc4901c32067576f5b474ee186def2fcd3fcbfa485739168093295f" warn_eol standard

--- a/share/ruby-build/2.0.0-p195
+++ b/share/ruby-build/2.0.0-p195
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.bz2#0be32aef7a7ab6e3708cc1d65cd3e0a99fa801597194bbedd5799c11d652eb5b" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p195" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p195.tar.bz2#0be32aef7a7ab6e3708cc1d65cd3e0a99fa801597194bbedd5799c11d652eb5b" warn_eol standard

--- a/share/ruby-build/2.0.0-p247
+++ b/share/ruby-build/2.0.0-p247
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.bz2#08e3d4b85b8a1118a8e81261f59dd8b4ddcfd70b6ae554e0ec5ceb99c3185e8a" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p247" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.bz2#08e3d4b85b8a1118a8e81261f59dd8b4ddcfd70b6ae554e0ec5ceb99c3185e8a" warn_eol standard

--- a/share/ruby-build/2.0.0-p353
+++ b/share/ruby-build/2.0.0-p353
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.bz2#3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p353" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.bz2#3de4e4d9aff4682fa4f8ed2b70bd0d746fae17452fc3d3a8e8f505ead9105ad9" warn_eol standard

--- a/share/ruby-build/2.0.0-p451
+++ b/share/ruby-build/2.0.0-p451
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2#5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p451" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p451.tar.bz2#5bf8a1c7616286b9dbc962912c3f58e67bc3a70306ca90b0882ef0bd442e02f5" warn_eol standard

--- a/share/ruby-build/2.0.0-p481
+++ b/share/ruby-build/2.0.0-p481
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.bz2#0762dad7e96d8091bdf33b3e3176c2066fbf3dc09dfe85fbf40e74e83c63d8e2" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p481" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.bz2#0762dad7e96d8091bdf33b3e3176c2066fbf3dc09dfe85fbf40e74e83c63d8e2" warn_eol standard

--- a/share/ruby-build/2.0.0-p576
+++ b/share/ruby-build/2.0.0-p576
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2#8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p576" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p576.tar.bz2#8cfdbffc81cebd1d25304225ffadc7dcb612a500c81ba6f5f95c5296dfa62059" warn_eol standard

--- a/share/ruby-build/2.0.0-p594
+++ b/share/ruby-build/2.0.0-p594
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2#e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p594" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p594.tar.bz2#e5aee3cf36898315f87771a5e657c81befb88b6afa585b70aaa57c47cc0e99a4" warn_eol standard

--- a/share/ruby-build/2.0.0-p598
+++ b/share/ruby-build/2.0.0-p598
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2#67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p598" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.bz2#67b2a93690f53e12b635ba1bcdbd41e8c5593f13d575fea92fdd8801ca088f0f" warn_eol standard

--- a/share/ruby-build/2.0.0-p643
+++ b/share/ruby-build/2.0.0-p643
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.bz2#1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p643" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p643.tar.bz2#1f626f20647693a215a8db3ea0d6ab5ab9cee7c1945cc441b9f8f7b9612b91a0" warn_eol standard

--- a/share/ruby-build/2.0.0-p645
+++ b/share/ruby-build/2.0.0-p645
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.bz2#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p645" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.bz2#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" warn_eol standard

--- a/share/ruby-build/2.0.0-p647
+++ b/share/ruby-build/2.0.0-p647
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.bz2#3c3782e313d1ec3ed06c104eafd133cc54ff5183b991786ece9e957fd6cf1cb9" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.bz2#3c3782e313d1ec3ed06c104eafd133cc54ff5183b991786ece9e957fd6cf1cb9" warn_eol standard

--- a/share/ruby-build/2.0.0-p648
+++ b/share/ruby-build/2.0.0-p648
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2#087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-p648" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p648.tar.bz2#087ad4dec748cfe665c856dbfbabdee5520268e94bb81a1d8565d76c3cc62166" warn_eol standard

--- a/share/ruby-build/2.0.0-preview1
+++ b/share/ruby-build/2.0.0-preview1
@@ -1,3 +1,3 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
-install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.bz2#79e5605003bf6766fbd123ce00a0027df716ba6d28494c35185909f7e61a5bdf" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview1.tar.bz2#79e5605003bf6766fbd123ce00a0027df716ba6d28494c35185909f7e61a5bdf" warn_eol standard

--- a/share/ruby-build/2.0.0-preview2
+++ b/share/ruby-build/2.0.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.bz2#cea98c000a113f10cb7d55753c759da1f1baa7ca9b3edf75fc19fa5f44bf71a0" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-preview2.tar.bz2#cea98c000a113f10cb7d55753c759da1f1baa7ca9b3edf75fc19fa5f44bf71a0" warn_eol standard

--- a/share/ruby-build/2.0.0-rc1
+++ b/share/ruby-build/2.0.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.bz2#4033ddadd0b44eecfcb7686231ebd109ee6f22bf09797a7e15882b9df0b1ee81" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc1.tar.bz2#4033ddadd0b44eecfcb7686231ebd109ee6f22bf09797a7e15882b9df0b1ee81" warn_eol standard

--- a/share/ruby-build/2.0.0-rc2
+++ b/share/ruby-build/2.0.0-rc2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2#d55f897bb04283c5fa80223d96d990fe8ecb598508dd59443b356cbba1f66145" warn_eol standard verify_openssl
+install_package "ruby-2.0.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-rc2.tar.bz2#d55f897bb04283c5fa80223d96d990fe8ecb598508dd59443b356cbba1f66145" warn_eol standard

--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" warn_eol standard verify_openssl
+install_package "ruby-2.1.0" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.bz2#1d3f4ad5f619ec15229206b6667586dcec7cc986672c8fbb8558161ecf07e277" warn_eol standard

--- a/share/ruby-build/2.1.0-dev
+++ b/share/ruby-build/2.1.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_git "ruby-2.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_1" warn_eol autoconf standard verify_openssl
+install_git "ruby-2.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_1" warn_eol autoconf standard

--- a/share/ruby-build/2.1.0-preview1
+++ b/share/ruby-build/2.1.0-preview1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.bz2#860b90d28b214393fd9d77ac2ad65b384d8249cd59b658c668cf0c7bad1db341" warn_eol standard verify_openssl
+install_package "ruby-2.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview1.tar.bz2#860b90d28b214393fd9d77ac2ad65b384d8249cd59b658c668cf0c7bad1db341" warn_eol standard

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.bz2#780fddf0e3c8a219057d578e83367ecfac5e945054b9f132b3b93ded4802d1ce" warn_eol standard verify_openssl
+install_package "ruby-2.1.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.bz2#780fddf0e3c8a219057d578e83367ecfac5e945054b9f132b3b93ded4802d1ce" warn_eol standard

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.bz2#af828bc0fe6aee5ffad0f8f10b48ee25964f54d5118570937ac7cf1c1df0edd3" warn_eol standard verify_openssl
+install_package "ruby-2.1.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.bz2#af828bc0fe6aee5ffad0f8f10b48ee25964f54d5118570937ac7cf1c1df0edd3" warn_eol standard

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" warn_eol standard verify_openssl
+install_package "ruby-2.1.1" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.bz2#96aabab4dd4a2e57dd0d28052650e6fcdc8f133fa8980d9b936814b1e93f6cfc" warn_eol standard

--- a/share/ruby-build/2.1.10
+++ b/share/ruby-build/2.1.10
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.10" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2#a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1" warn_eol standard verify_openssl
+install_package "ruby-2.1.10" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2#a74675578a9a801ac25eb7152bef3023432d6267f875b198eb9cd6944a5bf4f1" warn_eol standard

--- a/share/ruby-build/2.1.2
+++ b/share/ruby-build/2.1.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" warn_eol standard verify_openssl
+install_package "ruby-2.1.2" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.bz2#6948b02570cdfb89a8313675d4aa665405900e27423db408401473f30fc6e901" warn_eol standard

--- a/share/ruby-build/2.1.3
+++ b/share/ruby-build/2.1.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" warn_eol standard verify_openssl
+install_package "ruby-2.1.3" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.3.tar.bz2#36ce72f84ae4129f6cc66e33077a79d87b018ea7bf1dbc3d353604bf006f76d6" warn_eol standard

--- a/share/ruby-build/2.1.4
+++ b/share/ruby-build/2.1.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" warn_eol standard verify_openssl
+install_package "ruby-2.1.4" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.4.tar.bz2#f37f11a8c75ab9215bb9f61246ef98e0e57e1409f0872e5cf59033edcf5b8d2a" warn_eol standard

--- a/share/ruby-build/2.1.5
+++ b/share/ruby-build/2.1.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" warn_eol standard verify_openssl
+install_package "ruby-2.1.5" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.bz2#0241b40f1c731cb177994a50b854fb7f18d4ad04dcefc18acc60af73046fb0a9" warn_eol standard

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" warn_eol standard verify_openssl
+install_package "ruby-2.1.6" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.bz2#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" warn_eol standard

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" warn_eol standard verify_openssl
+install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.bz2#b02c1a5ecd718e3f6b316384d4ed6572f862a46063f5ae23d0340b0a245859b6" warn_eol standard

--- a/share/ruby-build/2.1.8
+++ b/share/ruby-build/2.1.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" warn_eol standard verify_openssl
+install_package "ruby-2.1.8" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.bz2#250d0b589cba97caddc86a28849365ad0d475539448cf76bbae93190985b3387" warn_eol standard

--- a/share/ruby-build/2.1.9
+++ b/share/ruby-build/2.1.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" warn_eol standard verify_openssl
+install_package "ruby-2.1.9" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.9.tar.bz2#4f21376aa11e09b499c3254bbd839e68e053c0d18e28d61c428a32347269036e" warn_eol standard

--- a/share/ruby-build/2.2.0
+++ b/share/ruby-build/2.2.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2#1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955" warn_eol standard verify_openssl
+install_package "ruby-2.2.0" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.bz2#1c031137999f832f86be366a71155113675b72420830ce432b777a0ff4942955" warn_eol standard

--- a/share/ruby-build/2.2.0-dev
+++ b/share/ruby-build/2.2.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" warn_eol autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/2.2.0-preview1
+++ b/share/ruby-build/2.2.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview1.tar.bz2#a3614c389de06b1636d8b919f2cd07e85311486bda2cb226a5549657a3610af5" warn_eol standard verify_openssl
+install_package "ruby-2.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview1.tar.bz2#a3614c389de06b1636d8b919f2cd07e85311486bda2cb226a5549657a3610af5" warn_eol standard

--- a/share/ruby-build/2.2.0-preview2
+++ b/share/ruby-build/2.2.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.bz2#9e49583f3fad3888fefc85b719fdb210a88ef54d80f9eac439b7ca4232fa7f0b" warn_eol standard verify_openssl
+install_package "ruby-2.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-preview2.tar.bz2#9e49583f3fad3888fefc85b719fdb210a88ef54d80f9eac439b7ca4232fa7f0b" warn_eol standard

--- a/share/ruby-build/2.2.0-rc1
+++ b/share/ruby-build/2.2.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-rc1.tar.bz2#e6a1f8d45ea749bdc92eb1269b77ec475bc600b66039ff90d77db8f50820a896" warn_eol standard verify_openssl
+install_package "ruby-2.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0-rc1.tar.bz2#e6a1f8d45ea749bdc92eb1269b77ec475bc600b66039ff90d77db8f50820a896" warn_eol standard

--- a/share/ruby-build/2.2.1
+++ b/share/ruby-build/2.2.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.bz2#4e5676073246b7ade207be3e80a930567a88100513591a0f19fc38e247370065" warn_eol standard verify_openssl
+install_package "ruby-2.2.1" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.1.tar.bz2#4e5676073246b7ade207be3e80a930567a88100513591a0f19fc38e247370065" warn_eol standard

--- a/share/ruby-build/2.2.10
+++ b/share/ruby-build/2.2.10
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.10" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.bz2#a54204d2728283c9eff0cf81d654f245fa5b3447d0824f1a6bc3b2c5c827381e" warn_eol standard verify_openssl
+install_package "ruby-2.2.10" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.10.tar.bz2#a54204d2728283c9eff0cf81d654f245fa5b3447d0824f1a6bc3b2c5c827381e" warn_eol standard

--- a/share/ruby-build/2.2.2
+++ b/share/ruby-build/2.2.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.bz2#f3b8ffa6089820ee5bdc289567d365e5748d4170e8aa246d2ea6576f24796535" warn_eol standard verify_openssl
+install_package "ruby-2.2.2" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.bz2#f3b8ffa6089820ee5bdc289567d365e5748d4170e8aa246d2ea6576f24796535" warn_eol standard

--- a/share/ruby-build/2.2.3
+++ b/share/ruby-build/2.2.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.bz2#c745cb98b29127d7f19f1bf9e0a63c384736f4d303b83c4f4bda3c2ee3c5e41f" warn_eol standard verify_openssl
+install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.bz2#c745cb98b29127d7f19f1bf9e0a63c384736f4d303b83c4f4bda3c2ee3c5e41f" warn_eol standard

--- a/share/ruby-build/2.2.4
+++ b/share/ruby-build/2.2.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.4" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2#31203696adbfdda6f2874a2de31f7c5a1f3bcb6628f4d1a241de21b158cd5c76" warn_eol standard verify_openssl
+install_package "ruby-2.2.4" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.4.tar.bz2#31203696adbfdda6f2874a2de31f7c5a1f3bcb6628f4d1a241de21b158cd5c76" warn_eol standard

--- a/share/ruby-build/2.2.5
+++ b/share/ruby-build/2.2.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.5" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2#22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700" warn_eol standard verify_openssl
+install_package "ruby-2.2.5" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.bz2#22f0c6f34c0024e0bcaaa8e6831b7c0041e1ef6120c781618b833bde29626700" warn_eol standard

--- a/share/ruby-build/2.2.6
+++ b/share/ruby-build/2.2.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.6" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.bz2#e845ba41ea3525aafaa4094212f1eadc57392732232b67b4394a7e0f046dddf7" warn_eol standard verify_openssl
+install_package "ruby-2.2.6" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.6.tar.bz2#e845ba41ea3525aafaa4094212f1eadc57392732232b67b4394a7e0f046dddf7" warn_eol standard

--- a/share/ruby-build/2.2.7
+++ b/share/ruby-build/2.2.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.7" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.bz2#80486c5991783185afeceeb315060a3dafc3889a2912e145b1a8457d7b005c5b" warn_eol standard verify_openssl
+install_package "ruby-2.2.7" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.7.tar.bz2#80486c5991783185afeceeb315060a3dafc3889a2912e145b1a8457d7b005c5b" warn_eol standard

--- a/share/ruby-build/2.2.8
+++ b/share/ruby-build/2.2.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.8" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2#b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e" warn_eol standard verify_openssl
+install_package "ruby-2.2.8" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.bz2#b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e" warn_eol standard

--- a/share/ruby-build/2.2.9
+++ b/share/ruby-build/2.2.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.2.9" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2#5e3cfcc3b69638e165f72f67b1321fa05aff62b0f9e9b32042a5a79614e7c70a" warn_eol standard verify_openssl
+install_package "ruby-2.2.9" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.9.tar.bz2#5e3cfcc3b69638e165f72f67b1321fa05aff62b0f9e9b32042a5a79614e7c70a" warn_eol standard

--- a/share/ruby-build/2.3.0
+++ b/share/ruby-build/2.3.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" warn_eol standard verify_openssl
+install_package "ruby-2.3.0" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0.tar.bz2#ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e" warn_eol standard

--- a/share/ruby-build/2.3.0-dev
+++ b/share/ruby-build/2.3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" warn_eol autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/2.3.0-preview1
+++ b/share/ruby-build/2.3.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.bz2#42b9c9e1740a5abe2855d11803524370bd95744c8dcb0068572ed5c969ac7f0f" warn_eol standard verify_openssl
+install_package "ruby-2.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview1.tar.bz2#42b9c9e1740a5abe2855d11803524370bd95744c8dcb0068572ed5c969ac7f0f" warn_eol standard

--- a/share/ruby-build/2.3.0-preview2
+++ b/share/ruby-build/2.3.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.bz2#e9b0464e50b2e5c31546e6b8ca8cad71fe2d2146ccf88b7419bbe9626af741cb" warn_eol standard verify_openssl
+install_package "ruby-2.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.0-preview2.tar.bz2#e9b0464e50b2e5c31546e6b8ca8cad71fe2d2146ccf88b7419bbe9626af741cb" warn_eol standard

--- a/share/ruby-build/2.3.1
+++ b/share/ruby-build/2.3.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" warn_eol standard verify_openssl
+install_package "ruby-2.3.1" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.bz2#4a7c5f52f205203ea0328ca8e1963a7a88cf1f7f0e246f857d595b209eac0a4d" warn_eol standard

--- a/share/ruby-build/2.3.2
+++ b/share/ruby-build/2.3.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" warn_eol standard verify_openssl
+install_package "ruby-2.3.2" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.2.tar.bz2#e6ce83d46819c4120c9295ff6b36b90393dd5f6bef3bb117a06d7399c11fc7c0" warn_eol standard

--- a/share/ruby-build/2.3.3
+++ b/share/ruby-build/2.3.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" warn_eol standard verify_openssl
+install_package "ruby-2.3.3" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.bz2#882e6146ed26c6e78c02342835f5d46b86de95f0dc4e16543294bc656594cc5b" warn_eol standard

--- a/share/ruby-build/2.3.4
+++ b/share/ruby-build/2.3.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" warn_eol standard verify_openssl
+install_package "ruby-2.3.4" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.4.tar.bz2#cd9808bb53824d6edb58beaadd3906cb23b987438ce75ab7bb279b2229930e2f" warn_eol standard

--- a/share/ruby-build/2.3.5
+++ b/share/ruby-build/2.3.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" warn_eol standard verify_openssl
+install_package "ruby-2.3.5" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.bz2#f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b" warn_eol standard

--- a/share/ruby-build/2.3.6
+++ b/share/ruby-build/2.3.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" warn_eol standard verify_openssl
+install_package "ruby-2.3.6" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.6.tar.bz2#07aa3ed3bffbfb97b6fc5296a86621e6bb5349c6f8e549bd0db7f61e3e210fd0" warn_eol standard

--- a/share/ruby-build/2.3.7
+++ b/share/ruby-build/2.3.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" warn_eol standard verify_openssl
+install_package "ruby-2.3.7" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.7.tar.bz2#18b12fafaf37d5f6c7139c1b445355aec76baa625a40300598a6c8597fc04d8e" warn_eol standard

--- a/share/ruby-build/2.3.8
+++ b/share/ruby-build/2.3.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" warn_eol standard verify_openssl
+install_package "ruby-2.3.8" "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.tar.bz2#4d1a3a88e8cf9aea624eb73843fbfc60a9a281582660f86d5e4e00870397407c" warn_eol standard

--- a/share/ruby-build/2.4.0
+++ b/share/ruby-build/2.4.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.0" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0.tar.bz2#440bbbdc49d08d3650f340dccb35986d9399177ad69a204def56e5d3954600cf" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/2.4.0-preview1
+++ b/share/ruby-build/2.4.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2#17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649" warn_eol standard verify_openssl
+install_package "ruby-2.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview1.tar.bz2#17570f0b84215ca82252f10c167ee50bc075383c018420c6b2601ae1cade0649" warn_eol standard

--- a/share/ruby-build/2.4.0-preview2
+++ b/share/ruby-build/2.4.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2#2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d" warn_eol standard verify_openssl
+install_package "ruby-2.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview2.tar.bz2#2224c55b2d87b5c0f08d23a4618e870027dbc1cffbfb4a05efd19eac4ff4cf1d" warn_eol standard

--- a/share/ruby-build/2.4.0-preview3
+++ b/share/ruby-build/2.4.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.4.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2#305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52" warn_eol standard verify_openssl
+install_package "ruby-2.4.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-preview3.tar.bz2#305a2b2c627990e54965393f6eb1c442eeddfa149128ccdd9f4334e2e00a2a52" warn_eol standard

--- a/share/ruby-build/2.4.0-rc1
+++ b/share/ruby-build/2.4.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_package "ruby-2.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-rc1.tar.bz2#3b156b20f9df0dd62cbeeb8e57e66ea872d2a5b55fabdef1889650122bcc2ea7" warn_eol standard verify_openssl
+install_package "ruby-2.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.0-rc1.tar.bz2#3b156b20f9df0dd62cbeeb8e57e66ea872d2a5b55fabdef1889650122bcc2ea7" warn_eol standard

--- a/share/ruby-build/2.4.1
+++ b/share/ruby-build/2.4.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.1" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.1.tar.bz2#ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.10
+++ b/share/ruby-build/2.4.10
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.10" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.tar.bz2#6ea3ce7fd0064524ae06dbdcd99741c990901dfc9c66d8139a02f907d30b95a8" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.10" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.tar.bz2#6ea3ce7fd0064524ae06dbdcd99741c990901dfc9c66d8139a02f907d30b95a8" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.2
+++ b/share/ruby-build/2.4.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.2" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.bz2#08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.3
+++ b/share/ruby-build/2.4.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.3" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.3.tar.bz2#0a703dffb7737f56e979c9ebe2482f07751803c71e307c20446b581e0f12cf30" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.4
+++ b/share/ruby-build/2.4.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.4" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.4.tar.bz2#45a8de577471b90dc4838c5ef26aeb253a56002896189055a44dc680644243f1" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.5
+++ b/share/ruby-build/2.4.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.5" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.bz2#276c8e73e51e4ba6a0fe81fb92669734e741ccea86f01c45e99f2c7ef7bcd1e3" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.6
+++ b/share/ruby-build/2.4.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.6" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.bz2#909f360debed1f22fdcfc9f5335c6eaa0713198db4a6c13bab426f8b89b28b02" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.7
+++ b/share/ruby-build/2.4.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.7" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.7.tar.gz#cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.8
+++ b/share/ruby-build/2.4.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.8" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.bz2#e30eedd91386bec81489d2637522c9017aebba46f98e8b502f679df6b2f6a469" warn_eol enable_shared standard

--- a/share/ruby-build/2.4.9
+++ b/share/ruby-build/2.4.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.4.9" "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.bz2#f72bdef50246ef047ba3ce9c59d2081b949feb16f9a04e008108e98f1a995e99" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.0
+++ b/share/ruby-build/2.5.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.0" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.bz2#d87eb3021f71d4f62e5a5329628ac9a6665902173296e551667edd94362325cc" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/2.5.0-preview1
+++ b/share/ruby-build/2.5.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2#1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446" warn_eol standard verify_openssl
+install_package "ruby-2.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-preview1.tar.bz2#1158e0eac184a1d8189fae985f58c9be185d6e7074b022e66567aec798fa3446" warn_eol standard

--- a/share/ruby-build/2.5.0-rc1
+++ b/share/ruby-build/2.5.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" warn_eol standard verify_openssl
+install_package "ruby-2.5.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0-rc1.tar.bz2#862a8e9e52432ba383660a23d3e87af11dbc18c863a19ef6367eb8259fc47c09" warn_eol standard

--- a/share/ruby-build/2.5.1
+++ b/share/ruby-build/2.5.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.1" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.1.tar.bz2#0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.2
+++ b/share/ruby-build/2.5.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.2" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.2.tar.bz2#ea3bcecc3b30cee271b4decde5e9ff3e17369d5fd1ed828d321c198307c9f0df" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.3
+++ b/share/ruby-build/2.5.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.3" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.bz2#228a787ba68a7b20ac6e1d5af3d176d36e8ed600eb754d6325da341c3088ed76" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.4
+++ b/share/ruby-build/2.5.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.4" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.4.tar.bz2#8a16566207b2334a6904a10a1f093befc3aaf9b2e6cf01c62b1c4ac15cb7d8fc" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.5
+++ b/share/ruby-build/2.5.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.5" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.bz2#1f2567a55dad6e50911ce42fcc705cf686924b897f597cabf803d88192024dcb" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.6
+++ b/share/ruby-build/2.5.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.6" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.6.tar.gz#1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.7
+++ b/share/ruby-build/2.5.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.7" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.7.tar.bz2#e67c69b141ed27158e47d9a4fe7e59749135b0f138dce06c8c15c3214543f56f" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.8
+++ b/share/ruby-build/2.5.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.8" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2#41fc93731ad3f3aa597d657f77ed68fa86b5e93c04dfbf7e542a8780702233f0" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.8" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.8.tar.bz2#41fc93731ad3f3aa597d657f77ed68fa86b5e93c04dfbf7e542a8780702233f0" warn_eol enable_shared standard

--- a/share/ruby-build/2.5.9
+++ b/share/ruby-build/2.5.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.5.9" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.bz2#bebbe3fe7899acd3ca2f213de38158709555e88a13f85ba5dc95239654bcfeeb" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.5.9" "https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.tar.bz2#bebbe3fe7899acd3ca2f213de38158709555e88a13f85ba5dc95239654bcfeeb" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.0
+++ b/share/ruby-build/2.6.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.0" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0.tar.bz2#c89ca663ad9a6238f4b1ec4d04c7dff630560c6e6eca6d30857c4d394f01a599" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.0-dev
+++ b/share/ruby-build/2.6.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.6.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.6.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/2.6.0-preview1
+++ b/share/ruby-build/2.6.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" warn_eol standard verify_openssl
+install_package "ruby-2.6.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview1.tar.bz2#8bd6c373df6ee009441270a8b4f86413d101b8f88e8051c55ef62abffadce462" warn_eol standard

--- a/share/ruby-build/2.6.0-preview2
+++ b/share/ruby-build/2.6.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" warn_eol standard verify_openssl
+install_package "ruby-2.6.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview2.tar.bz2#d8ede03d5ad3abd9d2c81cf0ad17a41d22b747c003cc16fd59befb2aaf48f0b2" warn_eol standard

--- a/share/ruby-build/2.6.0-preview3
+++ b/share/ruby-build/2.6.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview3.tar.bz2#1f09a2ac1ab26721923cbf4b9302a66d36bb302dc45e72112b41d6fccc5b5931" warn_eol standard verify_openssl
+install_package "ruby-2.6.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-preview3.tar.bz2#1f09a2ac1ab26721923cbf4b9302a66d36bb302dc45e72112b41d6fccc5b5931" warn_eol standard

--- a/share/ruby-build/2.6.0-rc1
+++ b/share/ruby-build/2.6.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc1.tar.bz2#b4e9c0e8801946e9f0baba30948955f4341e9e04f363c206b7bd774208053eb5" warn_eol standard verify_openssl
+install_package "ruby-2.6.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc1.tar.bz2#b4e9c0e8801946e9f0baba30948955f4341e9e04f363c206b7bd774208053eb5" warn_eol standard

--- a/share/ruby-build/2.6.0-rc2
+++ b/share/ruby-build/2.6.0-rc2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2#b3d03e471e3136f43bb948013d4f4974abb63d478e8ff7ec2741b22750a3ec50" warn_eol standard verify_openssl
+install_package "ruby-2.6.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.0-rc2.tar.bz2#b3d03e471e3136f43bb948013d4f4974abb63d478e8ff7ec2741b22750a3ec50" warn_eol standard

--- a/share/ruby-build/2.6.1
+++ b/share/ruby-build/2.6.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.1" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.bz2#82c9402920eac9ce777beb3f34eeadc2a3f3ce80f25004bbf54b5ed1280ba099" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.10
+++ b/share/ruby-build/2.6.10
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.10" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.bz2#399e1f13e7fedc3c6ae2ff541bbf26c44dfb63b07b6c186fdd15b4e526e27e9c" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.10" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.tar.bz2#399e1f13e7fedc3c6ae2ff541bbf26c44dfb63b07b6c186fdd15b4e526e27e9c" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.2
+++ b/share/ruby-build/2.6.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.2" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.2.tar.bz2#d126ada7f4147ce1029a80c2a37a0c4bfb37e9e82da8816662241a43faeb8915" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.3
+++ b/share/ruby-build/2.6.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.3" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.3.tar.bz2#dd638bf42059182c1d04af0d5577131d4ce70b79105231c4cc0a60de77b14f2e" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.4
+++ b/share/ruby-build/2.6.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.4" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.4.tar.bz2#fa1ecc67b99fa13201499002669412eae7cfbe2c30c4f1f4526e8491edfc5fa7" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.5
+++ b/share/ruby-build/2.6.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.5" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.bz2#97ddf1b922f83c1f5c50e75bf54e27bba768d75fea7cda903b886c6745e60f0a" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.6
+++ b/share/ruby-build/2.6.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.6" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2#f08b779079ecd1498e6a2548c39a86144c6c784dcec6f7e8a93208682eb8306e" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.6" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.bz2#f08b779079ecd1498e6a2548c39a86144c6c784dcec6f7e8a93208682eb8306e" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.7
+++ b/share/ruby-build/2.6.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.7" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.7.tar.bz2#775a5d47b73ce3ee5d600f993badd7b640a2caca138573326db6632858517710" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.7" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.7.tar.bz2#775a5d47b73ce3ee5d600f993badd7b640a2caca138573326db6632858517710" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.8
+++ b/share/ruby-build/2.6.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.8" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.bz2#dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.8" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.8.tar.bz2#dac96ca6df8bab5a6fc7778907f42498037f8ce05b63d20779dce3163e9fafe6" warn_eol enable_shared standard

--- a/share/ruby-build/2.6.9
+++ b/share/ruby-build/2.6.9
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.6.9" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.bz2#a0639060c4519572e51828eb742f09dd40f154c820f6007246de7a2090e3ee45" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.6.9" "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.9.tar.bz2#a0639060c4519572e51828eb742f09dd40f154c820f6007246de7a2090e3ee45" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.0
+++ b/share/ruby-build/2.7.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.0" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0.tar.bz2#7aa247a19622a803bdd29fdb28108de9798abe841254fe8ea82c31d125c6ab26" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.0-dev
+++ b/share/ruby-build/2.7.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.7.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-2.7.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/2.7.0-preview1
+++ b/share/ruby-build/2.7.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.0-preview1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview1.tar.bz2#d45b4a1712ec5c03a35e85e33bcb57c7426b856d35e4f04f7975ae3944d09952" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.0-preview2
+++ b/share/ruby-build/2.7.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.0-preview2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview2.tar.bz2#417c84346ba84d664a13833c94c6d9f888c89bb9bee9adf469580441eaede30b" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.0-preview3
+++ b/share/ruby-build/2.7.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2#df2ddee659873e6fc30a8590ecffa49cf3a4ef81fa922b0d09f821b69ee88bc3" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.0-preview3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-preview3.tar.bz2#df2ddee659873e6fc30a8590ecffa49cf3a4ef81fa922b0d09f821b69ee88bc3" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.0-rc1
+++ b/share/ruby-build/2.7.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc1.tar.bz2#1c5a02b63fa9fca37c41681bbbf20c55818a32315958c0a6c8f505943bfcb2d2" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.0-rc1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc1.tar.bz2#1c5a02b63fa9fca37c41681bbbf20c55818a32315958c0a6c8f505943bfcb2d2" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.0-rc2
+++ b/share/ruby-build/2.7.0-rc2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc2.tar.bz2#8f94ea7ba79b6e95225fb4a7870e882081182c3d12d58c4cad2a7d2e7865cf8e" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.0-rc2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.0-rc2.tar.bz2#8f94ea7ba79b6e95225fb4a7870e882081182c3d12d58c4cad2a7d2e7865cf8e" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.1
+++ b/share/ruby-build/2.7.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.1" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.bz2#d703d58a67e7ed822d6e4a6ea9e44255f689a5b6ea6752d17e8d031849822202" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.2
+++ b/share/ruby-build/2.7.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.2" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.bz2#65a590313d244d48dc2ef9a9ad015dd8bc6faf821621bbb269aa7462829c75ed" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.3
+++ b/share/ruby-build/2.7.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.3" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.3.tar.bz2#3e90e5a41d4df90e19c307ab0fb41789992c0b0128e6bbaa669b89ed44a0b68b" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.4
+++ b/share/ruby-build/2.7.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.4" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.4.tar.bz2#bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.5
+++ b/share/ruby-build/2.7.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.5" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.5.tar.bz2#d6b444341a5e06fcd6eaf1feb83a1c0c2da4705dbe4f275ee851761b185f4bd1" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.6
+++ b/share/ruby-build/2.7.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.6" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.tar.bz2#6de239d74cf6da09d0c17a116378a866743f5f0a52c9355da26b5d312ca6eed3" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.7
+++ b/share/ruby-build/2.7.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.7" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.7.tar.bz2#cf800820c9e69cdd31a8cdab920391f74ed935db2397a905afabd48961913658" warn_eol enable_shared standard

--- a/share/ruby-build/2.7.8
+++ b/share/ruby-build/2.7.8
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-2.7.8" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz#c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0" warn_eol enable_shared standard verify_openssl
+install_package "ruby-2.7.8" "https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.8.tar.gz#c2dab63cbc8f2a05526108ad419efa63a67ed4074dbbcf9fc2b1ca664cb45ba0" warn_eol enable_shared standard

--- a/share/ruby-build/3.0.0
+++ b/share/ruby-build/3.0.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz#a13ed141a1c18eb967aac1e33f4d6ad5f21be1ac543c344e0d6feeee54af8e28" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz#a13ed141a1c18eb967aac1e33f4d6ad5f21be1ac543c344e0d6feeee54af8e28" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.0-dev
+++ b/share/ruby-build/3.0.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-3.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_0" autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-3.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_0" autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/3.0.0-preview1
+++ b/share/ruby-build/3.0.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview1.tar.bz2#013bdc6e859d76d67a6fcd990d401ed57e6e25896bab96d1d0648a877f556dbb" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview1.tar.bz2#013bdc6e859d76d67a6fcd990d401ed57e6e25896bab96d1d0648a877f556dbb" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.0-preview2
+++ b/share/ruby-build/3.0.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview2.tar.gz#9de8661565c2b1007d91a580e9a7e02d23f1e8fc8df371feb15a2727aa05fd9a" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview2.tar.gz#9de8661565c2b1007d91a580e9a7e02d23f1e8fc8df371feb15a2727aa05fd9a" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.0-rc1
+++ b/share/ruby-build/3.0.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-rc1.tar.gz#e1270f38b969ce7b124f0a4c217e33eda643f75c7cb20debc62c17535406e37f" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-rc1.tar.gz#e1270f38b969ce7b124f0a4c217e33eda643f75c7cb20debc62c17535406e37f" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.1
+++ b/share/ruby-build/3.0.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.1.tar.gz#369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.1.tar.gz#369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.2
+++ b/share/ruby-build/3.0.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.2.tar.gz#5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.2.tar.gz#5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.3
+++ b/share/ruby-build/3.0.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.3" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.3.tar.gz#3586861cb2df56970287f0fd83f274bd92058872d830d15570b36def7f1a92ac" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.3" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.3.tar.gz#3586861cb2df56970287f0fd83f274bd92058872d830d15570b36def7f1a92ac" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.4
+++ b/share/ruby-build/3.0.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.4" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.4.tar.gz#70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.4" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.4.tar.gz#70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.5
+++ b/share/ruby-build/3.0.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.5" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz#9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.5" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz#9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.0.6
+++ b/share/ruby-build/3.0.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.6" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz#6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e" warn_unsupported enable_shared standard verify_openssl
+install_package "ruby-3.0.6" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz#6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.0
+++ b/share/ruby-build/3.1.0
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" enable_shared standard verify_openssl
+install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" enable_shared standard

--- a/share/ruby-build/3.1.0-dev
+++ b/share/ruby-build/3.1.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-3.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/3.1.0-preview1
+++ b/share/ruby-build/3.1.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" enable_shared standard verify_openssl
+install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" enable_shared standard

--- a/share/ruby-build/3.1.1
+++ b/share/ruby-build/3.1.1
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" enable_shared standard verify_openssl
+install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" enable_shared standard

--- a/share/ruby-build/3.1.2
+++ b/share/ruby-build/3.1.2
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" enable_shared standard verify_openssl
+install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" enable_shared standard

--- a/share/ruby-build/3.1.3
+++ b/share/ruby-build/3.1.3
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" enable_shared standard verify_openssl
+install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" enable_shared standard

--- a/share/ruby-build/3.1.4
+++ b/share/ruby-build/3.1.4
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" enable_shared standard verify_openssl
+install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" enable_shared standard

--- a/share/ruby-build/3.2.0
+++ b/share/ruby-build/3.2.0
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz#daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" enable_shared standard verify_openssl
+install_package "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz#daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" enable_shared standard

--- a/share/ruby-build/3.2.0-dev
+++ b/share/ruby-build/3.2.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-3.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/3.2.0-preview1
+++ b/share/ruby-build/3.2.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" enable_shared standard verify_openssl
+install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" enable_shared standard

--- a/share/ruby-build/3.2.0-preview2
+++ b/share/ruby-build/3.2.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" enable_shared standard verify_openssl
+install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" enable_shared standard

--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" enable_shared standard verify_openssl
+install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" enable_shared standard

--- a/share/ruby-build/3.2.0-rc1
+++ b/share/ruby-build/3.2.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" enable_shared standard verify_openssl
+install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" enable_shared standard

--- a/share/ruby-build/3.2.1
+++ b/share/ruby-build/3.2.1
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz#13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd" enable_shared standard verify_openssl
+install_package "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz#13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd" enable_shared standard

--- a/share/ruby-build/3.2.2
+++ b/share/ruby-build/3.2.2
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" enable_shared standard verify_openssl
+install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" enable_shared standard

--- a/share/ruby-build/3.3.0-dev
+++ b/share/ruby-build/3.3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_build standard_install_with_bundled_gems

--- a/share/ruby-build/3.3.0-preview1
+++ b/share/ruby-build/3.3.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview1.tar.gz#c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed" enable_shared standard verify_openssl
+install_package "ruby-3.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview1.tar.gz#c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed" enable_shared standard

--- a/share/ruby-build/3.3.0-preview2
+++ b/share/ruby-build/3.3.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview2.tar.gz#30ce8b0fe11b37b5ac088f5a5765744b935eac45bb89a9e381731533144f5991" enable_shared standard verify_openssl
+install_package "ruby-3.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview2.tar.gz#30ce8b0fe11b37b5ac088f5a5765744b935eac45bb89a9e381731533144f5991" enable_shared standard

--- a/test/build.bats
+++ b/test/build.bats
@@ -111,7 +111,7 @@ assert_build_log() {
 yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -144,7 +144,7 @@ yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 patch -p0 --force -i $TMP/ruby-patch.XXX
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -177,7 +177,7 @@ yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 patch -p1 --force -i $TMP/ruby-patch.XXX
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -211,7 +211,7 @@ yaml-0.1.6: [--prefix=$INSTALL_ROOT]
 make -j 2
 make install
 patch -p1 --force -i $TMP/ruby-patch.XXX
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -237,7 +237,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-libyaml-dir=$brew_libdir]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-libyaml-dir=$brew_libdir,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -261,7 +261,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-gmp-dir=$gmp_libdir]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-gmp-dir=$gmp_libdir,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -285,7 +285,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-readline-dir=$readline_libdir]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-readline-dir=$readline_libdir,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -310,7 +310,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-readline-dir=/custom]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+,--with-readline-dir=/custom]
 make -j 2
 make install
 OUT
@@ -337,7 +337,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -374,7 +374,7 @@ DEF
 openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,zlib-dynamic,no-ssl3,shared]
 make -j 2
 make install_sw install_ssldirs
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=$INSTALL_ROOT/openssl]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=$INSTALL_ROOT/openssl,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -398,7 +398,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=/path/to/openssl]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+,--with-openssl-dir=/path/to/openssl]
 make -j 2
 make install
 OUT
@@ -448,7 +448,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=$TMP/homebrew/opt/openssl@3.0]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=$TMP/homebrew/opt/openssl@3.0,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -471,7 +471,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,cppflags=-DYJIT_FORCE_ENABLE -DRUBY_PATCHLEVEL_NAME=test,--with-openssl-dir=/path/to/openssl,--with-readline-dir=/custom]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,cppflags=-DYJIT_FORCE_ENABLE -DRUBY_PATCHLEVEL_NAME=test,--with-openssl-dir=/path/to/openssl,--with-ext=openssl,psych,+,--with-readline-dir=/custom]
 make -j 2
 make install
 OUT
@@ -494,7 +494,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT
@@ -518,7 +518,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 4
 make install
 OUT
@@ -532,8 +532,7 @@ OUT
   stub_make_install
 
   export -n MAKE_OPTS
-  export RUBY_CONFIGURE_OPTS="--with-openssl-dir=/test"
-  run_inline_definition <<DEF
+  RUBY_CONFIGURE_OPTS="--with-openssl-dir=/test" run_inline_definition <<DEF
 install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
@@ -543,7 +542,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=/test]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+,--with-openssl-dir=/test]
 make -j 1
 make install
 OUT
@@ -566,7 +565,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install --globalmake RUBYMAKE=true with spaces
 OUT
@@ -594,8 +593,7 @@ CONF
   stub apply 'echo apply "$@" >> build.log'
   stub_make_install
 
-  export RUBY_CONFIGURE="${TMP}/custom-configure"
-  run_inline_definition <<DEF
+  RUBY_CONFIGURE="${TMP}/custom-configure" run_inline_definition <<DEF
 install_package "ruby-2.0.0" "http://ruby-lang.org/pub/ruby-2.0.0.tar.gz"
 DEF
   assert_success
@@ -606,7 +604,7 @@ DEF
 
   assert_build_log <<OUT
 apply -p1 -i /my/patch.diff
-ruby-2.0.0: [--prefix=$INSTALL_ROOT]
+ruby-2.0.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
 make -j 2
 make install
 OUT

--- a/test/compiler.bats
+++ b/test/compiler.bats
@@ -31,7 +31,7 @@ DEF
   assert_success
   run cat build.log
   assert_output <<OUT
-./configure --prefix=$INSTALL_ROOT
+./configure --prefix=$INSTALL_ROOT --with-ext=openssl,psych,+
 CC=clang
 CFLAGS=no
 make -j 2


### PR DESCRIPTION
Normally, Ruby `make` step will print a warning about any missing extensions, but will not abort the build and instead proceed as normal.

Since Ruby installations without openssl or psych are essentially broken, ruby-build used to have a `verify_openssl` build step to test if the newly built Ruby can load these extensions, and print helpful information and abort the build on errors:

    Loading the Ruby openssl extension failed
    ERROR: Ruby install aborted due to missing extensions

The `verify_opensl` implementation was necessary to provide a good experience for ruby-build users, but was hacky and I would prefer to eliminate it. Fixes #2241, fixes #1415

**It appears that passing `--with-ext=openssl,psych` to the Ruby configure step marks those extensions as mandatory and fails the `make` process if they failed to build.** That is exactly the behavior we want, so this change enables the configure option for all Ruby builds. https://github.com/ruby/ruby/commit/b58a30e1c14e971adba4096104274d5d692492e9

```
*** Following extensions are not compiled:
openssl:
	Could not be configured. It will not be installed.
	/private/var/folders/6k/fwzzx67n163b0lfftyw3313h0000gn/T/ruby-build.20231107113317.26428.4N23Wf/ruby-3.2.2/ext/openssl/extconf.rb:101: OpenSSL library could not be found. You might want to use --with-openssl-dir=<dir> option to specify the prefix where OpenSSL is installed.
	Check ext/openssl/mkmf.log for more details.
psych:
	Could not be configured. It will not be installed.
	Check ext/psych/mkmf.log for more details.
*** Fix the problems, then remove these directories and try again if you want.
make[1]: *** [note] Error 1
make: *** [build-ext] Error 2
```

/cc @nobu @hsbt: as people who are more familiar with Ruby build process than myself, do you foresee any potential problems with using `./configure --with-ext=openssl,psych` by default when building any Ruby version, even old ones? From what I can see, the `--with-ext` flag seems to have existed for a long time, but only started having the behavior that we want from Ruby 2.5.0. Thank you!

The new default ruby-build behavior can be avoided by explicitly passing another `--with-ext` value, e.g.:
```sh
ruby-build 3.2.2 /tmp/ruby-3.2.2 -- --with-ext=+
```