### PR TITLE
Fix definition lookup for ruby-prefixed names like `ruby-dev`

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1420,6 +1420,10 @@ resolve_version() {
 
   # Look for an exact match first.
   for DEFINITION_DIR in "${RUBY_BUILD_DEFINITIONS[@]}"; do
+    if [ -f "${DEFINITION_DIR}/$1" ]; then
+      echo "$1"
+      return 0
+    fi
     if [ -f "${DEFINITION_DIR}/${version}" ]; then
       echo "$version"
       return 0

--- a/test/definitions.bats
+++ b/test/definitions.bats
@@ -113,6 +113,16 @@ NUM_DEFINITIONS="$(ls "$BATS_TEST_DIRNAME"/../share/ruby-build | wc -l)"
   assert_success "3.2.1"
 }
 
+@test "resolve definition by exact match for ruby-prefixed name" {
+  export RUBY_BUILD_DEFINITIONS="${TMP}/definitions"
+  mkdir -p "${TMP}/definitions"
+
+  touch "${TMP}/definitions/ruby-dev"
+
+  run bin/ruby-build --resolve "ruby-dev"
+  assert_success "ruby-dev"
+}
+
 @test "resolve definition with ruby prefix" {
   export RUBY_BUILD_DEFINITIONS="${TMP}/definitions"
   mkdir -p "${TMP}/definitions"


### PR DESCRIPTION
Currently, `rbenv install ruby-dev` fails as follows since 92d57fdbb64cb45e0b7e1ca2369e8bd8d004986e introduced via #2610.

```
% ruby-build --version
ruby-build 20260501

% rbenv install -f -v ruby-dev
ruby-build: definition not found: ruby-dev

The following versions contain `ruby-dev' in the name:
  jruby-dev
  mruby-dev
  ruby-dev
  truffleruby-dev

See all available versions with `rbenv install --list-all'.

If the version you need is missing, try upgrading ruby-build:

  brew upgrade ruby-build
```

This patch fixes this regression by trying the exact match first, then falling back to the partial match intruduced via #2610.