### PR TITLE
Honor `$JAVA_HOME` in `require_java`

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -970,7 +970,11 @@ after_install_package() {
 require_java() {
   local required="$1"
   local java_version version_string
-  java_version="$(java -version 2>&1 || true)"
+  if [ -n "$JAVA_HOME" ]; then
+    java_version="$("$JAVA_HOME/bin/java" -version 2>&1 || true)"
+  else
+    java_version="$(java -version 2>&1 || true)"
+  fi
   version_string="$(grep 'java version' <<<"$java_version" | head -1 | grep -o '[0-9.]\+' | head -1 || true)"
   [ -n "$version_string" ] || version_string="$(grep 'openjdk version' <<<"$java_version" | head -1 | grep -o '[0-9.]\+' | head -1 || true)"
   IFS="."

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,6 +1,7 @@
 export TMP="$BATS_TMPDIR"/ruby-build-test
 export RUBY_BUILD_CURL_OPTS=
 export RUBY_BUILD_HTTP_CLIENT="curl"
+unset JAVA_HOME
 
 if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures"


### PR DESCRIPTION
JRuby does not require `$JAVA_HOME/bin` to be part of `$PATH`, therefore we should test java version with `$JAVA_HOME/bin/java -version` when `$JAVA_HOME` is defined.

See: https://github.com/ruby/ruby-builder/pull/22#issuecomment-2814646152