### PR TITLE
Bump OpenSSL to 3.0.16 in the 4.0-dev definition

### DIFF
--- a/share/ruby-build/4.0-dev
+++ b/share/ruby-build/4.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf enable_shared standard_install_with_bundled_gems


### PR DESCRIPTION
This PR updates the OpenSSL to 3.0.16 for 4.0-dev definition as was done in 3.5.0-preview1 and 4.0.0-preview2 definitions.

- https://github.com/rbenv/ruby-build/blob/v20251117/share/ruby-build/3.5.0-preview1#L1
- https://github.com/rbenv/ruby-build/blob/v20251117/share/ruby-build/4.0.0-preview2#L1