### PR TITLE
Clear LC_ALL for tr call

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -876,7 +876,7 @@ install_jruby_launcher() {
 
 fix_jruby_shebangs() {
   for file in "${PREFIX_PATH}/bin"/*; do
-    if [ "$(head -c 20 "$file" | LC_CTYPE=C tr -d '\0')" = "#!/usr/bin/env jruby" ]; then
+    if [ "$(head -c 20 "$file" | LC_CTYPE=C LC_ALL='' tr -d '\0')" = "#!/usr/bin/env jruby" ]; then
       sed -i.bak "1 s:.*:#\!${PREFIX_PATH}\/bin\/jruby:" "$file"
       rm "$file".bak
     fi


### PR DESCRIPTION
This resolves additional issues when tr is called in a shell that has set LC_ALL to a specific encoding. In that case, the tr may fail to ignore binary files, expecting that they are in some encoding.

See https://github.com/rbenv/ruby-build/issues/2279