### PR TITLE
Add Ruby 3.2.5

### DIFF
--- a/share/ruby-build/3.2.5
+++ b/share/ruby-build/3.2.5
@@ -1,0 +1,2 @@
+install_package "openssl-3.0.14" "https://www.openssl.org/source/openssl-3.0.14.tar.gz#eeca035d4dd4e84fc25846d952da6297484afa0650a6f84c682e39df3a4123ca" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "ruby-3.2.5" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gz#ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16" enable_shared standard


### PR DESCRIPTION
* Ruby 3.2.5 Released
https://www.ruby-lang.org/en/news/2024/07/26/ruby-3-2-5-released/