### PR TITLE
OpenSSL 3.0.18

### DIFF
--- a/share/ruby-build/3.1-dev
+++ b/share/ruby-build/3.1-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.1-dev" "https://github.com/ruby/ruby.git" "ruby_3_1" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.1.0
+++ b/share/ruby-build/3.1.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.0" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.tar.gz#50a0504c6edcb4d61ce6b8cfdbddaa95707195fab0ecd7b5e92654b2a9412854" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.0-preview1
+++ b/share/ruby-build/3.1.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0-preview1.tar.gz#540f49f4c3aceb1a5d7fb0b8522a04dd96bc4a22f9660a6b59629886c8e010d4" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.1
+++ b/share/ruby-build/3.1.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.1" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.1.tar.gz#fe6e4782de97443978ddba8ba4be38d222aa24dc3e3f02a6a8e7701c0eeb619d" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.2
+++ b/share/ruby-build/3.1.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.2" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz#61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.3
+++ b/share/ruby-build/3.1.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.3" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz#5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.4
+++ b/share/ruby-build/3.1.4
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.4" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.4.tar.gz#a3d55879a0dfab1d7141fdf10d22a07dbf8e5cdc4415da1bde06127d5cc3c7b6" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.5
+++ b/share/ruby-build/3.1.5
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.5" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.gz#3685c51eeee1352c31ea039706d71976f53d00ab6d77312de6aa1abaf5cda2c5" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.6
+++ b/share/ruby-build/3.1.6
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.6" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.6.tar.gz#0d0dafb859e76763432571a3109d1537d976266be3083445651dc68deed25c22" warn_eol enable_shared standard

--- a/share/ruby-build/3.1.7
+++ b/share/ruby-build/3.1.7
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.1.7" "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz#0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b" warn_eol enable_shared standard

--- a/share/ruby-build/3.2-dev
+++ b/share/ruby-build/3.2-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.2-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.2.0
+++ b/share/ruby-build/3.2.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz#daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" enable_shared standard

--- a/share/ruby-build/3.2.0-preview1
+++ b/share/ruby-build/3.2.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" enable_shared standard

--- a/share/ruby-build/3.2.0-preview2
+++ b/share/ruby-build/3.2.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" enable_shared standard

--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" enable_shared standard

--- a/share/ruby-build/3.2.0-rc1
+++ b/share/ruby-build/3.2.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" enable_shared standard

--- a/share/ruby-build/3.2.1
+++ b/share/ruby-build/3.2.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz#13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd" enable_shared standard

--- a/share/ruby-build/3.2.2
+++ b/share/ruby-build/3.2.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" enable_shared standard

--- a/share/ruby-build/3.2.3
+++ b/share/ruby-build/3.2.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz#af7f1757d9ddb630345988139211f1fd570ff5ba830def1cc7c468ae9b65c9ba" enable_shared standard

--- a/share/ruby-build/3.2.4
+++ b/share/ruby-build/3.2.4
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.4" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.gz#c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692" enable_shared standard

--- a/share/ruby-build/3.2.5
+++ b/share/ruby-build/3.2.5
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.5" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gz#ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16" enable_shared standard

--- a/share/ruby-build/3.2.6
+++ b/share/ruby-build/3.2.6
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.6" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.6.tar.gz#d9cb65ecdf3f18669639f2638b63379ed6fbb17d93ae4e726d4eb2bf68a48370" enable_shared standard

--- a/share/ruby-build/3.2.7
+++ b/share/ruby-build/3.2.7
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.7" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.7.tar.gz#8488fa620ff0333c16d437f2b890bba3b67f8745fdecb1472568a6114aad9741" enable_shared standard

--- a/share/ruby-build/3.2.8
+++ b/share/ruby-build/3.2.8
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.8" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz#77acdd8cfbbe1f8e573b5e6536e03c5103df989dc05fa68c70f011833c356075" enable_shared standard

--- a/share/ruby-build/3.2.9
+++ b/share/ruby-build/3.2.9
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz#dfdd77e4ea1b57ff3a6dbde6b0bdc3f31db5ac99e7fdd4eaf9e1fbb6ec2db8ce" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.2.9" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.9.tar.gz#abbad98db9aeb152773b0d35868e50003b8c467f3d06152577c4dfed9d88ed2a" enable_shared standard

