### PR TITLE
Auto update Ruby definition with Ruby releases

### DIFF
--- a/.github/workflows/update-ruby.yml
+++ b/.github/workflows/update-ruby.yml
@@ -1,0 +1,48 @@
+name: Update Ruby definitions
+
+on:
+  workflow_dispatch:
+    inputs:
+      ruby_version:
+          description: 'Ruby version'
+          required: true
+          default: '3.3.4'
+      openssl_version:
+            description: 'OpenSSL version'
+            required: true
+            default: '3.0.14'
+
+  repository_dispatch:
+    types: [update-ruby]
+
+jobs:
+  update-ruby:
+    name: Update Ruby definitions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Store Ruby version
+        run: echo "RUBY_VERSION=${{ github.event.client_payload.ruby_version || github.event.inputs.ruby_version }}" >> $GITHUB_ENV
+
+      - name: Store ABI version
+        run: echo "ABI_VERSION=$(echo ${{ env.RUBY_VERSION }} | cut -d '.' -f 1-2)" >> $GITHUB_ENV
+
+      - name: Store OpenSSL version
+        run: echo "OPENSSL_VERSION=${{ github.event.client_payload.openssl_version || github.event.inputs.openssl_version }}" >> $GITHUB_ENV
+
+      - name: Run script/update-cruby
+        run: |
+          curl -sL https://cache.ruby-lang.org/pub/ruby/${{ env.ABI_VERSION }}/ruby-${{ env.RUBY_VERSION }}.tar.gz
+          curl -sL https://www.openssl.org/source/openssl-${{ env.OPENSSL_VERSION }}.tar.gz
+          script/update-cruby ${{ env.RUBY_VERSION }} ${{ env.OPENSSL_VERSION }} .
+
+      - name: commit and push
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Added ${{ env.RUBY_VERSION }} with OpenSSL ${{ env.OPENSSL_VERSION }}"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/script/update-cruby
+++ b/script/update-cruby
@@ -3,16 +3,18 @@
 set -e
 set -o pipefail
 
-if [ $# -ne 2 ]; then
-  echo "usage: $0 VERSION RELEASE_DIRECTORY"
+if [ $# -ne 3 ]; then
+  echo "usage: $0 VERSION OPENSSL_VERSION RELEASE_DIRECTORY"
   exit 1
 fi
 
 version="$1"
-release_directory="$2"
+openssl_version="$2"
+release_directory="$3"
 file="share/ruby-build/${version}"
 
 basename="ruby-${version}.tar.gz"
+openssl_basename="openssl-${openssl_version}.tar.gz"
 major_minor_version=$(echo ${version} | cut -d '.' -f 1,2)
 url="https://cache.ruby-lang.org/pub/ruby/${major_minor_version}/${basename}"
 if command -v sha256sum >/dev/null; then
@@ -24,7 +26,17 @@ else
   exit 1
 fi
 
+openssl_url="https://www.openssl.org/source/openssl-${openssl_version}.tar.gz"
+if command -v sha256sum >/dev/null; then
+  openssl_sha256=$(sha256sum "$release_directory/$openssl_basename" | cut -d ' ' -f 1)
+elif command -v shasum >/dev/null; then
+  openssl_sha256=$(shasum -a 256 "$release_directory/$openssl_basename" | cut -d ' ' -f 1)
+else
+  echo "$0 requires sha256sum or shasum to be installed on the system."
+  exit 1
+fi
+
 cat > "$file" <<EOS
-!TODO! copy openssl line from other release with the same major.minor version
+install_package "openssl-${openssl_version}" "${openssl_url}#${openssl_sha256}" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-${version}" "${url}#${sha256}" enable_shared standard
 EOS


### PR DESCRIPTION
Background:

I and release manager of Ruby improve release workflow recently. I make this manual workflow to automated workflow. 

After Ruby release, https://github.com/ruby/ruby/pull/11286 notify to related repositories like docker image, snap package and etc.

I would like to create new definition of ruby-build with above notification. This PR makes it with repository_dispatch feature. After that, we can update definition with simple REST call like:

```
curl -L -X POST \
          -H "Authorization: Bearer xxx" \
          -H "Accept: application/vnd.github+json" \
          -H "X-GitHub-Api-Version: 2022-11-28" \
          https://api.github.com/repos/rbenv/ruby-build/dispatches \
          -d '{"event_type": "update-ruby", "client_payload":{"ruby_version":"3.3.4", "openssl_version":"3.0.14"}}'
```
