### PR TITLE
Fix library lookup path in the vendored OpenSSL

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1215,7 +1215,7 @@ build_package_openssl() {
   [[ "$1" != openssl-1.0.* ]] || nokerberos=1
 
   # Compile a shared lib with zlib dynamically linked.
-  package_option openssl configure --openssldir="$OPENSSLDIR" --libdir="lib" zlib-dynamic no-ssl3 shared ${nokerberos:+no-ssl2 no-krb5}
+  package_option openssl configure --openssldir="$OPENSSLDIR" --libdir="lib" -Wl,-rpath="$OPENSSL_PREFIX_PATH/lib" zlib-dynamic no-ssl3 shared ${nokerberos:+no-ssl2 no-krb5}
 
   # Skip building OpenSSL docs, which is slow.
   local make_target="install_sw install_ssldirs"

--- a/test/build.bats
+++ b/test/build.bats
@@ -397,7 +397,7 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,--libdir=lib,zlib-dynamic,no-ssl3,shared]
+openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,--libdir=lib,-Wl,-rpath=${INSTALL_ROOT}/openssl/lib,zlib-dynamic,no-ssl3,shared]
 make -j 2
 make install_sw install_ssldirs
 ruby-3.2.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=$INSTALL_ROOT/openssl,--with-ext=openssl,psych,+] PKG_CONFIG_PATH=${TMP}/install/openssl/lib/pkgconfig


### PR DESCRIPTION
When a vendored OpenSSL is needed for compiling Ruby, that OpenSSL installation ends up with its `bin/openssl` executable broken due to not finding "libssl.so" and "libcrypto.so" in the global load path for libraries. This doesn't seem to negatively affect the Ruby "openssl" extension at runtime, but does constitute a broken OpenSSL installation nevertheless.

This change causes the `bin/openssl` executable and related shared libraries to be built with an "RPATH" pointing to the "lib" directory of the vendored OpenSSL. See https://wiki.openssl.org/index.php/Compilation_and_Installation#Using_RPATHs

Fixes #2488 