### PR TITLE
Improve test output for failed stubs

### DIFF
--- a/test/stubs/stub
+++ b/test/stubs/stub
@@ -14,8 +14,8 @@ _STUB_RESULT="${PROGRAM}_STUB_RESULT"
 _STUB_END="${PROGRAM}_STUB_END"
 _STUB_DEBUG="${PROGRAM}_STUB_DEBUG"
 
-if [ -n "${!_STUB_DEBUG}" ]; then
-  echo "$program" "$@" >&${!_STUB_DEBUG}
+if [ -n "${!_STUB_DEBUG}" ] && [ -z "${!_STUB_END}" ]; then
+  echo stub: "$program" "$@" >&${!_STUB_DEBUG}
 fi
 
 [ -e "${!_STUB_PLAN}" ] || exit 1
@@ -25,9 +25,11 @@ fi
 # Initialize or load the stub run information.
 eval "${_STUB_INDEX}"=1
 eval "${_STUB_RESULT}"=0
+# shellcheck disable=SC1090
 [ ! -e "${!_STUB_RUN}" ] || source "${!_STUB_RUN}"
 
 # Expose this for stub scripts.
+# shellcheck disable=SC2317
 inspect_args() {
   local arg
   local sep=''
@@ -101,9 +103,11 @@ if [ -n "${!_STUB_END}" ]; then
   # Clean up the run file.
   rm -f "${!_STUB_RUN}"
 
+  stub_index_value="${!_STUB_INDEX}"
   # If the number of lines in the plan is larger than
   # the requested index, we failed.
-  if [ $index -ge "${!_STUB_INDEX}" ]; then
+  if [ "$index" -ge "$stub_index_value" ]; then
+    echo "$program: expected $index invocations, got $((stub_index_value-1))" >&2
     eval "${_STUB_RESULT}"=1
   fi
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -66,8 +66,16 @@ unstub() {
 
   export "${prefix}_STUB_END"=1
 
+  local stub_was_invoked=
+  [ -e "${TMP}/${program}-stub-run" ] && stub_was_invoked=1
+
   local STATUS=0
   "$path" || STATUS="$?"
+
+  local debug_var="${prefix}_STUB_DEBUG"
+  if [ $STATUS -ne 0 ] && [ -z "${!debug_var}" ] && [ -n "$stub_was_invoked" ]; then
+    echo "unstub $program: re-run test with ${debug_var}=3 to log \`$program' invocations" >&2
+  fi
 
   rm -f "$path"
   rm -f "${TMP}/${program}-stub-plan" "${TMP}/${program}-stub-run"


### PR DESCRIPTION
The `stub`/`unstub` test helpers are unfortunately opaque as both are undocumented, and when stubbing fails for some reason, determining why is left as a guessing/debugging exercise. This was a time-sink for myself on many an occasion.

This improves the `unstub <PROGRAM>` helper output with the following features:

- If the number of PROGRAM invocations was fewer than the number of stubbed (i.e. expected) arguments, it now prints `expected X invocations, got Y` to stderr;

- If PROGRAM got invoked but `unstub PROGRAM` still failed, it was likely that some of the invocations didn't match the stubbed ones. However, the human reading the test output has no insight into which invocations actually happened. The unstub helper now prints:

      re-run test with <PROGRAM>_STUB_DEBUG=3 to log `<PROGRAM>' invocations

  This "debug" mode already existed, but is off by default, and could previously only be discovered by someone who read the `stub` implementation code. After following the new suggestion, actual invocations of PROGRAM and all its arguments will be printed to stderr during the test run, hopefully making it clearer for the human debugging the test.