--- a/share/ruby-build/3.3-dev
+++ b/share/ruby-build/3.3-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.3-dev" "https://github.com/ruby/ruby.git" "ruby_3_3" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.3.0
+++ b/share/ruby-build/3.3.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz#96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d" enable_shared standard

--- a/share/ruby-build/3.3.0-preview1
+++ b/share/ruby-build/3.3.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview1.tar.gz#c3454a911779b8d747ab0ea87041030d002d533edacb2485fe558b7084da25ed" enable_shared standard

--- a/share/ruby-build/3.3.0-preview2
+++ b/share/ruby-build/3.3.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview2.tar.gz#30ce8b0fe11b37b5ac088f5a5765744b935eac45bb89a9e381731533144f5991" enable_shared standard

--- a/share/ruby-build/3.3.0-preview3
+++ b/share/ruby-build/3.3.0-preview3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-preview3.tar.gz#0969141be92e67e0edb84a8fb354acc98f01bd78e602a23a0f136045c82f4809" enable_shared standard

--- a/share/ruby-build/3.3.0-rc1
+++ b/share/ruby-build/3.3.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0-rc1.tar.gz#c4ff82395a90ef76c7f906b7687026e0ab96b094dcf3a532d9ab97784a073222" enable_shared standard

--- a/share/ruby-build/3.3.1
+++ b/share/ruby-build/3.3.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.1" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.gz#8dc2af2802cc700cd182d5430726388ccf885b3f0a14fcd6a0f21ff249c9aa99" enable_shared standard

--- a/share/ruby-build/3.3.2
+++ b/share/ruby-build/3.3.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.2" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.2.tar.gz#3be1d100ebf2a0ce60c2cd8d22cd9db4d64b3e04a1943be2c4ff7b520f2bcb5b" enable_shared standard

--- a/share/ruby-build/3.3.3
+++ b/share/ruby-build/3.3.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.3" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.3.tar.gz#83c05b2177ee9c335b631b29b8c077b4770166d02fa527f3a9f6a40d13f3cce2" enable_shared standard

--- a/share/ruby-build/3.3.4
+++ b/share/ruby-build/3.3.4
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.4" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.4.tar.gz#fe6a30f97d54e029768f2ddf4923699c416cdbc3a6e96db3e2d5716c7db96a34" enable_shared standard

--- a/share/ruby-build/3.3.5
+++ b/share/ruby-build/3.3.5
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.5" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.5.tar.gz#3781a3504222c2f26cb4b9eb9c1a12dbf4944d366ce24a9ff8cf99ecbce75196" enable_shared standard

--- a/share/ruby-build/3.3.6
+++ b/share/ruby-build/3.3.6
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.6" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.6.tar.gz#8dc48fffaf270f86f1019053f28e51e4da4cce32a36760a0603a9aee67d7fd8d" enable_shared standard

--- a/share/ruby-build/3.3.7
+++ b/share/ruby-build/3.3.7
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.7" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.7.tar.gz#9c37c3b12288c7aec20ca121ce76845be5bb5d77662a24919651aaf1d12c8628" enable_shared standard

--- a/share/ruby-build/3.3.8
+++ b/share/ruby-build/3.3.8
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.8" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.8.tar.gz#5ae28a87a59a3e4ad66bc2931d232dbab953d0aa8f6baf3bc4f8f80977c89cab" enable_shared standard

--- a/share/ruby-build/3.3.9
+++ b/share/ruby-build/3.3.9
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz#dfdd77e4ea1b57ff3a6dbde6b0bdc3f31db5ac99e7fdd4eaf9e1fbb6ec2db8ce" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.3.9" "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.9.tar.gz#d1991690a4e17233ec6b3c7844c1e1245c0adce3e00d713551d0458467b727b1" enable_shared standard

--- a/share/ruby-build/3.4-dev
+++ b/share/ruby-build/3.4-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-3.4-dev" "https://github.com/ruby/ruby.git" "ruby_3_4" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.4.0
+++ b/share/ruby-build/3.4.0
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.0" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.0.tar.gz#068c8523442174bd3400e786f4a6952352c82b1b9f6210fd17fb4823086d3379" enable_shared standard

