### PR TITLE
Fix regression in JRuby 9.3

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -889,7 +889,12 @@ install_jruby_launcher() {
   # workaround for https://github.com/jruby/jruby/issues/7799
   [[ $1 != "jruby-9.2."* ]] ||
     capture_command ./ruby gem update -q --silent --system 3.3.26 --no-document --no-post-install-message
-  capture_command ./ruby gem install jruby-launcher --no-document
+  if [[ $1 == "jruby-9.3."* ]]; then
+    # workaround for https://github.com/rbenv/ruby-build/issues/2550
+    capture_command ./ruby gem install jruby-launcher --version '<2' --no-document
+  else
+    capture_command ./ruby gem install jruby-launcher --no-document
+  fi
 }
 
 fix_jruby_shebangs() {


### PR DESCRIPTION
Commit f661b64caba52d33c60de0442bb69c6f0f384413 that restores `bin/jruby.sh` for all JRuby versions has an undesired effect on JRuby 9.3 when it pulls in jruby-launcher v2. Since JRuby 9.3 is EOL and won't get a fix for this, at least attempt to fix this in ruby-build since until recently JRuby 9.3 worked.

The fix is that JRuby 9.3 (and only those versions) is not allowed to install jruby-launcher versions 2.0 or greater.

I've tested this on macOS with openjdk v11 and jruby 9.3.15.0.

/cc @headius https://github.com/rbenv/ruby-build/pull/2517