### PR TITLE
Add an environment variable to always build openssl/libssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The build process may be configured through the following environment variables:
 | `RUBY_BUILD_TARBALL_OVERRIDE`   | Override the URL to fetch the ruby tarball from, optionally followed by `#checksum`.             |
 | `RUBY_BUILD_DEFINITIONS`        | Colon-separated list of paths to search for build definition files.                              |
 | `RUBY_BUILD_ROOT`               | The path prefix to search for build definitions files. *Deprecated:* use `RUBY_BUILD_DEFINITIONS`|
+| `RUBY_BUILD_VENDOR_OPENSSL`     | Build and vendor openssl even if the system openssl is compatible                                |
 | `CC`                            | Path to the C compiler.                                                                          |
 | `RUBY_CFLAGS`                   | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |
 | `CONFIGURE_OPTS`                | Additional `./configure` options.                                                                |

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1122,6 +1122,8 @@ normalize_semver() {
 # If a compatible Homebrew-installed OpenSSL version is found during
 # checking, Ruby will be linked to it and the check will return false.
 needs_openssl() {
+  [ -z "$RUBY_BUILD_VENDOR_OPENSSL" ] || return 0
+
   [[ "$RUBY_CONFIGURE_OPTS ${RUBY_CONFIGURE_OPTS_ARRAY[*]}" != *--with-openssl-dir=* ]] || return 1
 
   local system_version


### PR DESCRIPTION
* This is useful when one wants to avoid depending e.g. on which openssl version is installed in Homebrew, notably for https://github.com/ruby/setup-ruby/issues/668