### PR TITLE
Document examples of using custom defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,30 @@ Depending on the context, ruby-build does a little bit more than the above: for 
 
 #### Custom Build Definitions
 
-To install a version of Ruby that is not recognized by ruby-build, you can specify the path to a custom build definition file in place of a Ruby version number.
+To install a version of Ruby that is not available in ruby-build, you can specify the path to a custom build definition file in place of a Ruby version number.
+
+```sh
+# As a standalone program
+$ ruby-build -d /path/to/3.4-custom /opt/rubies  # installs to /opt/rubies/3.4-custom
+
+# As an rbenv plugin
+$ rbenv install /path/to/3.4-custom              # installs to $(rbenv root)/versions/3.4-custom
+```
+
+You can also provide a _directory_ of custom build definition files.
+The path(s) will be searched along with ruby-build's bundled `share/ruby-build/` directory.
+(Perhaps a collection of 3rd-party build definitions published as a git repo,
+or an organization's custom build definitions distributed in-house.)
+
+```sh
+# As a standalone program
+$ RUBY_BUILD_DEFINITIONS=/path/to/custom/defs ruby-build --definitions              # lists all available versions of Ruby, including custom defs
+$ RUBY_BUILD_DEFINITIONS=/path/to/custom/defs ruby-build -d 3.5-custom /opt/rubies  # installs to /opt/rubies/3.5-custom
+
+# As an rbenv plugin
+$ RUBY_BUILD_DEFINITIONS=/path/to/custom/defs rbenv install --list                  # lists all available versions of Ruby, including custom defs
+$ RUBY_BUILD_DEFINITIONS=/path/to/custom/defs rbenv install 3.5-custom              # installs to $(rbenv root)/versions/3.5-custom
+```
 
 Check out [default build definitions][definitions] as examples on how to write definition files.
 


### PR DESCRIPTION
Add examples of passing a custom build definition file in place of a 'known' ruby version. This is meant to more clearly document how users might use a custom build definition for a recently-released ruby that is not yet bundled in ruby-build.

This is primarily intended as a piece of documentation we can point to in Issues, wiki or to downstream tooling (like asdf-ruby) for how to use ruby-build to install additional builds of ruby. My _hope_ is that with a few examples, more folks self-service with _just-released_ rubies.

Additionally, document in the readme how to use `RUBY_BUILD_DEFINITIONS` path environment variable to provide a _collection_ of custom build definitions. This is meant to give guidance on how an organization might share multiple custom build definitions, or downstream users of ruby-build (like asdf-ruby) might publish unreleased rubies for installation.

nit/quibbling over wording: custom build defs _are_ recognized by ruby-build, just not bundled or available out of the box.