### PR TITLE
Modify `update-jruby` script to require Java 21+ for JRuby 10+

### DIFF
--- a/script/update-jruby
+++ b/script/update-jruby
@@ -18,7 +18,12 @@ archive="$release_directory/$basename"
 [ -e "$archive" ] || wget -O "$archive" "$url"
 sha256=$(sha256sum "$archive" | cut -d ' ' -f 1)
 
+min_java_version="8"
+if [ "${version%%.*}" -ge 10 ]; then
+  min_java_version="21"
+fi
+
 cat > "$file" <<EOS
-require_java 8
+require_java ${min_java_version}
 install_package "jruby-${version}" "${url}#${sha256}" jruby
 EOS


### PR DESCRIPTION
Any jruby version starting with `10.*` will have `require_java 21` instead of `require_java 8`.

/cc @headius https://github.com/rbenv/ruby-build/pull/2530#discussion_r2078079546