### PR TITLE
Mark Ruby 3.0.x as unsupported

### DIFF
--- a/share/ruby-build/3.0.0
+++ b/share/ruby-build/3.0.0
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz#a13ed141a1c18eb967aac1e33f4d6ad5f21be1ac543c344e0d6feeee54af8e28" enable_shared standard verify_openssl
+install_package "ruby-3.0.0" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.tar.gz#a13ed141a1c18eb967aac1e33f4d6ad5f21be1ac543c344e0d6feeee54af8e28" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-preview1
+++ b/share/ruby-build/3.0.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview1.tar.bz2#013bdc6e859d76d67a6fcd990d401ed57e6e25896bab96d1d0648a877f556dbb" enable_shared standard verify_openssl
+install_package "ruby-3.0.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview1.tar.bz2#013bdc6e859d76d67a6fcd990d401ed57e6e25896bab96d1d0648a877f556dbb" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-preview2
+++ b/share/ruby-build/3.0.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview2.tar.gz#9de8661565c2b1007d91a580e9a7e02d23f1e8fc8df371feb15a2727aa05fd9a" enable_shared standard verify_openssl
+install_package "ruby-3.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview2.tar.gz#9de8661565c2b1007d91a580e9a7e02d23f1e8fc8df371feb15a2727aa05fd9a" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.0-rc1
+++ b/share/ruby-build/3.0.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-rc1.tar.gz#e1270f38b969ce7b124f0a4c217e33eda643f75c7cb20debc62c17535406e37f" enable_shared standard verify_openssl
+install_package "ruby-3.0.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-rc1.tar.gz#e1270f38b969ce7b124f0a4c217e33eda643f75c7cb20debc62c17535406e37f" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.1
+++ b/share/ruby-build/3.0.1
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.1.tar.gz#369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727" enable_shared standard verify_openssl
+install_package "ruby-3.0.1" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.1.tar.gz#369825db2199f6aeef16b408df6a04ebaddb664fb9af0ec8c686b0ce7ab77727" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.2
+++ b/share/ruby-build/3.0.2
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.2.tar.gz#5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1" enable_shared standard verify_openssl
+install_package "ruby-3.0.2" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.2.tar.gz#5085dee0ad9f06996a8acec7ebea4a8735e6fac22f22e2d98c3f2bc3bef7e6f1" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.3
+++ b/share/ruby-build/3.0.3
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.3" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.3.tar.gz#3586861cb2df56970287f0fd83f274bd92058872d830d15570b36def7f1a92ac" enable_shared standard verify_openssl
+install_package "ruby-3.0.3" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.3.tar.gz#3586861cb2df56970287f0fd83f274bd92058872d830d15570b36def7f1a92ac" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.4
+++ b/share/ruby-build/3.0.4
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.4" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.4.tar.gz#70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b" enable_shared standard verify_openssl
+install_package "ruby-3.0.4" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.4.tar.gz#70b47c207af04bce9acea262308fb42893d3e244f39a4abc586920a1c723722b" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.5
+++ b/share/ruby-build/3.0.5
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.5" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz#9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776" enable_shared standard verify_openssl
+install_package "ruby-3.0.5" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz#9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776" warn_unsupported enable_shared standard verify_openssl

--- a/share/ruby-build/3.0.6
+++ b/share/ruby-build/3.0.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.6" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz#6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e" enable_shared standard verify_openssl
+install_package "ruby-3.0.6" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz#6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e" warn_unsupported enable_shared standard verify_openssl


### PR DESCRIPTION
It reaches EOL status in March 2024.