--- a/share/ruby-build/3.4.0-preview1
+++ b/share/ruby-build/3.4.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.0-preview1.tar.gz#1a3c322e90cb22e5fba0b5d257bb2be9988affa3867eba7642ed981fdde895bb" enable_shared standard

--- a/share/ruby-build/3.4.0-preview2
+++ b/share/ruby-build/3.4.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.0-preview2.tar.gz#443cd7ec54ade4786bc974ce9f5d49f172a60f8edc84b597b7fe2bd2a94b8371" enable_shared standard

--- a/share/ruby-build/3.4.0-rc1
+++ b/share/ruby-build/3.4.0-rc1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.0-rc1.tar.gz#1f3187d3366e90af6d760994f8bfe1fe8999a8ba3553ea4dcfae63e548236e2a" enable_shared standard

--- a/share/ruby-build/3.4.1
+++ b/share/ruby-build/3.4.1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.1" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.1.tar.gz#3d385e5d22d368b064c817a13ed8e3cc3f71a7705d7ed1bae78013c33aa7c87f" enable_shared standard

--- a/share/ruby-build/3.4.2
+++ b/share/ruby-build/3.4.2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.2" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.2.tar.gz#41328ac21f2bfdd7de6b3565ef4f0dd7543354d37e96f157a1552a6bd0eb364b" enable_shared standard

--- a/share/ruby-build/3.4.3
+++ b/share/ruby-build/3.4.3
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.3" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.3.tar.gz#55a4cd1dcbe5ca27cf65e89a935a482c2bb2284832939266551c0ec68b437f46" enable_shared standard

--- a/share/ruby-build/3.4.4
+++ b/share/ruby-build/3.4.4
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.4" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.4.tar.gz#a0597bfdf312e010efd1effaa8d7f1d7833146fdc17950caa8158ffa3dcbfa85" enable_shared standard

--- a/share/ruby-build/3.4.5
+++ b/share/ruby-build/3.4.5
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz#dfdd77e4ea1b57ff3a6dbde6b0bdc3f31db5ac99e7fdd4eaf9e1fbb6ec2db8ce" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.5" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.5.tar.gz#1d88d8a27b442fdde4aa06dc99e86b0bbf0b288963d8433112dd5fac798fd5ee" enable_shared standard

--- a/share/ruby-build/3.4.6
+++ b/share/ruby-build/3.4.6
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.17" "https://github.com/openssl/openssl/releases/download/openssl-3.0.17/openssl-3.0.17.tar.gz#dfdd77e4ea1b57ff3a6dbde6b0bdc3f31db5ac99e7fdd4eaf9e1fbb6ec2db8ce" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.4.6" "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.6.tar.gz#e3c19ab9e8f41b3723124fbc0114cde7cbf55e65aa9c58c12acd89ec9c0dd1b9" enable_shared standard

--- a/share/ruby-build/3.5.0-preview1
+++ b/share/ruby-build/3.5.0-preview1
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-3.5.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.5/ruby-3.5.0-preview1.tar.gz#ecf09c7eb902e91cdaf9cc553cd00cca9b848b3fc0e14297850f9ab08cdd46f0" enable_shared standard

--- a/share/ruby-build/4.0-dev
+++ b/share/ruby-build/4.0-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/4.0.0-preview2
+++ b/share/ruby-build/4.0.0-preview2
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.16" "https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz#57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_package "ruby-4.0.0-preview2" "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.0-preview2.tar.gz#0a3330dae710302e11f7f0323e83219ab3c6517984691a312c662f329c5120e1" enable_shared standard

--- a/share/ruby-build/ruby-dev
+++ b/share/ruby-build/ruby-dev
@@ -1,2 +1,2 @@
-install_package "openssl-3.0.15" "https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz#23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533" openssl --if needs_openssl:1.0.2-3.x.x
+install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
 install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf enable_shared standard_install_with_bundled_gems


### PR DESCRIPTION
Made with `script/update-openssl`

Ref. https://github.com/rbenv/ruby-build/pull/2585 /cc @koic 

I thought, as long as we're updating OpenSSL in some formulae, we might upgrade to the latest OpenSSL 3.0.x across the board? Any possible downsides to this?