### PR TITLE
Don't delete jruby.sh

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -935,7 +935,7 @@ build_package_artichoke() {
 remove_windows_files() {
   # shellcheck disable=SC2164
   cd "$PREFIX_PATH"
-  rm -f bin/*.exe bin/*.dll bin/*.bat bin/jruby.sh
+  rm -f bin/*.exe bin/*.dll bin/*.bat
 }
 
 clean_prefix_path_truffleruby() {


### PR DESCRIPTION
I'm not sure why this file was being deleted but this code dates way back! Unfortunately deleting this interferes with a new version of the native JRuby launcher we want to release which is dependent on the shell script being present. This PR removes jruby.sh from the `remove_windows_files` function so it can be used by the new launcher.

See https://github.com/jruby/jruby-launcher/pull/48#issuecomment-2772272290