### PR TITLE
Fix jruby-dev to use updated URLs and support arm64 too

### DIFF
--- a/share/ruby-build/jruby-dev
+++ b/share/ruby-build/jruby-dev
@@ -1,12 +1,19 @@
-case $(uname -s) in
-Linux)
-  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-ubuntu-24.04.tar.gz" jruby
+platform="$(uname -s)-$(uname -m)"
+case $platform in
+Linux-x86_64)
+  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-ubuntu-24.04-x64.tar.gz" jruby
   ;;
-Darwin)
-  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-macos-latest.tar.gz" jruby
+Linux-aarch64)
+  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-ubuntu-24.04-arm64.tar.gz" jruby
+  ;;
+Darwin-x86_64)
+  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-darwin-x64.tar.gz" jruby
+  ;;
+Darwin-arm64)
+  install_package "jruby-head" "https://github.com/ruby/jruby-dev-builder/releases/latest/download/jruby-head-darwin-arm64.tar.gz" jruby
   ;;
 *)
-  colorize 1 "Unsupported operating system: $(uname -s)"
+  colorize 1 "Unsupported platform: $platform"
   return 1
   ;;
 esac


### PR DESCRIPTION
The structure is copied from truffleruby-dev.

cc @headius 