### PR TITLE
Add CRuby security-fix releases 3.0.7, 3.1.5, 3.2.4, and 3.3.1

### DIFF
--- a/share/ruby-build/3.0.7
+++ b/share/ruby-build/3.0.7
@@ -1,0 +1,2 @@
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
+install_package "ruby-3.0.7" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.gz#2a3411977f2850431136b0fab8ad53af09fb74df2ee2f4fb7f11b378fe034388" enable_shared standard

--- a/share/ruby-build/3.1.5
+++ b/share/ruby-build/3.1.5
@@ -1,0 +1,2 @@
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "ruby-3.1.5" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.gz#3685c51eeee1352c31ea039706d71976f53d00ab6d77312de6aa1abaf5cda2c5" enable_shared standard

--- a/share/ruby-build/3.2.4
+++ b/share/ruby-build/3.2.4
@@ -1,0 +1,2 @@
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "ruby-3.2.4" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.gz#c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692" enable_shared standard

--- a/share/ruby-build/3.3.1
+++ b/share/ruby-build/3.3.1
@@ -1,0 +1,2 @@
+install_package "openssl-3.1.4" "https://www.openssl.org/source/openssl-3.1.4.tar.gz#840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "ruby-3.3.1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.gz#8dc2af2802cc700cd182d5430726388ccf885b3f0a14fcd6a0f21ff249c9aa99" enable_shared standard


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/

https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/

https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/

https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/