### PR TITLE
Add JRuby 10.0.0.1 and 9.4.12.1

### DIFF
--- a/share/ruby-build/jruby-10.0.0.1
+++ b/share/ruby-build/jruby-10.0.0.1
@@ -1,0 +1,2 @@
+require_java 21
+install_package "jruby-10.0.0.1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/10.0.0.1/jruby-dist-10.0.0.1-bin.tar.gz#0ba34ac5dfec7c22659b14db668a06284db7fc1c820c49c04b92271a6636bafb" jruby

--- a/share/ruby-build/jruby-9.4.12.1
+++ b/share/ruby-build/jruby-9.4.12.1
@@ -1,0 +1,2 @@
+require_java 8
+install_package "jruby-9.4.12.1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.4.12.1/jruby-dist-9.4.12.1-bin.tar.gz#b7fbaf1dda7a9d477cccda9197273fac85dc1f6dcb4046e1f7aa5b11a48d148b" jruby


### PR DESCRIPTION
This adds JRuby 10.0.0.1 and 9.4.12.1, which include the jruby-openssl fix for https://github.com/jruby/jruby-openssl/security/advisories/GHSA-72qj-48g4-5xgx.