### PR TITLE
Simplify JRuby version check

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -860,7 +860,7 @@ build_package_jruby() {
   cd "${PREFIX_PATH}/bin"
   ln -fs jruby ruby
   chmod +x ruby
-  install_jruby_launcher
+  install_jruby_launcher "$1"
   remove_windows_files
   fix_jruby_shebangs
 }
@@ -869,9 +869,7 @@ install_jruby_launcher() {
   # shellcheck disable=SC2164
   cd "${PREFIX_PATH}/bin"
   # workaround for https://github.com/jruby/jruby/issues/7799
-  local jruby_version
-  jruby_version="$(./ruby -e 'puts JRUBY_VERSION' 2>/dev/null)"
-  [[ $jruby_version != "9.2."* ]] ||
+  [[ $1 != "jruby-9.2."* ]] ||
     capture_command ./ruby gem update -q --silent --system 3.3.26 --no-document --no-post-install-message
   capture_command ./ruby gem install jruby-launcher --no-document
 }

--- a/test/build.bats
+++ b/test/build.bats
@@ -848,7 +848,6 @@ DEF
   assert_success
 
   assert_build_log <<OUT
-jruby [-e,puts JRUBY_VERSION]
 jruby [gem,install,jruby-launcher,--no-document]
 OUT
 


### PR DESCRIPTION
In case shelling out to jruby failed, the error output wouldn't get printed to stderr but ruby-build would abort.

Followup to https://github.com/rbenv/ruby-build/pull/2246

Ref. #2403