### PR TITLE
compute_sha2: drop support for OS X Leopard

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -313,9 +313,7 @@ compute_sha2() {
     output="$(shasum -a 256 -b)" || return 1
     echo "${output% *}"
   elif type openssl &>/dev/null; then
-    local openssl
-    openssl="$(command -v "$(brew --prefix openssl 2>/dev/null || true)"/bin/openssl openssl | head -1)"
-    output="$("$openssl" dgst -sha256 2>/dev/null)" || return 1
+    output="$(openssl dgst -sha256 2>/dev/null)" || return 1
     echo "${output##* }"
   elif type sha256sum &>/dev/null; then
     output="$(sha256sum -b)" || return 1


### PR DESCRIPTION
When computing the SHA-2 checksum, `openssl dgst` is a potential candidate if openssl was found in PATH. Previously, openssl from Homebrew would also get explicitly added to the candidates list because, historically, Homebrew did not link it to PATH, OS X Leopard did not have `shasum`, and `/usr/bin/openssl` could not calculate sha256 checksums.

This drops support for OS X Leopard, which last had an update 15 years ago.

Ref. b396ad7cd13cc02015a006326837fbfe279e174c