### PR TITLE
Switch to EA builds from graalvm/graal-languages-ea-builds for truffleruby+graalvm-dev

### DIFF
--- a/share/ruby-build/truffleruby+graalvm-dev
+++ b/share/ruby-build/truffleruby+graalvm-dev
@@ -1,19 +1,26 @@
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-jvm-dev-linux-amd64.tar.gz" truffleruby
+  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-linux-amd64.url"
   ;;
 Linux-aarch64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-jvm-dev-linux-aarch64.tar.gz" truffleruby
+  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-linux-aarch64.url"
   ;;
 Darwin-x86_64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-jvm-dev-macos-amd64.tar.gz" truffleruby
+  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-darwin-amd64.url"
   ;;
 Darwin-arm64)
-  install_package "truffleruby+graalvm-dev" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-jvm-dev-macos-aarch64.tar.gz" truffleruby
+  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-darwin-aarch64.url"
   ;;
 *)
   colorize 1 "Unsupported platform: $platform"
   return 1
   ;;
 esac
+
+pushd "$BUILD_PATH" >/dev/null
+http get $url url.txt
+url=$(<url.txt)
+popd
+
+install_package "truffleruby+graalvm-dev" "$url" truffleruby


### PR DESCRIPTION
* See https://github.com/graalvm/graal-languages-ea-builds
* These are based on Oracle GraalVM.
* cc @nirvdrum 