### PR TITLE
Use LTS version of OpenSSL 3

### DIFF
--- a/share/ruby-build/3.1-dev
+++ b/share/ruby-build/3.1-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.1-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.1.0
+++ b/share/ruby-build/3.1.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" enable_shared standard

--- a/share/ruby-build/3.1.0-preview1
+++ b/share/ruby-build/3.1.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" enable_shared standard

--- a/share/ruby-build/3.1.1
+++ b/share/ruby-build/3.1.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" enable_shared standard

--- a/share/ruby-build/3.1.2
+++ b/share/ruby-build/3.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" enable_shared standard

--- a/share/ruby-build/3.1.3
+++ b/share/ruby-build/3.1.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" enable_shared standard

--- a/share/ruby-build/3.1.4
+++ b/share/ruby-build/3.1.4
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" enable_shared standard

--- a/share/ruby-build/3.1.5
+++ b/share/ruby-build/3.1.5
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.5" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.gz#3685c51eeee1352c31ea039706d71976f53d00ab6d77312de6aa1abaf5cda2c5" enable_shared standard

--- a/share/ruby-build/3.1.6
+++ b/share/ruby-build/3.1.6
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz#0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" enable_shared standard

--- a/share/ruby-build/3.2-dev
+++ b/share/ruby-build/3.2-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.2-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.2.0
+++ b/share/ruby-build/3.2.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz#daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" enable_shared standard

--- a/share/ruby-build/3.2.0-preview1
+++ b/share/ruby-build/3.2.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" enable_shared standard

--- a/share/ruby-build/3.2.0-preview2
+++ b/share/ruby-build/3.2.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" enable_shared standard

--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" enable_shared standard

--- a/share/ruby-build/3.2.0-rc1
+++ b/share/ruby-build/3.2.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" enable_shared standard

--- a/share/ruby-build/3.2.1
+++ b/share/ruby-build/3.2.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz#13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd" enable_shared standard

--- a/share/ruby-build/3.2.2
+++ b/share/ruby-build/3.2.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" enable_shared standard

--- a/share/ruby-build/3.2.3
+++ b/share/ruby-build/3.2.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz#af7f1757d9ddb630345988139211f1fd570ff5ba830def1cc7c468ae9b65c9ba" enable_shared standard

--- a/share/ruby-build/3.2.4
+++ b/share/ruby-build/3.2.4
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.4" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.gz#c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692" enable_shared standard

--- a/share/ruby-build/3.3-dev
+++ b/share/ruby-build/3.3-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.3-dev" "https://github.com/ruby/ruby.git" "ruby_3_3" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.3.0
+++ b/share/ruby-build/3.3.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz#96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d" enable_shared standard

--- a/share/ruby-build/3.3.0-preview1
+++ b/share/ruby-build/3.3.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview1.tar.gz#c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed" enable_shared standard

--- a/share/ruby-build/3.3.0-preview2
+++ b/share/ruby-build/3.3.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview2.tar.gz#30ce8b0fe11b37b5ac088f5a5765744b935eac45bb89a9e381731533144f5991" enable_shared standard

--- a/share/ruby-build/3.3.0-preview3
+++ b/share/ruby-build/3.3.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview3.tar.gz#0969141be92e67e0edb84a8fb354acc98f01bd78e602a23a0f136045c82f4809" enable_shared standard

--- a/share/ruby-build/3.3.0-rc1
+++ b/share/ruby-build/3.3.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-rc1.tar.gz#c4ff82395a90ef76c7f906b7687026e0ab96b094dcf3a532d9ab97784a073222" enable_shared standard

--- a/share/ruby-build/3.3.1
+++ b/share/ruby-build/3.3.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.gz#8dc2af2802cc700cd182d5430726388ccf885b3f0a14fcd6a0f21ff249c9aa99" enable_shared standard

--- a/share/ruby-build/3.3.2
+++ b/share/ruby-build/3.3.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.2.tar.gz#3be1d100ebf2a0ce60c2cd8d22cd9db4d64b3e04a1943be2c4ff7b520f2bcb5b" enable_shared standard

--- a/share/ruby-build/3.4-dev
+++ b/share/ruby-build/3.4-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_install_with_bundled_gems

--- a/share/ruby-build/3.4.0-preview1
+++ b/share/ruby-build/3.4.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.0-preview1.tar.gz#1a3c322e90cb22e5fba0b5d257bb2be9988affa3867eba7642ed981fdde895bb" enable_shared standard

--- a/share/ruby-build/ruby-dev
+++ b/share/ruby-build/ruby-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.13" "https://www.openssl.org/source/openssl-3.0.13.tar.gz#88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_install_with_bundled_gems


### PR DESCRIPTION
I investigate release/maintenance policy of OpenSSL 3 series.

From https://www.openssl.org/policies/releasestrat.html.

>Version 3.0 will be supported until 2026-09-07 (LTS).

OpenSSL 3.1/3.2 will become EOL status in 2025. We should switch to use LTS version for missing OpenSSL environment. 