### PR TITLE
Skip passing `--with-readline-dir` for Ruby 3.3+

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -655,7 +655,10 @@ build_package_standard() {
   local PACKAGE_CFLAGS="${package_var_name}_CFLAGS"
 
   if [ "$package_var_name" = "RUBY" ]; then
-    if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-readline-dir=* ]]; then
+    # shellcheck disable=SC2155
+    local ruby_semver="$(normalize_semver "${package_name#ruby-}")"
+    if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-readline-dir=* && "$ruby_semver" -lt 300300 ]]; then
+      # Ruby 3.3+ does not need external readline: https://github.com/rbenv/ruby-build/issues/2330
       use_homebrew_readline || use_freebsd_readline || true
     fi
     if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-libffi-dir=* ]]; then
@@ -672,7 +675,7 @@ build_package_standard() {
         # use openssl installed from Ports Collection
         package_option ruby configure --with-openssl-dir="/usr/local"
       fi
-    elif [ "$(normalize_semver "${package_name#ruby-}")" -lt 200707 ]; then
+    elif [ "$ruby_semver" -lt 200707 ]; then
       local opt
       for opt in $RUBY_CONFIGURE_OPTS "${RUBY_CONFIGURE_OPTS_ARRAY[@]}"; do
         if [[ $opt == --with-openssl-dir=* ]]; then
@@ -690,7 +693,7 @@ build_package_standard() {
     fi
     if [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-ext* &&
           "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--without-ext* &&
-          "$(normalize_semver "${package_name#ruby-}")" -ge 200500 ]]; then
+          "$ruby_semver" -ge 200500 ]]; then
       # For Ruby 2.5+, fail the `make` step if any of these extensions were not compiled.
       # Otherwise, the build would have succeeded, but Ruby would be useless at runtime.
       # https://github.com/ruby/ruby/commit/b58a30e1c14e971adba4096104274d5d692492e9

--- a/test/build.bats
+++ b/test/build.bats
@@ -293,6 +293,30 @@ make install
 OUT
 }
 
+@test "readline is not auto-discovered for Ruby 3.3" {
+  cached_tarball "ruby-3.3.0" configure
+
+  readline_libdir="$TMP/homebrew-readline"
+  mkdir -p "$readline_libdir"
+
+  stub_repeated brew "--prefix readline : echo '$readline_libdir'"
+  stub_make_install
+
+  run_inline_definition <<DEF
+install_package "ruby-3.3.0" "http://ruby-lang.org/ruby/3.0/ruby-3.3.0.tar.gz"
+DEF
+  assert_success
+
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+ruby-3.3.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
+make -j 2
+make install
+OUT
+}
+
 @test "readline is not linked from Homebrew when explicitly defined" {
   cached_tarball "ruby-3.2.0" configure
 


### PR DESCRIPTION
Apparently, `--with-readline-dir` is no longer needed starting from Ruby 3.3.0. It doesn't seem harmful to pass it, but since it might cause confusion to see the implicit value being passed as part of ruby-build output, it might be a good idea to only conditionally pass it for older rubies.

Fixes https://github.com/rbenv/ruby-build/issues/2330