### PR TITLE
Allow installation of Ruby 2.7, 3.0, 3.1 on Fedora >= 42

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -207,7 +207,7 @@ is_freebsd() {
 }
 
 is_fedora() {
-  if [ -r /etc/os-release ]; then
+  [ -r /etc/os-release ] || return 1
       # shellcheck disable=SC1091
       source /etc/os-release
       # This will treat Aurora, Bazzite, BlueFin, uCore, and other Fedora variants as `fedora`.

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -211,13 +211,9 @@ is_fedora() {
       # shellcheck disable=SC1091
       source /etc/os-release
       # This will treat Aurora, Bazzite, BlueFin, uCore, and other Fedora variants as `fedora`.
-      # shellcheck disable=SC2153
-      local os_id
-      od_id="${ID_LIKE:-$ID}"
-      local os_version
-      os_version=$VERSION_ID
-      [ "${od_id}" = "fedora" ] || return 1
-      [ $# -eq 0 ] || [ "${os_version}" -ge "$1" ]
+      if [[ "${ID_LIKE:-$ID}" != "fedora" || ( $# -gt 0 && "$VERSION_ID" -lt "$1") ]]; then
+        return 1
+      fi
   fi
 }
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -728,10 +728,12 @@ build_package_standard() {
     if [ -z "$CC" ] && is_mac 1010; then
       export CC=clang
     elif [ "$ruby_semver" -lt 300200 ]; then
-      # Ruby older than 3.2 can't compile on GCC v15 unless options are provided to
-      #   use older GNU standard that is effectively "like GCC v14" => -std=gnu17
+      # GCC v15 changed the default mode from gnu17 to gnu23.
+      # See: https://gcc.gnu.org/gcc-15/changes.html#c
+      # Ruby older than 3.2 can't compile on GCC v15 in the default mode of gnu23.
+      # See: https://github.com/rbenv/ruby-build/discussions/2529
       if is_fedora && is_fedora 42; then
-        # Fedora 42+ has GCC v15 as default
+        # Fedora 42+ uses GCC v15 with mode gnu23 as default, so we configure for mode gnu17
         export CFLAGS="$CFLAGS -std=gnu17"
       fi
     fi

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -728,7 +728,7 @@ build_package_standard() {
       # See: https://gcc.gnu.org/gcc-15/changes.html#c
       # Ruby older than 3.2 can't compile on GCC v15 in the default mode of gnu23.
       # See: https://github.com/rbenv/ruby-build/discussions/2529
-      if is_fedora && is_fedora 42; then
+      if is_fedora 42; then
         # Fedora 42+ uses GCC v15 with mode gnu23 as default, so we configure for mode gnu17
         export CFLAGS="$CFLAGS -std=gnu17"
       fi

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -730,7 +730,7 @@ build_package_standard() {
       # See: https://github.com/rbenv/ruby-build/discussions/2529
       if is_fedora 42; then
         # Fedora 42+ uses GCC v15 with mode gnu23 as default, so we configure for mode gnu17
-        export CFLAGS="$CFLAGS -std=gnu17"
+        export CFLAGS="-std=gnu17 $CFLAGS "
       fi
     fi
     # ./configure --prefix=/path/to/ruby

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -206,6 +206,21 @@ is_freebsd() {
   [ "$(uname -s)" = "FreeBSD" ]
 }
 
+is_fedora() {
+  if [ -r /etc/os-release ]; then
+      # shellcheck disable=SC1091
+      source /etc/os-release
+      # This will treat Aurora, Bazzite, BlueFin, uCore, and other Fedora variants as `fedora`.
+      # shellcheck disable=SC2153
+      local os_id
+      od_id="${ID_LIKE:-$ID}"
+      local os_version
+      os_version=$VERSION_ID
+      [ "${od_id}" = "fedora" ] || return 1
+      [ $# -eq 0 ] || [ "${os_version}" -ge "$1" ]
+  fi
+}
+
 freebsd_package_prefix() {
   local package="$1"
   pkg info --prefix "$package" 2>/dev/null | cut -wf2
@@ -712,6 +727,13 @@ build_package_standard() {
     fi
     if [ -z "$CC" ] && is_mac 1010; then
       export CC=clang
+    elif [ "$ruby_semver" -lt 300200 ]; then
+      # Ruby older than 3.2 can't compile on GCC v15 unless options are provided to
+      #   use older GNU standard that is effectively "like GCC v14" => -std=gnu17
+      if is_fedora && is_fedora 42; then
+        # Fedora 42+ has GCC v15 as default
+        export CFLAGS="$CFLAGS -std=gnu17"
+      fi
     fi
     # ./configure --prefix=/path/to/ruby
     # shellcheck disable=SC2086,SC2153

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -208,12 +208,11 @@ is_freebsd() {
 
 is_fedora() {
   [ -r /etc/os-release ] || return 1
-      # shellcheck disable=SC1091
-      source /etc/os-release
-      # This will treat Aurora, Bazzite, BlueFin, uCore, and other Fedora variants as `fedora`.
-      if [[ "${ID_LIKE:-$ID}" != "fedora" || ( $# -gt 0 && "$VERSION_ID" -lt "$1") ]]; then
-        return 1
-      fi
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  # Treat Aurora, Bazzite, BlueFin, uCore, and other Fedora variants as "fedora".
+  if [[ "${ID_LIKE:-$ID}" != "fedora" || ( $# -gt 0 && "$VERSION_ID" -lt "$1") ]]; then
+    return 1
   fi
 }
 
@@ -723,15 +722,15 @@ build_package_standard() {
     fi
     if [ -z "$CC" ] && is_mac 1010; then
       export CC=clang
-    elif [ "$ruby_semver" -lt 300200 ]; then
-      # GCC v15 changed the default mode from gnu17 to gnu23.
-      # See: https://gcc.gnu.org/gcc-15/changes.html#c
-      # Ruby older than 3.2 can't compile on GCC v15 in the default mode of gnu23.
-      # See: https://github.com/rbenv/ruby-build/discussions/2529
-      if is_fedora 42; then
-        # Fedora 42+ uses GCC v15 with mode gnu23 as default, so we configure for mode gnu17
-        export CFLAGS="-std=gnu17 $CFLAGS "
-      fi
+    elif [ "$ruby_semver" -lt 300200 ] && is_fedora 42; then
+      # Fedora 42+ has updated to GCC v15. GCC v15 changed the default
+      # mode from gnu17 to gnu23: https://gcc.gnu.org/gcc-15/changes.html#c
+      #
+      # Ruby < 3.2 can't compile on GCC v15 in the default mode of gnu23.
+      #
+      # TODO: Consider changing this to check for GCC v15 specifically
+      # rather than inspecting the OS itself.
+      export CFLAGS="-std=gnu17 $CFLAGS"
     fi
     # ./configure --prefix=/path/to/ruby
     # shellcheck disable=SC2086,SC2153


### PR DESCRIPTION
Fixes https://github.com/rbenv/ruby-build/issues/2542

~~Sadly this only allows installation of Ruby 3.1, as it fails in a different way on Ruby 3.0.~~ UPDATE: This works as-is for Ruby 3.0 once a C++ compiler is installed (aside: why does Ruby 3.0 need C++?).

```
sudo rpm-ostree install gcc-c++
systemctl reboot
```

This is an alternative resolution for https://github.com/rbenv/ruby-build/discussions/2529, and partially obviates the need for the [entry in the wiki](https://github.com/rbenv/ruby-build/wiki#fedora-42-and-ruby-31) (at least it bumps back the need for an external solution to Ruby < 2.7).

Also worth noting that the workaround in the wiki is not possible on Fedora Atomic Desktop systems, e.g. Universal Blue-based Aurora, Bazzite, BlueFin, or uCore, because they disable the `dnf` tool for installing software (due to being "Atomic").

```
> ruby-build 3.1.7 ~/.rubies/ruby-3.1.7

==> Downloading ruby-3.1.7.tar.gz...by-3.1.7
-> curl -q -fL -o ruby-3.1.7.tar.gz https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 19.8M  100 19.8M    0     0  10.1M      0  0:00:01  0:00:01 --:--:-- 10.1M
==> Installing ruby-3.1.7...

WARNING: ruby-3.1.7 is past its end of life and is now unsupported.
It no longer receives bug fixes or critical security updates.

ruby-build: using readline from homebrew
-> ./configure "--prefix=$HOME/.rubies/ruby-3.1.7" --enable-shared --with-readline-dir=/home/linuxbrew/.linuxbrew/opt/readline --with-ext=openssl,psych,+
-> make -j 22
-> make install
==> Installed ruby-3.1.7 to /home/pboling/.rubies/ruby-3.1.7
```
