### PR TITLE
Fix 3.1.6 version definition

### DIFF
--- a/share/ruby-build/3.1.6
+++ b/share/ruby-build/3.1.6
@@ -1,2 +1,2 @@
 install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz#"0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" enable_shared standard
+install_package "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz#0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" enable_shared standard


### PR DESCRIPTION
There is an extra quote and it was causing a failure:

```
/home/vscode/.rbenv/plugins/ruby-build/share/ruby-build/3.1.6: line 2: unexpected EOF while looking for matching `"'
```