### PR TITLE
Mark Ruby 3.0.7 as unsupported

### DIFF
--- a/share/ruby-build/3.0.7
+++ b/share/ruby-build/3.0.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_package "ruby-3.0.7" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.gz#2a3411977f2850431136b0fab8ad53af09fb74df2ee2f4fb7f11b378fe034388" enable_shared standard
+install_package "ruby-3.0.7" "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.gz#2a3411977f2850431136b0fab8ad53af09fb74df2ee2f4fb7f11b378fe034388" warn_unsupported enable_shared standard


### PR DESCRIPTION
This one was missed in https://github.com/rbenv/ruby-build/pull/2307 or was added after, hopefully this removes ruby 3.0.7 from `rbenv install -l` unless you list-all