### PR TITLE
Fix linking to vendored OpenSSL on 64-bit systems

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1209,20 +1209,20 @@ build_package_openssl() {
   # Tell Ruby to use this openssl for its extension.
   package_option ruby configure --with-openssl-dir="$OPENSSL_PREFIX_PATH"
 
-  # Make sure pkg-config finds our build first.
-  export PKG_CONFIG_PATH="${OPENSSL_PREFIX_PATH}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-
   local nokerberos
   [[ "$1" != openssl-1.0.* ]] || nokerberos=1
 
   # Compile a shared lib with zlib dynamically linked.
-  package_option openssl configure --openssldir="$OPENSSLDIR" zlib-dynamic no-ssl3 shared ${nokerberos:+no-ssl2 no-krb5}
+  package_option openssl configure --openssldir="$OPENSSLDIR" --libdir="lib" zlib-dynamic no-ssl3 shared ${nokerberos:+no-ssl2 no-krb5}
 
   # Skip building OpenSSL docs, which is slow.
   local make_target="install_sw install_ssldirs"
   [[ "$1" != openssl-1.0.* ]] || make_target="install_sw" # OpenSSL 1.0 does not have `install_ssldirs`
 
   OPENSSL_CONFIGURE="${OPENSSL_CONFIGURE:-./config}" MAKE_INSTALL_TARGET="$make_target" build_package_standard "$@"
+
+  # Make sure pkg-config finds the new OpenSSL installation.
+  export PKG_CONFIG_PATH="${OPENSSL_PREFIX_PATH}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 
   local pem_file="$OPENSSLDIR/cert.pem"
   if is_mac; then

--- a/test/build.bats
+++ b/test/build.bats
@@ -397,8 +397,8 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,zlib-dynamic,no-ssl3,shared] PKG_CONFIG_PATH=${TMP}/install/openssl/lib/pkgconfig
-PKG_CONFIG_PATH=${TMP}/install/openssl/lib/pkgconfig make -j 2
+openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,--libdir=lib,zlib-dynamic,no-ssl3,shared]
+make -j 2
 make install_sw install_ssldirs
 ruby-3.2.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=$INSTALL_ROOT/openssl,--with-ext=openssl,psych,+] PKG_CONFIG_PATH=${TMP}/install/openssl/lib/pkgconfig
 PKG_CONFIG_PATH=${TMP}/install/openssl/lib/pkgconfig make -j 2


### PR DESCRIPTION
On 64-bit systems, the build system for OpenSSL tends to produce a "lib64" directory instead of a "lib" directory due to its "multilib" feature being enabled by default. However, the Ruby "openssl" extension assumes that the directory is always named "lib", or explicitly passed via `--with-openssl-lib`.

This disables multilib support in OpenSSL by passing `--libdir=lib` to OpenSSL configure step.

Reported in https://github.com/rbenv/ruby-build/discussions/2376