### PR TITLE
Avoid array subscript error when checking OpenSSL versions

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1154,7 +1154,7 @@ needs_openssl() {
   # shellcheck disable=SC2207
   versions=( $(awk '{print $2}' <<<"$brew_installs" | sort_versions) )
   local index="${#versions[@]}"
-  while [ $((index--)) -ge 0 ]; do
+  while [ $((--index)) -ge 0 ]; do
     homebrew_version="$(normalize_semver "${versions[index]}")"
     (( homebrew_version >= lower_bound && homebrew_version < upper_bound )) || continue
     while read -r formula version prefix; do


### PR DESCRIPTION
If none of Homebrew OpenSSL versions satisfy the `needs_openssl` requirement, array iteration will reach `index=-1` and that will raise a non-fatal error when accessing the `versions` array. This makes sure not to go past index=0.

Fixes https://github.com/rbenv/ruby-build/issues/2455