### PR TITLE
Support building from arbitrary git revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ The build process may be configured through the following environment variables:
 | `RUBY_MAKE_INSTALL_OPTS`        | Additional `make install` options (applies only to Ruby source).                                 |
 | `NO_COLOR`                      | Disable ANSI colors in output. The default is to use colors for output connected to a terminal.  |
 | `CLICOLOR_FORCE`                | Use ANSI colors in output even when not connected to a terminal.                                 |
+| `RUBY_REPO`                     | The URL of the git repository to use when building `ruby-dev`                                    |
+| `RUBY_REF`                      | The git branch (or revision) to use when building `ruby-dev`, e.g. `some-branch@af12decf`        |
 
 #### Applying Patches
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -571,6 +571,18 @@ fetch_git() {
   local git_url="$2"
   local git_ref="$3"
 
+  local git_branch=${git_ref}
+  local git_sha=''
+  if [[ "${git_ref}" = *@* ]]; then
+    git_branch="$(echo "${git_ref}" | cut -d@ -f 1)"
+    git_sha="$(echo "${git_ref}" | cut -d@ -f 2)"
+  fi
+
+  local depth_args=("--depth" "1")
+  if [[ -n "${git_sha}" ]]; then
+    depth_args=()
+  fi
+
   log_info "Cloning ${git_url}..."
 
   if ! type git &>/dev/null; then
@@ -582,18 +594,24 @@ fetch_git() {
     local cache_dir
     cache_dir="$RUBY_BUILD_CACHE_PATH/$(sanitize "$git_url")"
     if [ -e "$cache_dir" ]; then
-      log_command git -C "$cache_dir" fetch --force "$git_url" "+${git_ref}:${git_ref}" 2>&3
+      log_command git -C "$cache_dir" fetch --force "$git_url" "+${git_branch}:${git_branch}" 2>&3
     else
-      log_command git clone --bare --branch "$git_ref" "$git_url" "$cache_dir" 2>&3
+      log_command git clone --bare --single-branch --branch "$git_branch" "$git_url" "$cache_dir" 2>&3
     fi
     git_url="$cache_dir"
   fi
 
   if [ -e "$package_name" ]; then
-    log_command git -C "$package_name" fetch --depth 1 origin "+${git_ref}" 2>&3
-    log_command git -C "$package_name" checkout -q -B "$git_ref" "origin/${git_ref}" 2>&3
+    log_command git -C "$package_name" fetch "${depth_args[@]}" origin "+${git_ref}" 2>&3
+    if [ -z "${git_sha}" ]; then
+      log_command git -C "$package_name" checkout -q -B "$git_branch" "origin/${git_branch}" 2>&3
+    fi
   else
-    log_command git clone --depth 1 --branch "$git_ref" "$git_url" "$package_name" 2>&3
+    log_command git clone "${depth_args[@]}" --single-branch --branch "$git_branch" "$git_url" "$package_name" 2>&3
+  fi
+
+  if [ -n "${git_sha}" ]; then
+    log_command git -C "$package_name" checkout -q "$git_sha" 2>&3
   fi
 }
 

--- a/share/ruby-build/ruby-dev
+++ b/share/ruby-build/ruby-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.5.4" "https://github.com/openssl/openssl/releases/download/openssl-3.5.4/openssl-3.5.4.tar.gz#967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99" openssl --if needs_openssl:1.1.1-3.x.x
-install_git "ruby-master" "https://github.com/ruby/ruby.git" "master" autoconf enable_shared standard_install_with_bundled_gems
+install_git "ruby-master" "${RUBY_REPO:-https://github.com/ruby/ruby.git}" "${RUBY_REF:-master}" autoconf enable_shared standard_install_with_bundled_gems


### PR DESCRIPTION
While bisecting, or building a nightly Ruby CI and some other situations, it is useful to be able to build a specific Ruby revision rather than just the tip of Ruby's master branch.

This PR allows to do this easily with:

```bash
RUBY_DEV_REPO=https://github.com/byroot/ruby.git RUBY_DEV_REF=my-branch@deadbeef ruby-build ruby-ruby path/to/install
```

(of course no strong opinion on the naming of these env vars, perhaps they should be prefixed by `RUBY_BUILD_`).


This is way more convenient than generating a definition on the fly, or than to maintain a long list of definitions like I used to do at https://github.com/Shopify/ruby-definitions

