### PR TITLE
Allow named pipes as build definition argument

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1431,6 +1431,10 @@ if [ "${#EXTRA_ARGUMENTS[@]}" -gt 0 ]; then
 fi
 
 if [ "$APPEND_DEFINITION_TO_PREFIX" = "true" ]; then
+  if [ -p "$DEFINITION_PATH" ]; then
+    echo "ruby-build: using named pipes in combination with \`--dir' is not possible" >&2
+    EARLY_EXIT=usage_error
+  fi
   PREFIX_PATH="$PREFIX_PATH/$(basename "$DEFINITION_PATH")"
 fi
 
@@ -1457,7 +1461,7 @@ usage_error )
 esac
 
 # expand the <definition> argument to full path of the definition file
-if [ ! -f "$DEFINITION_PATH" ]; then
+if [[ ! -f "$DEFINITION_PATH" && ! -p "$DEFINITION_PATH" ]]; then
   for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
     if [ -f "${DEFINITION_DIR}/${DEFINITION_PATH}" ]; then
       DEFINITION_PATH="${DEFINITION_DIR}/${DEFINITION_PATH}"


### PR DESCRIPTION
Allow ruby-build to read a build definition from a named pipe in addition to just from regular files.

Example:
```
ruby-build <(echo "...") /path/to/ruby
```