### PR TITLE
Support `ruby-build ruby-X.Y.Z DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ PREFIX=/usr/local ./ruby-build-*/install.sh
 # As a standalone program
 $ ruby-build --list                        # lists available versions of Ruby
 $ ruby-build 3.2.2 /opt/rubies/ruby-3.2.2  # installs Ruby 3.2.2
+$ ruby-build -d ruby-3.2.2 /opt/rubies     # alternate form for the previous example
 
 # As an rbenv plugin
 $ rbenv install 3.2.2  # installs Ruby 3.2.2 to ~/.rbenv/versions/3.2.2

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1456,6 +1456,17 @@ if [ ! -f "$DEFINITION_PATH" ]; then
     fi
   done
 
+  # If the given definition is like ruby-X.Y.Z, search again with X.Y.Z
+  if [[ "$DEFINITION_PATH" =~ ^ruby-[0-9] ]]; then
+    DEFINITION_PATH="${DEFINITION_PATH#ruby-}"
+    for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
+      if [ -f "${DEFINITION_DIR}/${DEFINITION_PATH}" ]; then
+        DEFINITION_PATH="${DEFINITION_DIR}/${DEFINITION_PATH}"
+        break
+      fi
+    done
+  fi
+
   if [ ! -f "$DEFINITION_PATH" ]; then
     echo "ruby-build: definition not found: ${DEFINITION_PATH}" >&2
     exit 2

--- a/share/man/man1/ruby-build.1
+++ b/share/man/man1/ruby-build.1
@@ -41,6 +41,9 @@ ruby\-build \-\-version
 ruby\-build downloads, compiles, and installs a Ruby version named by the
 \fIdefinition\fP argument into the location specified by \fIprefix\fP.
 .sp
+The \fIdefinition\fP argument can optionally start with "ruby\-", in which case
+it resolves to a CRuby that matches the version number that follows.
+.sp
 The \fIdefinition\fP argument can be a path to a file on disk, in which case
 it is sourced into ruby\-build as a bash script.
 .sp
@@ -98,18 +101,27 @@ Resolve names to IPv6 addresses only
 .RE
 .SH "EXAMPLES"
 .sp
-Install Ruby version 3.2.2 under \f(CR/opt/rubies\fP while tweaking some
-configuration options:
+Install a Ruby version while tweaking some configuration options:
 .sp
 .if n .RS 4
 .nf
 .fam C
-$ ruby\-build 3.2.2 /opt/rubies/ruby\-3.2.2 \-\- \-\-disable\-install\-doc \-\-with\-openssl\-dir=/opt/openssl
+$ ruby\-build 3.2.2 /path/to/destination \-\- \-\-disable\-install\-doc \-\-with\-openssl\-dir=/opt/openssl
 .fam
 .fi
 .if n .RE
 .sp
-Install Ruby version 3.3.5 under \f(CR~/.rbenv/versions\fP:
+Install a Ruby version to \f(CR~/.rubies/ruby\-3.2.2\fP:
+.sp
+.if n .RS 4
+.nf
+.fam C
+$ ruby\-build \-\-dir ruby\-3.2.2 ~/.rubies
+.fam
+.fi
+.if n .RE
+.sp
+Install a Ruby version to \f(CR~/.rbenv/versions/3.3.5\fP:
 .sp
 .if n .RS 4
 .nf
@@ -119,12 +131,12 @@ $ ruby\-build \-\-dir 3.3.5 ~/.rbenv/versions
 .fi
 .if n .RE
 .sp
-Usage as rbenv plugin:
+Usage as rbenv plugin, accomplishes the same as the previous example:
 .sp
 .if n .RS 4
 .nf
 .fam C
-$ rbenv install 3.2.2
+$ rbenv install 3.3.5
 .fam
 .fi
 .if n .RE

--- a/share/man/man1/ruby-build.1.adoc
+++ b/share/man/man1/ruby-build.1.adoc
@@ -20,6 +20,9 @@ ruby-build --version
 ruby-build downloads, compiles, and installs a Ruby version named by the
 _definition_ argument into the location specified by _prefix_.
 
+The _definition_ argument can optionally start with "ruby-", in which case
+it resolves to a CRuby that matches the version number that follows.
+
 The _definition_ argument can be a path to a file on disk, in which case
 it is sourced into ruby-build as a bash script.
 
@@ -61,20 +64,24 @@ and print everything to standard streams.
 
 == Examples
 
-Install Ruby version 3.2.2 under `/opt/rubies` while tweaking some
-configuration options:
+Install a Ruby version while tweaking some configuration options:
 ----
-$ ruby-build 3.2.2 /opt/rubies/ruby-3.2.2 -- --disable-install-doc --with-openssl-dir=/opt/openssl
+$ ruby-build 3.2.2 /path/to/destination -- --disable-install-doc --with-openssl-dir=/opt/openssl
 ----
 
-Install Ruby version 3.3.5 under `~/.rbenv/versions`:
+Install a Ruby version to `~/.rubies/ruby-3.2.2`:
+----
+$ ruby-build --dir ruby-3.2.2 ~/.rubies
+----
+
+Install a Ruby version to `~/.rbenv/versions/3.3.5`:
 ----
 $ ruby-build --dir 3.3.5 ~/.rbenv/versions
 ----
 
-Usage as rbenv plugin:
+Usage as rbenv plugin, accomplishes the same as the previous example:
 ----
-$ rbenv install 3.2.2
+$ rbenv install 3.3.5
 ----
 
 == Environment Variables

--- a/test/build.bats
+++ b/test/build.bats
@@ -629,6 +629,30 @@ OUT
   assert [ -x "$INSTALL_ROOT"/without-checksum/bin/package ]
 }
 
+@test "nested install destination with ruby prefix" {
+  cached_tarball "ruby-3.2.0" configure
+
+  stub_repeated brew false
+  stub_make_install
+
+  mkdir -p "$TMP"/definitions
+  cat > "$TMP"/definitions/3.2.0 <<DEF
+install_package "ruby-3.2.0" "http://ruby-lang.org/ruby/2.0/ruby-3.2.0.tar.gz"
+DEF
+
+  RUBY_BUILD_DEFINITIONS="$TMP"/definitions run ruby-build --dir ruby-3.2.0 "$INSTALL_ROOT"
+  assert_success
+
+  unstub brew
+  unstub make
+
+  assert_build_log <<OUT
+ruby-3.2.0: [--prefix=$INSTALL_ROOT/ruby-3.2.0,--with-ext=openssl,psych,+]
+make -j 2
+make install
+OUT
+}
+
 @test "custom relative install destination" {
   export RUBY_BUILD_CACHE_PATH="$FIXTURE_ROOT"
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -653,6 +653,19 @@ make install
 OUT
 }
 
+@test "definition file with ruby prefix" {
+  export RUBY_BUILD_CACHE_PATH="$FIXTURE_ROOT"
+
+  cd "$TMP"
+  cat > ruby-123-internal <<DEF
+install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz" copy
+DEF
+
+  run ruby-build ruby-123-internal "$INSTALL_ROOT"
+  assert_success
+  assert [ -x "$INSTALL_ROOT"/bin/package ]
+}
+
 @test "custom relative install destination" {
   export RUBY_BUILD_CACHE_PATH="$FIXTURE_ROOT"
 


### PR DESCRIPTION
* By searching a X.Y.Z definition if no ruby-X.Y.Z definition is not found.

So this enables for example:
```
$ ruby-build ruby-3.3.5 PREFIX
```

And with https://github.com/rbenv/ruby-build/pull/2447 it enables:
```
$ ruby-build -d ruby-3.3.4 ~/.rubies
...
==> Installed ruby-3.3.4 to /home/eregon/.rubies/ruby-3.3.4
```

It would remove the need for https://github.com/ruby/ruby-builder/blob/135bc7c215df24a672d0735189aafc510923d380/.github/workflows/build.yml#L67-L74 and likely other places working around the "asymmetry" that CRuby definitions don't have a prefix.