### PR TITLE
Clarify RUBY_BUILD_ROOT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The build process may be configured through the following environment variables:
 | `RUBY_BUILD_MIRROR_URL`         | Custom mirror URL root.                                                                          |
 | `RUBY_BUILD_MIRROR_PACKAGE_URL` | Custom complete mirror URL (e.g. http://mirror.example.com/package-1.0.0.tar.gz).                |
 | `RUBY_BUILD_SKIP_MIRROR`        | Bypass the download mirror and fetch all package files from their original URLs.                 |
-| `RUBY_BUILD_ROOT`               | Custom build definition directory. (Default: `share/ruby-build`)                                 |
+| `RUBY_BUILD_ROOT`               | Custom build definition directory containing `share/ruby-build/<defs>`. (Default: ruby-build's installation prefix ) |
 | `RUBY_BUILD_TARBALL_OVERRIDE`   | Override the URL to fetch the ruby tarball from, optionally followed by `#checksum`.             |
 | `RUBY_BUILD_DEFINITIONS`        | Additional paths to search for build definitions. (Colon-separated list)                         |
 | `CC`                            | Path to the C compiler.                                                                          |

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ The build process may be configured through the following environment variables:
 | `RUBY_BUILD_MIRROR_URL`         | Custom mirror URL root.                                                                          |
 | `RUBY_BUILD_MIRROR_PACKAGE_URL` | Custom complete mirror URL (e.g. http://mirror.example.com/package-1.0.0.tar.gz).                |
 | `RUBY_BUILD_SKIP_MIRROR`        | Bypass the download mirror and fetch all package files from their original URLs.                 |
-| `RUBY_BUILD_ROOT`               | Custom build definition directory containing `share/ruby-build/<defs>`. (Default: ruby-build's installation prefix ) |
 | `RUBY_BUILD_TARBALL_OVERRIDE`   | Override the URL to fetch the ruby tarball from, optionally followed by `#checksum`.             |
-| `RUBY_BUILD_DEFINITIONS`        | Additional paths to search for build definitions. (Colon-separated list)                         |
+| `RUBY_BUILD_DEFINITIONS`        | Colon-separated list of paths to search for build definition files.                              |
+| `RUBY_BUILD_ROOT`               | The path prefix to search for build definitions files. *Deprecated:* use `RUBY_BUILD_DEFINITIONS`|
 | `CC`                            | Path to the C compiler.                                                                          |
 | `RUBY_CFLAGS`                   | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |
 | `CONFIGURE_OPTS`                | Additional `./configure` options.                                                                |


### PR DESCRIPTION
The RUBY_BUILD_ROOT itself does not default to share/ruby-build/ but rather must point to a directory that has definitions under `share/ruby-build/`.

The misleading verbiage was introduced: https://github.com/rbenv/ruby-build/commit/af2df4e74a305e4018331531e43e5d9276bb6875

Original phrasing introduced: https://github.com/rbenv/ruby-build/commit/ff75ca72045ce54b4c47d1b5c51e3d921cc63c96

Could still use some rephrasing I think. It's awkward to explain the env var must point to a directory that itself contains a particular path; without implying that the env var itself contains the "share/ruby-build/" path.

fixes #2391 