### PR TITLE
Add Ruby 3.3.4

### DIFF
--- a/share/ruby-build/3.3.4
+++ b/share/ruby-build/3.3.4
@@ -1,0 +1,2 @@
+install_package "openssl-3.1.5" "https://www.openssl.org/source/openssl-3.1.5.tar.gz#6ae015467dabf0469b139ada93319327be24b98251ffaeceda0221848dc09262" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "ruby-3.3.4" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.4.tar.gz#fe6a30f97d54e029768f2ddf4923699c416cdbc3a6e96db3e2d5716c7db96a34" enable_shared standard


### PR DESCRIPTION
This pull request adds Ruby 3.3.4 to ruby-build.

* Ruby 3.3.4 Released
https://www.ruby-lang.org/en/news/2024/07/09/ruby-3-3-4-released/

This commit works in my Ubuntu 24.04 environment as follows.

```ruby
$ more /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04 LTS"
$ ruby -v
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [x86_64-linux]
$
```