### PR TITLE
Remove deprecated verify_openssl step from build definitions

### DIFF
--- a/share/ruby-build/3.3.0-preview3
+++ b/share/ruby-build/3.3.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.3.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview3.tar.gz#0969141be92e67e0edb84a8fb354acc98f01bd78e602a23a0f136045c82f4809" enable_shared standard verify_openssl
+install_package "ruby-3.3.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview3.tar.gz#0969141be92e67e0edb84a8fb354acc98f01bd78e602a23a0f136045c82f4809" enable_shared standard

--- a/share/ruby-build/ruby-dev
+++ b/share/ruby-build/ruby-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_build standard_install_with_bundled_gems verify_openssl
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_build standard_install_with_bundled_gems


### PR DESCRIPTION
Followup to #2296