### PR TITLE
Fix `ruby-build` upgrade instructions

### DIFF
--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -126,7 +126,7 @@ See all available versions with \`rbenv install --list-all'.
 
 If the version you need is missing, try upgrading ruby-build:
 
-  brew upgrade ruby-build
+  brew install ruby-build
 OUT
 
   unstub brew


### PR DESCRIPTION
I get bit by this every time I need to upgrade Ruby. `brew upgrade` actually upgrades all installed packages, whereas `brew install ruby-build` will update a singular dependency. This PR updates those instructions so we don't get bit by this.

See https://github.com/orgs/Homebrew/discussions/3126 for more information.