### PR TITLE
Update truffleruby-dev to use newer ubuntu download

### DIFF
--- a/share/ruby-build/truffleruby-dev
+++ b/share/ruby-build/truffleruby-dev
@@ -1,7 +1,7 @@
 platform="$(uname -s)-$(uname -m)"
 case $platform in
 Linux-x86_64)
-  install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-20.04.tar.gz" truffleruby
+  install_package "truffleruby-head" "https://github.com/ruby/truffleruby-dev-builder/releases/latest/download/truffleruby-head-ubuntu-24.04.tar.gz" truffleruby
   ;;
 Linux-aarch64)
   install_package "truffleruby-head" "https://github.com/graalvm/graalvm-ce-dev-builds/releases/latest/download/truffleruby-community-dev-linux-aarch64.tar.gz" truffleruby


### PR DESCRIPTION
The latest release no longer includes 20.04
https://github.com/ruby/truffleruby-dev-builder/releases/tag/v20250424.114841
