### PR TITLE
Add Ruby 3.3.0

### DIFF
--- a/share/ruby-build/3.3.0
+++ b/share/ruby-build/3.3.0
@@ -1,0 +1,2 @@
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "ruby-3.3.0" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz#96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d" enable_shared standard


### PR DESCRIPTION
This worked well on my machine.

```
$ ruby-build 3.3.0 /opt/rubies/3.3.0
==> Downloading ruby-3.3.0.tar.gz...
-> curl -q -fL -o ruby-3.3.0.tar.gz https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.0M  100 21.0M    0     0  21.0M      0 --:--:-- --:--:-- --:--:-- 21.0M
==> Installing ruby-3.3.0...
-> ./configure --prefix=/opt/rubies/3.3.0 --enable-shared --with-ext=openssl,psych,+
-> make -j 20
-> make install
==> Installed ruby-3.3.0 to /opt/rubies/3.3.0

$ /opt/rubies/3.3.0/bin/ruby -v
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
```