### PR TITLE
Use --enable-shared for dev builds too, not only for releases

### DIFF
--- a/share/ruby-build/2.4-dev
+++ b/share/ruby-build/2.4-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.4-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol autoconf standard_install_with_bundled_gems
+install_git "ruby-2.4-dev" "https://github.com/ruby/ruby.git" "ruby_2_4" warn_eol autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/2.5-dev
+++ b/share/ruby-build/2.5-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.5-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol autoconf standard_install_with_bundled_gems
+install_git "ruby-2.5-dev" "https://github.com/ruby/ruby.git" "ruby_2_5" warn_eol autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/2.6-dev
+++ b/share/ruby-build/2.6-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.6-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" autoconf standard_install_with_bundled_gems
+install_git "ruby-2.6-dev" "https://github.com/ruby/ruby.git" "ruby_2_6" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/2.7-dev
+++ b/share/ruby-build/2.7-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-2.7-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" autoconf standard_install_with_bundled_gems
+install_git "ruby-2.7-dev" "https://github.com/ruby/ruby.git" "ruby_2_7" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.0-dev
+++ b/share/ruby-build/3.0-dev
@@ -1,2 +1,2 @@
 install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz#cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" openssl --if needs_openssl:1.0.1-1.x.x
-install_git "ruby-3.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_0" autoconf standard_install_with_bundled_gems
+install_git "ruby-3.0-dev" "https://github.com/ruby/ruby.git" "ruby_3_0" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.1-dev
+++ b/share/ruby-build/3.1-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.1-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf standard_install_with_bundled_gems
+install_git "ruby-3.1-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.2-dev
+++ b/share/ruby-build/3.2-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.2-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf standard_install_with_bundled_gems
+install_git "ruby-3.2-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.3-dev
+++ b/share/ruby-build/3.3-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.3-dev" "https://github.com/ruby/ruby.git" "ruby_3_3" autoconf standard_install_with_bundled_gems
+install_git "ruby-3.3-dev" "https://github.com/ruby/ruby.git" "ruby_3_3" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.4-dev
+++ b/share/ruby-build/3.4-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_install_with_bundled_gems
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/ruby-dev
+++ b/share/ruby-build/ruby-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf standard_install_with_bundled_gems
+install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf enable_shared standard_install_with_bundled_gems

--- a/test/build.bats
+++ b/test/build.bats
@@ -750,7 +750,7 @@ OUT
   stub_make_install "update-gems"
 
   run_inline_definition <<DEF
-install_package "ruby-3.2.0" "http://ruby-lang.org/ruby/3.0/ruby-3.2.0.tar.gz" autoconf standard_install_with_bundled_gems
+install_package "ruby-3.2.0" "http://ruby-lang.org/ruby/3.0/ruby-3.2.0.tar.gz" autoconf enable_shared standard_install_with_bundled_gems
 DEF
   assert_success
 
@@ -761,7 +761,7 @@ DEF
 
   assert_build_log <<OUT
 autoreconf -i
-ruby-3.2.0: [--prefix=$INSTALL_ROOT,--with-ext=openssl,psych,+]
+ruby-3.2.0: [--prefix=${TMP}/install,--enable-shared,--with-ext=openssl,psych,+]
 make -j 2
 make update-gems extract-gems install
 OUT


### PR DESCRIPTION
* Only from Ruby 2.4+ since older releases don't use --enable-shared by default.
* As with releases it can be disabled by setting RUBY_CONFIGURE_OPTS=--disable-shared.

But since `--enable-shared` is currently broken on master we should wait https://bugs.ruby-lang.org/issues/20783 to be fixed before merging this.