### PR TITLE
Add -d, --dir option to install to <prefix>/<definition> instead of <prefix>

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Usage: ruby-build [-kpv] <definition> <prefix> [-- <configure-args...>]
+# Usage: ruby-build [-dvpk] <definition> <prefix> [-- <configure-args...>]
 #        ruby-build {--list|--definitions}
 #        ruby-build --version
 #
@@ -8,6 +8,7 @@
 #   --definitions   List all local definitions, including outdated ones
 #   --version       Show version of ruby-build
 #
+#   -d, --dir       Install the Ruby in <prefix>/<definition> instead of <prefix>
 #   -v, --verbose   Verbose mode: forward all build output to stdout/stderr
 #   -p, --patch     Apply a patch from stdin before building
 #   -k, --keep      Do not remove source tree after installation
@@ -1358,6 +1359,7 @@ unset HAS_PATCH
 unset IPV4
 unset IPV6
 unset EARLY_EXIT
+unset APPEND_DEFINITION_TO_PREFIX
 
 RUBY_BUILD_INSTALL_PREFIX="$(abs_dirname "$0")/.."
 
@@ -1377,6 +1379,9 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "l" | "list")
     EARLY_EXIT=list_maintained_versions
+    ;;
+  "d" | "dir")
+    APPEND_DEFINITION_TO_PREFIX=true
     ;;
   "k" | "keep" )
     KEEP_BUILD_PATH=true
@@ -1423,6 +1428,10 @@ fi
 
 if [ "${#EXTRA_ARGUMENTS[@]}" -gt 0 ]; then
   RUBY_CONFIGURE_OPTS_ARRAY=("${EXTRA_ARGUMENTS[@]}")
+fi
+
+if [ "$APPEND_DEFINITION_TO_PREFIX" = "true" ]; then
+  PREFIX_PATH="$PREFIX_PATH/$(basename "$DEFINITION_PATH")"
 fi
 
 case "$EARLY_EXIT" in

--- a/share/man/man1/ruby-build.1
+++ b/share/man/man1/ruby-build.1
@@ -2,12 +2,12 @@
 .\"     Title: ruby-build
 .\"    Author: Mislav Marohnić
 .\" Generator: Asciidoctor 2.0.20
-.\"      Date: 2023-11-11
+.\"      Date: 2024-09-23
 .\"    Manual: ruby-build Manual
 .\"    Source: ruby-build 20240917
 .\"  Language: English
 .\"
-.TH "RUBY\-BUILD" "1" "2023-11-11" "ruby\-build 20240917" "ruby\-build Manual"
+.TH "RUBY\-BUILD" "1" "2024-09-23" "ruby\-build 20240917" "ruby\-build Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -31,7 +31,7 @@
 ruby-build \- Download, compile, and install a version of Ruby
 .SH "SYNOPSIS"
 .sp
-ruby\-build [\-kpv] \fI<definition>\fP \fI<prefix>\fP [\-\- \fI<configure\-args>\fP...]
+ruby\-build [\-dvpk] \fI<definition>\fP \fI<prefix>\fP [\-\- \fI<configure\-args>\fP...]
 .br
 ruby\-build {\-\-list|\-\-definitions}
 .br
@@ -67,6 +67,11 @@ List all local definitions, including outdated ones
 Show version of ruby\-build
 .RE
 .sp
+\fB\-d, \-\-dir\fP
+.RS 4
+Install the Ruby in the \fIprefix/definition\fP destination instead of directly in \fIprefix\fP
+.RE
+.sp
 \fB\-v, \-\-verbose\fP
 .RS 4
 Verbose mode: forward all build output to stdout/stderr
@@ -100,6 +105,16 @@ configuration options:
 .nf
 .fam C
 $ ruby\-build 3.2.2 /opt/rubies/ruby\-3.2.2 \-\- \-\-disable\-install\-doc \-\-with\-openssl\-dir=/opt/openssl
+.fam
+.fi
+.if n .RE
+.sp
+Install Ruby version 3.3.5 under \f(CR~/.rbenv/versions\fP:
+.sp
+.if n .RS 4
+.nf
+.fam C
+$ ruby\-build \-\-dir 3.3.5 ~/.rbenv/versions
 .fam
 .fi
 .if n .RE

--- a/share/man/man1/ruby-build.1.adoc
+++ b/share/man/man1/ruby-build.1.adoc
@@ -11,7 +11,7 @@ ruby-build - Download, compile, and install a version of Ruby
 
 == Synopsis
 
-ruby-build [-kpv] _<definition>_ _<prefix>_ [-- _<configure-args>_...] +
+ruby-build [-dvpk] _<definition>_ _<prefix>_ [-- _<configure-args>_...] +
 ruby-build {--list|--definitions} +
 ruby-build --version
 
@@ -41,6 +41,9 @@ and print everything to standard streams.
 *--version*::
   Show version of ruby-build
 
+*-d, --dir*::
+  Install the Ruby in the _prefix/definition_ destination instead of directly in _prefix_
+
 *-v, --verbose*::
   Verbose mode: forward all build output to stdout/stderr
 
@@ -62,6 +65,11 @@ Install Ruby version 3.2.2 under `/opt/rubies` while tweaking some
 configuration options:
 ----
 $ ruby-build 3.2.2 /opt/rubies/ruby-3.2.2 -- --disable-install-doc --with-openssl-dir=/opt/openssl
+----
+
+Install Ruby version 3.3.5 under `~/.rbenv/versions`:
+----
+$ ruby-build --dir 3.3.5 ~/.rbenv/versions
 ----
 
 Usage as rbenv plugin:

--- a/test/build.bats
+++ b/test/build.bats
@@ -620,6 +620,15 @@ make install --globalmake RUBYMAKE=true with spaces
 OUT
 }
 
+@test "nested install destination" {
+  export RUBY_BUILD_CACHE_PATH="$FIXTURE_ROOT"
+
+  run ruby-build -d "$FIXTURE_ROOT"/definitions/without-checksum "$INSTALL_ROOT"
+  assert_success
+  refute [ -d "$INSTALL_ROOT"/bin ]
+  assert [ -x "$INSTALL_ROOT"/without-checksum/bin/package ]
+}
+
 @test "custom relative install destination" {
   export RUBY_BUILD_CACHE_PATH="$FIXTURE_ROOT"
 


### PR DESCRIPTION
* Similar to ruby-install's -r, --rubies-dir flag.

So this enables for example:
```
$ ruby-build -d truffleruby+graalvm-24.1.0 ~/.rubies
...
==> Installed truffleruby+graalvm-24.1.0 to /home/eregon/.rubies/truffleruby+graalvm-24.1.0
```

Which I find quite convenient compared to having to copy-paste the definition names after the rubies directory.