### PR TITLE
Mark Ruby 3.2 as EOL

### DIFF
--- a/share/ruby-build/3.2-dev
+++ b/share/ruby-build/3.2-dev
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_git "ruby-3.2-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf enable_shared standard_install_with_bundled_gems
+install_git "ruby-3.2-dev" "https://github.com/ruby/ruby.git" "ruby_3_2" autoconf warn_eol enable_shared standard_install_with_bundled_gems

--- a/share/ruby-build/3.2.0
+++ b/share/ruby-build/3.2.0
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz#daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" enable_shared standard
+install_package "ruby-3.2.0" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz#daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.0-preview1
+++ b/share/ruby-build/3.2.0-preview1
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" enable_shared standard
+install_package "ruby-3.2.0-preview1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview1.tar.gz#6946b966c561d5dfc2a662b88e8211be30bfffc7bb2f37ce3cc62d6c46a0b818" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.0-preview2
+++ b/share/ruby-build/3.2.0-preview2
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" enable_shared standard
+install_package "ruby-3.2.0-preview2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview2.tar.gz#8a78fd7a221b86032f96f25c1d852954c94d193b9d21388a9b434e160b7ed891" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.0-preview3
+++ b/share/ruby-build/3.2.0-preview3
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" enable_shared standard
+install_package "ruby-3.2.0-preview3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-preview3.tar.gz#c041d1488e62730d3a10dbe7cf7a3b3e4268dc867ec20ec991e7d16146640487" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.0-rc1
+++ b/share/ruby-build/3.2.0-rc1
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" enable_shared standard
+install_package "ruby-3.2.0-rc1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0-rc1.tar.gz#3bb9760c1ac1b66416aaa4899809f6ccd010e57038eaaeca19a383fd56275dac" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.1
+++ b/share/ruby-build/3.2.1
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz#13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd" enable_shared standard
+install_package "ruby-3.2.1" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.1.tar.gz#13d67901660ee3217dbd9dd56059346bd4212ce64a69c306ef52df64935f8dbd" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.10
+++ b/share/ruby-build/3.2.10
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.10" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.10.tar.gz#880acb05e08da8c559c56a13e512bae1b472da67c72ebb750c765f9c2134e689" enable_shared standard
+install_package "ruby-3.2.10" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.10.tar.gz#880acb05e08da8c559c56a13e512bae1b472da67c72ebb750c765f9c2134e689" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.11
+++ b/share/ruby-build/3.2.11
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.19" "https://github.com/openssl/openssl/releases/download/openssl-3.0.19/openssl-3.0.19.tar.gz#fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.11" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.11.tar.gz#b3eeabd6636f334531db3ffdc3229eb05e524740e6c84fdc043720573cf2f8b2" enable_shared standard
+install_package "ruby-3.2.11" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.11.tar.gz#b3eeabd6636f334531db3ffdc3229eb05e524740e6c84fdc043720573cf2f8b2" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.2
+++ b/share/ruby-build/3.2.2
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" enable_shared standard
+install_package "ruby-3.2.2" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.2.tar.gz#96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.3
+++ b/share/ruby-build/3.2.3
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz#af7f1757d9ddb630345988139211f1fd570ff5ba830def1cc7c468ae9b65c9ba" enable_shared standard
+install_package "ruby-3.2.3" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.3.tar.gz#af7f1757d9ddb630345988139211f1fd570ff5ba830def1cc7c468ae9b65c9ba" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.4
+++ b/share/ruby-build/3.2.4
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.4" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.gz#c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692" enable_shared standard
+install_package "ruby-3.2.4" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.gz#c72b3c5c30482dca18b0f868c9075f3f47d8168eaf626d4e682ce5b59c858692" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.5
+++ b/share/ruby-build/3.2.5
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.5" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gz#ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16" enable_shared standard
+install_package "ruby-3.2.5" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.5.tar.gz#ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.6
+++ b/share/ruby-build/3.2.6
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.6" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.6.tar.gz#d9cb65ecdf3f18669639f2638b63379ed6fbb17d93ae4e726d4eb2bf68a48370" enable_shared standard
+install_package "ruby-3.2.6" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.6.tar.gz#d9cb65ecdf3f18669639f2638b63379ed6fbb17d93ae4e726d4eb2bf68a48370" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.7
+++ b/share/ruby-build/3.2.7
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.7" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.7.tar.gz#8488fa620ff0333c16d437f2b890bba3b67f8745fdecb1472568a6114aad9741" enable_shared standard
+install_package "ruby-3.2.7" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.7.tar.gz#8488fa620ff0333c16d437f2b890bba3b67f8745fdecb1472568a6114aad9741" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.8
+++ b/share/ruby-build/3.2.8
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.8" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz#77acdd8cfbbe1f8e573b5e6536e03c5103df989dc05fa68c70f011833c356075" enable_shared standard
+install_package "ruby-3.2.8" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.8.tar.gz#77acdd8cfbbe1f8e573b5e6536e03c5103df989dc05fa68c70f011833c356075" warn_eol enable_shared standard

--- a/share/ruby-build/3.2.9
+++ b/share/ruby-build/3.2.9
@@ -1,2 +1,2 @@
 install_package "openssl-3.0.18" "https://github.com/openssl/openssl/releases/download/openssl-3.0.18/openssl-3.0.18.tar.gz#d80c34f5cf902dccf1f1b5df5ebb86d0392e37049e5d73df1b3abae72e4ffe8b" openssl --if needs_openssl:1.0.2-3.x.x
-install_package "ruby-3.2.9" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.9.tar.gz#abbad98db9aeb152773b0d35868e50003b8c467f3d06152577c4dfed9d88ed2a" enable_shared standard
+install_package "ruby-3.2.9" "https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.9.tar.gz#abbad98db9aeb152773b0d35868e50003b8c467f3d06152577c4dfed9d88ed2a" warn_eol enable_shared standard


### PR DESCRIPTION
Ruby 3.2 reached End of Life on 01 April 2026