### PR TITLE
Fix commands printed when TMPDIR is empty

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -110,10 +110,9 @@ colorize() {
 
 print_command() {
   local arg
-  local tmpdir="${TMPDIR%/}"
   for arg; do
-    arg="${arg//$tmpdir\//\$TMPDIR/}"
-    arg="${arg//$HOME\//\$HOME/}"
+    [ "${#TMPDIR}" -le 1 ] || arg="${arg//$TMP\//\$TMPDIR/}"
+    [ "${#HOME}" -le 1 ] || arg="${arg//$HOME\//\$HOME/}"
     case "$arg" in
     *\'* | *\$* )
       printf ' "%s"' "$arg" ;;

--- a/test/output.bats
+++ b/test/output.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "print_command" {
+  mkdir -p "$TMP"
+
+  cat <<EOF > "$TMP"/definition
+print_command ./configure --prefix="\$PREFIX_PATH" --arg='with spaces'
+EOF
+  # substitute $TMPDIR in command invocations
+  TMPDIR="/tmp/" run ruby-build "$TMP"/definition /tmp/path/to/prefix
+  assert_output " ./configure \"--prefix=\$TMPDIR/path/to/prefix\" '--arg=with spaces'"
+  # doesn't substitute TMPDIR if it didn't come from user's environment
+  TMPDIR="" run ruby-build "$TMP"/definition /tmp/path/to/prefix
+  assert_output " ./configure --prefix=/tmp/path/to/prefix '--arg=with spaces'"
+
+  cat <<EOF > "$TMP"/definition
+print_command install --bindir="$TMP"/home/.local/bin
+EOF
+  # substitute $HOME in command invocations
+  HOME="$TMP"/home TMPDIR="" run ruby-build "$TMP"/definition /tmp/path/to/prefix
+  assert_output " install \"--bindir=\$HOME/.local/bin\""
+  # do not substitute $HOME if it's root path
+  HOME="/" TMPDIR="" run ruby-build "$TMP"/definition /tmp/path/to/prefix
+  assert_output " install --bindir=${TMP}/home/.local/bin"
+}


### PR DESCRIPTION
Do not blindly try to substitute an empty string with "$TMPDIR" 🤦 

Fixes #2299