### PR TITLE
Fix installing OpenSSL on non-Linux or with clang

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1211,11 +1211,21 @@ build_package_openssl() {
   # Tell Ruby to use this openssl for its extension.
   package_option ruby configure --with-openssl-dir="$OPENSSL_PREFIX_PATH"
 
-  local nokerberos
-  [[ "$1" != openssl-1.0.* ]] || nokerberos=1
-
   # Compile a shared lib with zlib dynamically linked.
-  package_option openssl configure --openssldir="$OPENSSLDIR" --libdir="lib" -Wl,-rpath="$OPENSSL_PREFIX_PATH/lib" zlib-dynamic no-ssl3 shared ${nokerberos:+no-ssl2 no-krb5}
+  package_option openssl configure --openssldir="$OPENSSLDIR" --libdir="lib" zlib-dynamic no-ssl3 shared
+
+  # Help OpenSSL find its own shared libraries on Linux.
+  if [ "$(uname -s)" = "Linux" ]; then
+    # shellcheck disable=SC2031
+    if [ "$CC" = "clang" ] || "${CC:-cc}" --version 2>&1 | grep -wq clang; then
+      package_option openssl configure -Wl,-rpath,"$OPENSSL_PREFIX_PATH/lib"
+    else
+      package_option openssl configure -Wl,-rpath="$OPENSSL_PREFIX_PATH/lib"
+    fi
+  fi
+
+  # Disable SSLv2 and Kerberos on older OpenSSL
+  [[ "$1" != openssl-1.0.* ]] || package_option openssl configure no-ssl2 no-krb5
 
   # Skip building OpenSSL docs, which is slow.
   local make_target="install_sw install_ssldirs"

--- a/test/build.bats
+++ b/test/build.bats
@@ -378,7 +378,9 @@ OUT
 
   stub_repeated uname '-s : echo Linux'
   stub_repeated brew false
-  stub cc '-xc -E - : echo "OpenSSL 1.0.1a  1 Aug 2023"'
+  stub cc \
+    '-xc -E - : echo "OpenSSL 1.0.1a  1 Aug 2023"' \
+    '--version : echo gcc'
   stub openssl "version -d : echo 'OPENSSLDIR: \"${TMP}/ssl\"'"
   stub_make_install "install_sw"
   stub_make_install
@@ -397,12 +399,41 @@ DEF
   unstub make
 
   assert_build_log <<OUT
-openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,--libdir=lib,-Wl,-rpath=${INSTALL_ROOT}/openssl/lib,zlib-dynamic,no-ssl3,shared]
+openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,--libdir=lib,zlib-dynamic,no-ssl3,shared,-Wl,-rpath=${INSTALL_ROOT}/openssl/lib]
 make -j 2
 make install_sw install_ssldirs
 ruby-3.2.0: [--prefix=$INSTALL_ROOT,--with-openssl-dir=$INSTALL_ROOT/openssl,--with-ext=openssl,psych,+] PKG_CONFIG_PATH=${TMP}/install/openssl/lib/pkgconfig
 PKG_CONFIG_PATH=${TMP}/install/openssl/lib/pkgconfig make -j 2
 make install
+OUT
+}
+
+@test "install OpenSSL with clang" {
+  cached_tarball "openssl-1.1.1w" config
+
+  mkdir -p "${TMP}/ssl/certs"
+  touch "${TMP}/ssl/cert.pem"
+
+  stub_repeated uname '-s : echo Linux'
+  stub cc '--version : echo "Hello clang 1.2.3"'
+  stub openssl "version -d : echo 'OPENSSLDIR: \"${TMP}/ssl\"'"
+  stub_make_install "install_sw"
+
+  mkdir -p "$INSTALL_ROOT"/openssl/ssl # OPENSSLDIR
+  run_inline_definition <<DEF
+install_package "openssl-1.1.1w" "https://www.openssl.org/source/openssl-1.1.1w.tar.gz" openssl
+DEF
+  assert_success
+
+  unstub uname
+  unstub cc
+  # unstub openssl
+  unstub make
+
+  assert_build_log <<OUT
+openssl-1.1.1w: [--prefix=${INSTALL_ROOT}/openssl,--openssldir=${INSTALL_ROOT}/openssl/ssl,--libdir=lib,zlib-dynamic,no-ssl3,shared,-Wl,-rpath,${INSTALL_ROOT}/openssl/lib]
+make -j 2
+make install_sw install_ssldirs
 OUT
 }
 


### PR DESCRIPTION
The recent rpath argument addition broke compilation of OpenSSL with clang since it seems expect this syntax (comma instead of "="):

    -Wl,-rpath,<path>

Also, it doesn't seem that the rpath argument is necessary for any platform other than "Linux"; that is, we should skip passing it on BSD and macOS.

Thanks @jeremy https://github.com/rbenv/ruby-build/pull/2493#pullrequestreview-2550800730