### PR TITLE
Simplify `truffleruby+graalvm-dev` build definition re: download redirect

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -423,8 +423,15 @@ http_head_aria2c() {
 }
 
 http_get_aria2c() {
-  # shellcheck disable=SC2086
-  log_command aria2c --allow-overwrite=true --no-conf=true --console-log-level=warn --stderr $ARIA2_OPTS -o "$2" "$1" 2>&3
+  local destfile="$2"
+  if [[ $destfile == /* ]]; then
+    # the "-o" option to aria2c cannot be an absolute path, but we can achieve that with "--dir"
+    # shellcheck disable=SC2086
+    log_command aria2c --allow-overwrite=true --no-conf=true --console-log-level=warn --stderr $ARIA2_OPTS --dir "${destfile%/*}" -o "${destfile##*/}" "$1" 2>&3
+  else
+    # shellcheck disable=SC2086
+    log_command aria2c --allow-overwrite=true --no-conf=true --console-log-level=warn --stderr $ARIA2_OPTS -o "$destfile" "$1" 2>&3
+  fi
 }
 
 http_head_curl() {

--- a/share/ruby-build/truffleruby+graalvm-dev
+++ b/share/ruby-build/truffleruby+graalvm-dev
@@ -1,16 +1,16 @@
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)
-  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-linux-amd64.url"
+  url="https://github.com/graalvm/graal-languages-ea-builds/raw/HEAD/truffleruby/versions/latest-jvm-linux-amd64.url"
   ;;
 Linux-aarch64)
-  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-linux-aarch64.url"
+  url="https://github.com/graalvm/graal-languages-ea-builds/raw/HEAD/truffleruby/versions/latest-jvm-linux-aarch64.url"
   ;;
 Darwin-x86_64)
-  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-darwin-amd64.url"
+  url="https://github.com/graalvm/graal-languages-ea-builds/raw/HEAD/truffleruby/versions/latest-jvm-darwin-amd64.url"
   ;;
 Darwin-arm64)
-  url="https://raw.githubusercontent.com/graalvm/graal-languages-ea-builds/main/truffleruby/versions/latest-jvm-darwin-aarch64.url"
+  url="https://github.com/graalvm/graal-languages-ea-builds/raw/HEAD/truffleruby/versions/latest-jvm-darwin-aarch64.url"
   ;;
 *)
   colorize 1 "Unsupported platform: $platform"
@@ -18,9 +18,7 @@ Darwin-arm64)
   ;;
 esac
 
-pushd "$BUILD_PATH" >/dev/null
-http get $url url.txt
-url=$(<url.txt)
-popd
-
-install_package "truffleruby+graalvm-dev" "$url" truffleruby
+urlfile="$(mktemp "${TMP}/truffleruby.XXXXXX")"
+http get "$url" "$urlfile"
+install_package "truffleruby+graalvm-dev" "$(<"$urlfile")" truffleruby
+rm -f "$urlfile"


### PR DESCRIPTION
The `http get <url> <destfile>` utility had a bug with aria2c downloader where it couldn't properly save to destfile if it was an absolute path.

I have tried having `http get <url> -` consistently print the downloaded file to stdout, but this conflicted with the output of `log_command` (which is also to stdout) so for now let's keep using the temporary file to resolve manual URL redirects.

Followup to https://github.com/rbenv/ruby-build/pull/2356 /cc @rwstauner