### PR TITLE
Add `-f` flag to curl for HTTP error handling

### DIFF
--- a/.github/workflows/update-ruby.yml
+++ b/.github/workflows/update-ruby.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Run script/update-cruby
         run: |
-          curl -sL https://cache.ruby-lang.org/pub/ruby/${{ env.ABI_VERSION }}/ruby-${{ env.RUBY_VERSION }}.tar.gz -O
-          curl -sL https://www.openssl.org/source/openssl-${{ env.OPENSSL_VERSION }}.tar.gz -O
+          curl -fsL https://cache.ruby-lang.org/pub/ruby/${{ env.ABI_VERSION }}/ruby-${{ env.RUBY_VERSION }}.tar.gz -O
+          curl -fsL https://www.openssl.org/source/openssl-${{ env.OPENSSL_VERSION }}.tar.gz -O
           script/update-cruby ${{ env.RUBY_VERSION }} ${{ env.OPENSSL_VERSION }} .
           rm *.gz
 


### PR DESCRIPTION
Ensures that the command fails when an HTTP error (e.g., 404) occurs.
