### PR TITLE
Mark JRuby versions 9.2 through 9.3 as EOL

### DIFF
--- a/script/update-eol
+++ b/script/update-eol
@@ -13,7 +13,7 @@ date_to_seconds() {
 
 now_seconds="$(date '+%s')"
 
-curl -fsSL https://endoflife.date/api/ruby.json | jq -r '.[] | [.cycle,.eol] | @tsv' | while read -r cycle eol_date; do
+while read -r cycle eol_date; do
   eol_seconds="$(date_to_seconds "$eol_date")"
   days_to_eol=$(((eol_seconds - now_seconds) / 60 / 60 / 24))
   if [ $days_to_eol -lt 0 ]; then
@@ -23,7 +23,14 @@ curl -fsSL https://endoflife.date/api/ruby.json | jq -r '.[] | [.cycle,.eol] | @
     grep -L warn_unsupported share/ruby-build/"$cycle"[.-]* | grep -ve '-dev$' | \
       xargs sed -i.bak -E '/openssl/n; s/(.+)"/\1" warn_unsupported/'
   fi
-done
+done < <(
+  curl -fsSL https://endoflife.date/api/ruby.json | jq -r '.[] | [.cycle,.eol] | @tsv'
+  printf "%s\t%s\n" "jruby-9.0" "1970-01-01"
+  printf "%s\t%s\n" "jruby-9.1" "1970-01-01"
+  printf "%s\t%s\n" "jruby-9.2" "1970-01-01"
+  printf "%s\t%s\n" "jruby-9.3" "2024-01-01"
+  printf "%s\t%s\n" "jruby-9.4" "2026-05-01"
+)
 
 num_updated="$(rm -fv share/ruby-build/*.bak | wc -l)"
 printf "definition files updated: %d\n" "$num_updated"

--- a/share/ruby-build/jruby-9.2.0.0
+++ b/share/ruby-build/jruby-9.2.0.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.0.0/jruby-bin-9.2.0.0.tar.gz#42718dea5fc90b7696cb3fccf8e8d546729173963ad0bc477d66545677d00684" jruby
+install_package "jruby-9.2.0.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.0.0/jruby-bin-9.2.0.0.tar.gz#42718dea5fc90b7696cb3fccf8e8d546729173963ad0bc477d66545677d00684" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.1.0
+++ b/share/ruby-build/jruby-9.2.1.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.1.0/jruby-dist-9.2.1.0-bin.tar.gz#8c987378b144eff0dcc553312f1853c05ee9135f3ffdac7b0828b7ad62f32835" jruby
+install_package "jruby-9.2.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.1.0/jruby-dist-9.2.1.0-bin.tar.gz#8c987378b144eff0dcc553312f1853c05ee9135f3ffdac7b0828b7ad62f32835" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.10.0
+++ b/share/ruby-build/jruby-9.2.10.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.10.0/jruby-bin-9.2.10.0.tar.gz#9199707712c683c525252ccb1de5cb8e75f53b790c5b57a18f6367039ec79553" jruby
+install_package "jruby-9.2.10.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.10.0/jruby-bin-9.2.10.0.tar.gz#9199707712c683c525252ccb1de5cb8e75f53b790c5b57a18f6367039ec79553" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.11.0
+++ b/share/ruby-build/jruby-9.2.11.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.11.0/jruby-bin-9.2.11.0.tar.gz#8ae82da1a2658192c1445c9611347752c6bffadc284ec0dc0615e36bb5badf07" jruby
+install_package "jruby-9.2.11.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.11.0/jruby-bin-9.2.11.0.tar.gz#8ae82da1a2658192c1445c9611347752c6bffadc284ec0dc0615e36bb5badf07" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.11.1
+++ b/share/ruby-build/jruby-9.2.11.1
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.11.1" "https://s3.amazonaws.com/jruby.org/downloads/9.2.11.1/jruby-bin-9.2.11.1.tar.gz#f10449c82567133908e5e1ac076438307a7f0916f617f40fa314b78873a195dc" jruby
+install_package "jruby-9.2.11.1" "https://s3.amazonaws.com/jruby.org/downloads/9.2.11.1/jruby-bin-9.2.11.1.tar.gz#f10449c82567133908e5e1ac076438307a7f0916f617f40fa314b78873a195dc" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.12.0
+++ b/share/ruby-build/jruby-9.2.12.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.12.0/jruby-bin-9.2.12.0.tar.gz#307f6124c4301d723e2d0ff4c0105fa9eee8950c3f9971e14bbe8862030e6c04" jruby
+install_package "jruby-9.2.12.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.12.0/jruby-bin-9.2.12.0.tar.gz#307f6124c4301d723e2d0ff4c0105fa9eee8950c3f9971e14bbe8862030e6c04" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.13.0
+++ b/share/ruby-build/jruby-9.2.13.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.13.0/jruby-bin-9.2.13.0.tar.gz#73a8c241a162e644c87e864c3485c55adedeb82a6fd80fa3cb538fdacda7af58" jruby
+install_package "jruby-9.2.13.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.13.0/jruby-bin-9.2.13.0.tar.gz#73a8c241a162e644c87e864c3485c55adedeb82a6fd80fa3cb538fdacda7af58" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.14.0
+++ b/share/ruby-build/jruby-9.2.14.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.14.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.14.0/jruby-bin-9.2.14.0.tar.gz#32e73b2551f01e459ece84f732bcbf80712c3b71b6df7dbd063354b4d277e0b5" jruby
+install_package "jruby-9.2.14.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.14.0/jruby-bin-9.2.14.0.tar.gz#32e73b2551f01e459ece84f732bcbf80712c3b71b6df7dbd063354b4d277e0b5" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.15.0
+++ b/share/ruby-build/jruby-9.2.15.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.15.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.15.0/jruby-bin-9.2.15.0.tar.gz#9e8e5d73c42d1dad8a795a6dc39bd87e88fc8863f76e065e4099c32d085205b0" jruby
+install_package "jruby-9.2.15.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.15.0/jruby-bin-9.2.15.0.tar.gz#9e8e5d73c42d1dad8a795a6dc39bd87e88fc8863f76e065e4099c32d085205b0" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.16.0
+++ b/share/ruby-build/jruby-9.2.16.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.16.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.16.0/jruby-bin-9.2.16.0.tar.gz#5ae27f149f73f3fea4f34359cbb773c25d9d987e72b5edec9e8b93957997eb30" jruby
+install_package "jruby-9.2.16.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.16.0/jruby-bin-9.2.16.0.tar.gz#5ae27f149f73f3fea4f34359cbb773c25d9d987e72b5edec9e8b93957997eb30" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.17.0
+++ b/share/ruby-build/jruby-9.2.17.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.17.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.17.0/jruby-bin-9.2.17.0.tar.gz#7701d3537b3a606d2765ac6d5c40e675ddaa01d3cebad26a21a66e3aadd5c202" jruby
+install_package "jruby-9.2.17.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.17.0/jruby-bin-9.2.17.0.tar.gz#7701d3537b3a606d2765ac6d5c40e675ddaa01d3cebad26a21a66e3aadd5c202" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.18.0
+++ b/share/ruby-build/jruby-9.2.18.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.18.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.18.0/jruby-bin-9.2.18.0.tar.gz#425a5c970a6d918ae531275850634d12169e3557754b2b817fbfb7987a32c1a7" jruby
+install_package "jruby-9.2.18.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.18.0/jruby-bin-9.2.18.0.tar.gz#425a5c970a6d918ae531275850634d12169e3557754b2b817fbfb7987a32c1a7" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.19.0
+++ b/share/ruby-build/jruby-9.2.19.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.19.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.19.0/jruby-bin-9.2.19.0.tar.gz#1f74885a2d3fa589fcbeb292a39facf7f86be3eac1ab015e32c65d32acf3f3bf" jruby
+install_package "jruby-9.2.19.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.19.0/jruby-bin-9.2.19.0.tar.gz#1f74885a2d3fa589fcbeb292a39facf7f86be3eac1ab015e32c65d32acf3f3bf" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.20.0
+++ b/share/ruby-build/jruby-9.2.20.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.20.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.20.0/jruby-bin-9.2.20.0.tar.gz#bf0c4f206382478ab3e3cd7fce9b18d1b7de7da37124e97e24525cff99639c4b" jruby
+install_package "jruby-9.2.20.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.20.0/jruby-bin-9.2.20.0.tar.gz#bf0c4f206382478ab3e3cd7fce9b18d1b7de7da37124e97e24525cff99639c4b" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.20.1
+++ b/share/ruby-build/jruby-9.2.20.1
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.20.1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.20.1/jruby-dist-9.2.20.1-bin.tar.gz#79cdbc475a7041f4b44766c069051d21dd2473ce1638a0b668aa9439fb631963" jruby
+install_package "jruby-9.2.20.1" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.20.1/jruby-dist-9.2.20.1-bin.tar.gz#79cdbc475a7041f4b44766c069051d21dd2473ce1638a0b668aa9439fb631963" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.21.0
+++ b/share/ruby-build/jruby-9.2.21.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.21.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.21.0/jruby-dist-9.2.21.0-bin.tar.gz#dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a" jruby
+install_package "jruby-9.2.21.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.21.0/jruby-dist-9.2.21.0-bin.tar.gz#dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.3.0
+++ b/share/ruby-build/jruby-9.2.3.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.3.0/jruby-bin-9.2.3.0.tar.gz#d9c2d179696394aafe41027f0e48fa53267ecde04b3d10babc88fea4d523336a" jruby
+install_package "jruby-9.2.3.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.3.0/jruby-bin-9.2.3.0.tar.gz#d9c2d179696394aafe41027f0e48fa53267ecde04b3d10babc88fea4d523336a" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.4.0
+++ b/share/ruby-build/jruby-9.2.4.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.4.0/jruby-bin-9.2.4.0.tar.gz#b9638c82c85d89f6e8b2da1b876ac235bb9ed47f2163b3c851f0496c9bd58a0c" jruby
+install_package "jruby-9.2.4.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.4.0/jruby-bin-9.2.4.0.tar.gz#b9638c82c85d89f6e8b2da1b876ac235bb9ed47f2163b3c851f0496c9bd58a0c" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.4.1
+++ b/share/ruby-build/jruby-9.2.4.1
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.4.1" "https://s3.amazonaws.com/jruby.org/downloads/9.2.4.1/jruby-bin-9.2.4.1.tar.gz#c89821120d74f17f90c9bc346cc7bd1278df623fc1fe60ea3b5c0a8a01360d5b" jruby
+install_package "jruby-9.2.4.1" "https://s3.amazonaws.com/jruby.org/downloads/9.2.4.1/jruby-bin-9.2.4.1.tar.gz#c89821120d74f17f90c9bc346cc7bd1278df623fc1fe60ea3b5c0a8a01360d5b" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.5.0
+++ b/share/ruby-build/jruby-9.2.5.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.5.0/jruby-bin-9.2.5.0.tar.gz#f4ad088082eca73561df983f6cb0a937b966cba3a36454e88f63930ed2bdf349" jruby
+install_package "jruby-9.2.5.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.5.0/jruby-bin-9.2.5.0.tar.gz#f4ad088082eca73561df983f6cb0a937b966cba3a36454e88f63930ed2bdf349" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.6.0
+++ b/share/ruby-build/jruby-9.2.6.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.6.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.6.0/jruby-bin-9.2.6.0.tar.gz#70a1ff0e17a98baa63ea92c91fd38ff1e55a2056e5d57ba0409c4543d29e0e3d" jruby
+install_package "jruby-9.2.6.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.6.0/jruby-bin-9.2.6.0.tar.gz#70a1ff0e17a98baa63ea92c91fd38ff1e55a2056e5d57ba0409c4543d29e0e3d" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.7.0
+++ b/share/ruby-build/jruby-9.2.7.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.7.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.7.0/jruby-bin-9.2.7.0.tar.gz#da7c1a5ce90015c0bafd4bca0352294e08fe1c9ec049ac51e82fe57ed50e1348" jruby
+install_package "jruby-9.2.7.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.7.0/jruby-bin-9.2.7.0.tar.gz#da7c1a5ce90015c0bafd4bca0352294e08fe1c9ec049ac51e82fe57ed50e1348" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.8.0
+++ b/share/ruby-build/jruby-9.2.8.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.8.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.8.0/jruby-bin-9.2.8.0.tar.gz#b7c58688093f54acd89d732a8bf40e3ae0ac4c92488d6f5b424c33e4fb09c7bb" jruby
+install_package "jruby-9.2.8.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.8.0/jruby-bin-9.2.8.0.tar.gz#b7c58688093f54acd89d732a8bf40e3ae0ac4c92488d6f5b424c33e4fb09c7bb" warn_eol jruby

--- a/share/ruby-build/jruby-9.2.9.0
+++ b/share/ruby-build/jruby-9.2.9.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.2.9.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.9.0/jruby-bin-9.2.9.0.tar.gz#ced3fbb81b4f29f6a7fe7207e678e4154d95cc94de9f509fcaaf05768a6bf911" jruby
+install_package "jruby-9.2.9.0" "https://s3.amazonaws.com/jruby.org/downloads/9.2.9.0/jruby-bin-9.2.9.0.tar.gz#ced3fbb81b4f29f6a7fe7207e678e4154d95cc94de9f509fcaaf05768a6bf911" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.0.0
+++ b/share/ruby-build/jruby-9.3.0.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.0.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.0.0/jruby-dist-9.3.0.0-bin.tar.gz#2dc1f85936d3ff3adc20d90e5f4894499c585a7ea5fedec67154e2f9ecb1bc9b" jruby
+install_package "jruby-9.3.0.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.0.0/jruby-dist-9.3.0.0-bin.tar.gz#2dc1f85936d3ff3adc20d90e5f4894499c585a7ea5fedec67154e2f9ecb1bc9b" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.1.0
+++ b/share/ruby-build/jruby-9.3.1.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.1.0/jruby-dist-9.3.1.0-bin.tar.gz#4a9778c114452c0227e10e6718b2c5e128b310b9c6551be93bdd938888f3c418" jruby
+install_package "jruby-9.3.1.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.1.0/jruby-dist-9.3.1.0-bin.tar.gz#4a9778c114452c0227e10e6718b2c5e128b310b9c6551be93bdd938888f3c418" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.10.0
+++ b/share/ruby-build/jruby-9.3.10.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.10.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.10.0/jruby-dist-9.3.10.0-bin.tar.gz#c78c127e0aa166f257eeab03c4733ba3d96a445314eff7e5dc1f8154d2b5ae45" jruby
+install_package "jruby-9.3.10.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.10.0/jruby-dist-9.3.10.0-bin.tar.gz#c78c127e0aa166f257eeab03c4733ba3d96a445314eff7e5dc1f8154d2b5ae45" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.11.0
+++ b/share/ruby-build/jruby-9.3.11.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.11.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.11.0/jruby-dist-9.3.11.0-bin.tar.gz#655f120c8f29ee81c24b98f2932f6384e317062bcd40720dd8bfef555f97eac9" jruby
+install_package "jruby-9.3.11.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.11.0/jruby-dist-9.3.11.0-bin.tar.gz#655f120c8f29ee81c24b98f2932f6384e317062bcd40720dd8bfef555f97eac9" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.13.0
+++ b/share/ruby-build/jruby-9.3.13.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.13.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.13.0/jruby-dist-9.3.13.0-bin.tar.gz#da60d6cb5c4e4d191abe20448e337b394b27bf0e095133966bcab8ac1191f51d" jruby
+install_package "jruby-9.3.13.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.13.0/jruby-dist-9.3.13.0-bin.tar.gz#da60d6cb5c4e4d191abe20448e337b394b27bf0e095133966bcab8ac1191f51d" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.14.0
+++ b/share/ruby-build/jruby-9.3.14.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.14.0/jruby-dist-9.3.14.0-bin.tar.gz#04c482511d497f41c335345247ee52985be9a8174c042e306dc4c24fac81a9f9" jruby
+install_package "jruby-9.3.14.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.14.0/jruby-dist-9.3.14.0-bin.tar.gz#04c482511d497f41c335345247ee52985be9a8174c042e306dc4c24fac81a9f9" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.15.0
+++ b/share/ruby-build/jruby-9.3.15.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.15.0/jruby-dist-9.3.15.0-bin.tar.gz#0f8f8e4ed2fe97976d1c68350e967b937a860001fe3cbb42247a8612ab246628" jruby
+install_package "jruby-9.3.15.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.15.0/jruby-dist-9.3.15.0-bin.tar.gz#0f8f8e4ed2fe97976d1c68350e967b937a860001fe3cbb42247a8612ab246628" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.2.0
+++ b/share/ruby-build/jruby-9.3.2.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.2.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.2.0/jruby-dist-9.3.2.0-bin.tar.gz#26699ca02beeafa8326573c1125c57a5971ba8b94d15f84e6b3baf2594244f33" jruby
+install_package "jruby-9.3.2.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.2.0/jruby-dist-9.3.2.0-bin.tar.gz#26699ca02beeafa8326573c1125c57a5971ba8b94d15f84e6b3baf2594244f33" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.3.0
+++ b/share/ruby-build/jruby-9.3.3.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.3.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.3.0/jruby-dist-9.3.3.0-bin.tar.gz#3da828cbe287d5468507f1c2c42bef6cf34bc5361bcd6a5d99c207b21b9fdc5c" jruby
+install_package "jruby-9.3.3.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.3.0/jruby-dist-9.3.3.0-bin.tar.gz#3da828cbe287d5468507f1c2c42bef6cf34bc5361bcd6a5d99c207b21b9fdc5c" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.4.0
+++ b/share/ruby-build/jruby-9.3.4.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.4.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.4.0/jruby-dist-9.3.4.0-bin.tar.gz#531544d327a87155d8c804f153a2df3cf04f0182561cb2dd2c9372f48605b65c" jruby
+install_package "jruby-9.3.4.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.4.0/jruby-dist-9.3.4.0-bin.tar.gz#531544d327a87155d8c804f153a2df3cf04f0182561cb2dd2c9372f48605b65c" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.6.0
+++ b/share/ruby-build/jruby-9.3.6.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.6.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.6.0/jruby-dist-9.3.6.0-bin.tar.gz#747af6af99a674f208f40da8db22d77c6da493a83280e990b52d523abd9499e2" jruby
+install_package "jruby-9.3.6.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.6.0/jruby-dist-9.3.6.0-bin.tar.gz#747af6af99a674f208f40da8db22d77c6da493a83280e990b52d523abd9499e2" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.7.0
+++ b/share/ruby-build/jruby-9.3.7.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.7.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.7.0/jruby-dist-9.3.7.0-bin.tar.gz#94a7a8b3beeac2253a8876e73adfac6bececb2b54d2ddfa68f245dc81967d0c1" jruby
+install_package "jruby-9.3.7.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.7.0/jruby-dist-9.3.7.0-bin.tar.gz#94a7a8b3beeac2253a8876e73adfac6bececb2b54d2ddfa68f245dc81967d0c1" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.8.0
+++ b/share/ruby-build/jruby-9.3.8.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.8.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.8.0/jruby-dist-9.3.8.0-bin.tar.gz#674a4d1308631faa5f0124d01d73eb1edc89346ee7de21c70e14305bd61b46df" jruby
+install_package "jruby-9.3.8.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.8.0/jruby-dist-9.3.8.0-bin.tar.gz#674a4d1308631faa5f0124d01d73eb1edc89346ee7de21c70e14305bd61b46df" warn_eol jruby

--- a/share/ruby-build/jruby-9.3.9.0
+++ b/share/ruby-build/jruby-9.3.9.0
@@ -1,2 +1,2 @@
 require_java 8
-install_package "jruby-9.3.9.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.9.0/jruby-dist-9.3.9.0-bin.tar.gz#251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8" jruby
+install_package "jruby-9.3.9.0" "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.3.9.0/jruby-dist-9.3.9.0-bin.tar.gz#251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8" warn_eol jruby


### PR DESCRIPTION
JRuby 9.3 was EOL from the beginning of 2024, it seems

https://www.jruby.org/2023/11/02/jruby-9-3-13-0.html
https://github.com/jruby/jruby/wiki/Roadmap