### PR TITLE
Fixes "integer expression expected" error

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -720,7 +720,7 @@ build_package_standard() {
     fi
     if [ -z "$CC" ] && is_mac 1010; then
       export CC=clang
-    elif [ "$ruby_semver" -lt 30200 ] && is_fedora 42; then
+    elif [[ "$package_var_name" = "RUBY" && "$ruby_semver" -lt 30200 ]] && is_fedora 42; then
       # Fedora 42+ has updated to GCC v15. GCC v15 changed the default
       # mode from gnu17 to gnu23: https://gcc.gnu.org/gcc-15/changes.html#c
       #

--- a/test/build.bats
+++ b/test/build.bats
@@ -423,6 +423,12 @@ install_package "ruby-3.2.0" "http://ruby-lang.org/ruby/2.0/ruby-3.2.0.tar.gz"
 DEF
   assert_success
 
+  sanitized_output="$(grep -v '^\(->\|==>\)' <<<"$output" || true)"
+  if [ -n "$sanitized_output" ]; then
+    echo "expected no warnings, got: $sanitized_output"
+    return 1
+  fi
+
   unstub uname
   unstub brew
   unstub cc


### PR DESCRIPTION
This happens while compiling OpenSSL or any other non-Ruby package:

    ruby-build: line 723: [: : integer expression expected

This was because $ruby_semver was checked as a numeric value but was never set.

Fixes https://github.com/rbenv/ruby-build/issues/2572
Followup to https://github.com/rbenv/ruby-build/pull/2543