### PR TITLE
Introduce "with_bundled_gems" build step for dev rubies and unify "standard"

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -634,7 +634,7 @@ build_package_warn_unsupported() {
   } >&2
 }
 
-build_package_standard_build() {
+build_package_standard() {
   local package_name="$1"
 
   if [ "${MAKEOPTS+defined}" ]; then
@@ -708,13 +708,7 @@ build_package_standard_build() {
       sed "s:\\([[:space:]]*Check\\) \\(ext/.*\\):\\1 ${PWD}/\\2:" >&2
   fi
 
-  return $status
-}
-
-build_package_standard_install() {
-  local package_name="$1"
-  local package_var_name
-  package_var_name="$(capitalize "${package_name%%-*}")"
+  [ $status -eq 0 ] || return $status
 
   local PACKAGE_MAKE_INSTALL_OPTS="${package_var_name}_MAKE_INSTALL_OPTS"
   local PACKAGE_MAKE_INSTALL_OPTS_ARRAY="${package_var_name}_MAKE_INSTALL_OPTS_ARRAY[@]"
@@ -724,17 +718,19 @@ build_package_standard_install() {
   capture_command "$MAKE" ${MAKE_INSTALL_TARGET:-install} "${!PACKAGE_MAKE_INSTALL_OPTS_ARRAY}" $MAKE_INSTALL_OPTS ${!PACKAGE_MAKE_INSTALL_OPTS}
 }
 
+# Used in place of "standard" step for building development branches of Ruby.
 build_package_standard_install_with_bundled_gems() {
-  capture_command "$MAKE" update-gems
-  capture_command "$MAKE" extract-gems
-
-  build_package_standard_install "$@"
+  MAKE_INSTALL_TARGET="update-gems extract-gems install" build_package_standard "$@"
 }
 
-# Backward Compatibility for standard function
-build_package_standard() {
-  build_package_standard_build "$@"
-  build_package_standard_install "$@"
+# Kept for backward compatibility with 3rd-party Ruby definitions.
+build_package_standard_build() {
+  true
+}
+
+# Kept for backward compatibility with 3rd-party Ruby definitions.
+build_package_standard_install() {
+  build_package_standard "$@"
 }
 
 build_package_autoconf() {

--- a/share/ruby-build/2.2.0-dev
+++ b/share/ruby-build/2.2.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" warn_eol autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-2.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_2" warn_eol autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/2.3.0-dev
+++ b/share/ruby-build/2.3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.2u" "https://www.openssl.org/source/openssl-1.0.2u.tar.gz#ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" openssl --if needs_openssl:0.9.6-1.0.x
-install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" warn_eol autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-2.3.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_3" warn_eol autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/2.4.0-dev
+++ b/share/ruby-build/2.4.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-2.4.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/2.5.0-dev
+++ b/share/ruby-build/2.5.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-2.5.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/2.6.0-dev
+++ b/share/ruby-build/2.6.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.6.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-2.6.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/2.7.0-dev
+++ b/share/ruby-build/2.7.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.7.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-2.7.0-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.0.0-dev
+++ b/share/ruby-build/3.0.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-3.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_0" autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-3.0.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_0" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.1.0-dev
+++ b/share/ruby-build/3.1.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-3.1.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.2.0-dev
+++ b/share/ruby-build/3.2.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-3.2.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.3.0-dev
+++ b/share/ruby-build/3.3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/ruby-dev
+++ b/share/ruby-build/ruby-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_build standard_install_with_bundled_gems
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_install_with_bundled_gems


### PR DESCRIPTION
This merges "standard_build" and "standard_install" build steps into one again and defines a "standard_install_with_bundled_gems" build step that just invokes "standard" with the addition of `update-gems` & `extract-gems`.

The goal is to have a single `standard` step again instead of maintaining it as two distinct `build_package_standard_build` and `build_package_standard_install` functions.

A runtime difference that will be a result of this change is that three separate invocations `make update-gems`, `make extract-gems`, and `make install` are now executed as one: `make update-gems extract-gems install`.

/cc @hsbt as this reverts parts of https://github.com/rbenv/ruby-build/pull/1098