### PR TITLE
Suggest to install rubies in a user-writable directory in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ PREFIX=/usr/local ./ruby-build-*/install.sh
 # As a standalone program
 $ ruby-build --list                        # lists latest stable releases for each Ruby
 $ ruby-build --definitions                 # lists all definitions, including outdated ones
-$ ruby-build 3.2.2 /opt/rubies/ruby-3.2.2  # installs Ruby 3.2.2
-$ ruby-build -d ruby-3.2.2 /opt/rubies     # alternate form for the previous example
+$ ruby-build 3.2.2 ~/.rubies/ruby-3.2.2    # installs Ruby 3.2.2
+$ ruby-build -d ruby-3.2.2 ~/.rubies       # alternate form for the previous example
 
 # As an rbenv plugin
 $ rbenv install 3.2.2  # installs Ruby 3.2.2 to ~/.rbenv/versions/3.2.2


### PR DESCRIPTION
Otherwise `gem install` and `bundle install` (without `--path`) won't work without `sudo`. In fact the previous example install command wouldn't work at all without `sudo`.