### PR TITLE
Warn that Ruby 3.1 support ends in less than 6 months

### DIFF
--- a/share/ruby-build/3.1.0
+++ b/share/ruby-build/3.1.0
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" enable_shared standard
+install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.0-preview1
+++ b/share/ruby-build/3.1.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" enable_shared standard
+install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.1
+++ b/share/ruby-build/3.1.1
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" enable_shared standard
+install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.2
+++ b/share/ruby-build/3.1.2
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" enable_shared standard
+install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.3
+++ b/share/ruby-build/3.1.3
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" enable_shared standard
+install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.4
+++ b/share/ruby-build/3.1.4
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" enable_shared standard
+install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.5
+++ b/share/ruby-build/3.1.5
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.5" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.gz#3685c51eeee1352c31ea039706d71976f53d00ab6d77312de6aa1abaf5cda2c5" enable_shared standard
+install_package "ruby-3.1.5" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.gz#3685c51eeee1352c31ea039706d71976f53d00ab6d77312de6aa1abaf5cda2c5" warn_unsupported enable_shared standard

--- a/share/ruby-build/3.1.6
+++ b/share/ruby-build/3.1.6
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz#0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" enable_shared standard
+install_package "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz#0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" warn_unsupported enable_shared standard


### PR DESCRIPTION
Generated with `script/update-eol`