### PR TITLE
Allow "nonexistent version" test to work without brew

### DIFF
--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -88,11 +88,19 @@ OUT
 }
 
 @test "nonexistent version" {
+  stub_git_dir=
+  if [ ! -d "${BATS_TEST_DIRNAME}"/../.git ]; then
+    stub_git_dir="${BATS_TEST_DIRNAME}"/../.git
+    mkdir "$stub_git_dir"
+  fi
+
   stub_repeated brew false
   stub_ruby_build 'echo ERROR >&2 && exit 2' \
     "--definitions : echo 1.8.7 1.9.3-p0 1.9.3-p194 2.1.2 | tr ' ' $'\\n'"
 
   run rbenv-install 1.9.3
+  [ -z "$stub_git_dir" ] || rmdir "$stub_git_dir"
+
   assert_failure
   assert_output <<OUT
 ERROR


### PR DESCRIPTION
Currently, this test fails if Homebrew isn't present as it expects a
Homebrew-specific output. This commit varies the expected output based
on whether Homebrew is installed.

This patch was originally created for the Debian package for ruby-build:
https://salsa.debian.org/ruby-team/ruby-build/-/blob/607093e5198cc75ffa8e9a3b551843be5f2f6d93/debian/patches/0001-Fix-nonexistent-version-test-to-work-regardless-of-e.patch
