### PR TITLE
Add PicoRuby 3.4.2 with new r2p2 executable

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -885,7 +885,9 @@ build_package_picoruby() {
   mkdir -p "$PREFIX_PATH"
   cp -fR build/host/* include "$PREFIX_PATH"
   ln -fs picoruby "$PREFIX_PATH/bin/ruby"
-  ln -fs picoirb "$PREFIX_PATH/bin/irb"
+  if [ -f build/host/bin/picoirb ]; then
+    ln -fs picoirb "$PREFIX_PATH/bin/irb"
+  fi
 }
 
 build_package_jruby() {

--- a/share/ruby-build/picoruby-3.4.2
+++ b/share/ruby-build/picoruby-3.4.2
@@ -1,0 +1,1 @@
+install_package "picoruby-3.4.2" "https://github.com/picoruby/picoruby/releases/download/3.4.2/picoruby-3.4.2.tar.gz#75a7dded2b2dff443a80e3bb8075ccf2fe7b77282f8a8a69689fc700b51d61f3" picoruby


### PR DESCRIPTION
This commit adds PicoRuby 3.4.2 and introduces a ~~new build function to accommodate changes in the build artifacts.~~ new artifacts: r2p2

Version numbering context:
PicoRuby's version numbers are aligned with mruby's VM code specification compatibility. Version 3.4 indicates compatibility with mruby 3.4 VM code format, or RITE0300. Version 3.4.2 indicates minor bug fix in PicoRuby.

Build artifact changes:
Starting from version 3.4.2, PicoRuby has replaced the irb executable with r2p2 (POSIX version of PicoRuby shell system including IRB). The new build produces three executables:
- picoruby: main Ruby interpreter
- picorbc: Ruby bytecode compiler
- r2p2: interactive REPL (replaces picoirb)

Implementation:
- ~~Added build_package_picoruby_r2p2() function for version 3.4.2+~~
- ~~Existing build_package_picoruby() remains for version 3.0.0~~
- ~~The new function creates only the 'ruby' symlink, omitting 'irb'~~
- Added conditional symlink logic in `build_package_picoruby()`: symlinks picoirb as irb if present
  - If there's no picoirb in artifacts, symlink for irb is not created
- Added picoruby-3.4.2 definition file

The split in build functions allows proper support for both the legacy 3.0.0 release with irb and newer releases with r2p2.