### PR TITLE
rbenv install: error out instead of prompting in non-interactive mode

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -178,6 +178,10 @@ PREFIX="${RBENV_ROOT}/versions/${VERSION_NAME}"
 if [ -d "${PREFIX}/bin" ]; then
   if [ -z "$FORCE" ] && [ -z "$SKIP_EXISTING" ]; then
     echo "rbenv: $PREFIX already exists" >&2
+    if [ ! -t 0 ]; then
+      echo "rbenv: must use \`--force' or \`--skip-existing' in non-interactive mode" >&2
+      exit 1
+    fi
     read -rp "continue with installation? (y/N) "
 
     case "$REPLY" in

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -69,6 +69,11 @@ if [ -z "$FORCE" ]; then
     exit 1
   fi
 
+  if [ ! -t 0 ]; then
+    echo "rbenv: must use \`--force' in non-interactive mode" >&2
+    exit 1
+  fi
+
   read -p "rbenv: remove $PREFIX? [yN] "
   case "$REPLY" in
   y* | Y* ) ;;


### PR DESCRIPTION
Fixes https://github.com/rbenv/ruby-build/issues/2374