### PR TITLE
Abandon using `--show-progress` for wget

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -445,7 +445,7 @@ http_head_wget() {
 
 http_get_wget() {
   # shellcheck disable=SC2086
-  log_command wget -nv --show-progress $WGET_OPTS -O "$2" "$1" 2>&3
+  log_command wget $WGET_OPTS -O "$2" "$1" 2>&3
 }
 
 fetch_tarball() {


### PR DESCRIPTION
It seems like there exist platforms that have wget which does not support the `--show-progress` option. This reverts to using wget in its default verbose mode where a progress bar and bunch more information are printed to stderr.

Fixes https://github.com/rbenv/ruby-build/issues/2301
Followup to https://github.com/rbenv/ruby-build/pull/2230

```
-> wget -O ruby-3.2.2.tar.gz https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz
--2023-11-08 23:59:46--  https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz
Resolving cache.ruby-lang.org (cache.ruby-lang.org)... 151.101.193.178, 151.101.1.178, 151.101.65.178, ...
Connecting to cache.ruby-lang.org (cache.ruby-lang.org)|151.101.193.178|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 20467023 (20M) [application/x-tar]
Saving to: ‘ruby-3.2.2.tar.gz’

ruby-3.2.2.tar.gz        100%[========================================>]  19.52M  30.3MB/s    in 0.6s    

2023-11-08 23:59:48 (30.3 MB/s) - ‘ruby-3.2.2.tar.gz’ saved [20467023/20467023]
```

Users can set an environment variable to opt into less verbose wget behavior that still shows a simple progress bar:
```
export RUBY_BUILD_WGET_OPTS="-nv --show-progress"
```