### PR TITLE
rbenv install: fix substituting $HOME with "~"

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -250,8 +250,10 @@ if [ "$STATUS" == "2" ]; then
       printf ":\n\n"
       echo "  brew upgrade ruby-build"
     elif [ -d "${here}/.git" ]; then
+      display_here="$here"
+      [[ -z "${HOME%/}" || $here != "${HOME}/"* ]] || display_here="~${here#"$HOME"}"
       printf ":\n\n"
-      echo "  git -C ${here/${HOME}\//~/} pull"
+      echo "  git -C $display_here pull"
     else
       printf ".\n"
     fi

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -89,8 +89,8 @@ OUT
 
 @test "nonexistent version" {
   display_here="${BATS_TEST_DIRNAME}"/..
-  if [[ -n $HOME && "$display_here" == "${HOME%/}/"* ]]; then
-    display_here="~${display_here#"${HOME%/}"}"
+  if [[ -n $HOME && $display_here == "${HOME}/"* ]]; then
+    display_here="~${display_here#"${HOME}"}"
   fi
 
   stub_git_dir=

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -88,6 +88,11 @@ OUT
 }
 
 @test "nonexistent version" {
+  display_here="${BATS_TEST_DIRNAME}"/..
+  if [[ -n $HOME && "$display_here" == "${HOME%/}/"* ]]; then
+    display_here="~${display_here#"${HOME%/}"}"
+  fi
+
   stub_repeated brew false
   stub_ruby_build 'echo ERROR >&2 && exit 2' \
     "--definitions : echo 1.8.7 1.9.3-p0 1.9.3-p194 2.1.2 | tr ' ' $'\\n'"
@@ -105,7 +110,7 @@ See all available versions with \`rbenv install --list-all'.
 
 If the version you need is missing, try upgrading ruby-build:
 
-  git -C ${BATS_TEST_DIRNAME/$HOME\//~/}/.. pull
+  git -C $display_here pull
 OUT
 
   unstub brew


### PR DESCRIPTION
Depending on bash version, the expression `${var/$HOME\//~/}` will not have effect because the "~" character in the replacement expression is expanded.

The updated approach is a bit of a mouthful, but it avoids using "~" in a substitution pattern, while also guarding against values of HOME that are blank or when HOME is literally just "/".