### PR TITLE
Fix Fedora version check when VERSION_ID is decimal

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -211,7 +211,7 @@ is_fedora() {
   # shellcheck disable=SC1091
   source /etc/os-release
   # Treat Aurora, Bazzite, BlueFin, uCore, and other Fedora variants as "fedora".
-  if [[ "${ID_LIKE:-$ID}" != "fedora" || ( $# -gt 0 && "$VERSION_ID" -lt "$1") ]]; then
+  if [[ "${ID_LIKE:-$ID}" != "fedora" || ( $# -gt 0 && "${VERSION_ID%%.*}" -lt "$1") ]]; then
     return 1
   fi
 }


### PR DESCRIPTION
This fixes RHEL builds where VERSION_ID=7.9

Fixes https://github.com/rbenv/ruby-build/issues/2546