### PR TITLE
Fix removing -O3 on ruby-dev and Ruby < 3.2 on Fedora 42+

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The build process may be configured through the following environment variables:
 | `RUBY_BUILD_ROOT`               | The path prefix to search for build definitions files. *Deprecated:* use `RUBY_BUILD_DEFINITIONS`|
 | `RUBY_BUILD_VENDOR_OPENSSL`     | Build and vendor openssl even if the system openssl is compatible                                |
 | `CC`                            | Path to the C compiler.                                                                          |
-| `RUBY_CFLAGS`                   | Additional `CFLAGS` options (_e.g.,_ to override `-O3`).                                         |
+| `RUBY_CFLAGS`                   | Overrides Ruby's default `CFLAGS`, including `-O3` (beware: without a `-O` flag Ruby is built unoptimized). To add flags, use `RUBY_CONFIGURE_OPTS=cflags=...` instead |
 | `CONFIGURE_OPTS`                | Additional `./configure` options.                                                                |
 | `MAKE`                          | Custom `make` command (_e.g.,_ `gmake`).                                                         |
 | `MAKE_OPTS` / `MAKEOPTS`        | Additional `make` options.                                                                       |

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -748,17 +748,11 @@ build_package_standard() {
       #
       # TODO: Consider changing this to check for GCC v15 specifically
       # rather than inspecting the OS itself.
-      if [ "${CFLAGS+defined}" ]; then
-        # If the user overrides CFLAGS they are responsible for it.
-        # The usual trap is specifying no `-O` flag and getting a `-O0` slow build.
-        export CFLAGS="-std=gnu17 $CFLAGS"
-      else
-        # Use the `cflags` configure variable, which Ruby's configure appends to
-        # its default optflags/debugflags/warnflags, unlike CFLAGS which would
-        # override them and notably lose the -O3, producing a much slower Ruby.
-        # configure ignores `cflags` when CFLAGS is given, hence the branch above.
-        export cflags="-std=gnu17 $cflags"
-      fi
+
+      # Use the cflags configure variable, which Ruby's configure appends to
+      # its default optflags/debugflags/warnflags, unlike CFLAGS which would
+      # override them and notably lose the -O3, producing a -O0 Ruby.
+      export cflags="-std=gnu17 $cflags"
     fi
     # ./configure --prefix=/path/to/ruby
     # shellcheck disable=SC2086,SC2153

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -748,7 +748,17 @@ build_package_standard() {
       #
       # TODO: Consider changing this to check for GCC v15 specifically
       # rather than inspecting the OS itself.
-      export CFLAGS="-std=gnu17 $CFLAGS"
+      if [ "${CFLAGS+defined}" ]; then
+        # If the user overrides CFLAGS they are responsible for it.
+        # The usual trap is specifying no `-O` flag and getting a `-O0` slow build.
+        export CFLAGS="-std=gnu17 $CFLAGS"
+      else
+        # Use the `cflags` configure variable, which Ruby's configure appends to
+        # its default optflags/debugflags/warnflags, unlike CFLAGS which would
+        # override them and notably lose the -O3, producing a much slower Ruby.
+        # configure ignores `cflags` when CFLAGS is given, hence the branch above.
+        export cflags="-std=gnu17 $cflags"
+      fi
     fi
     # ./configure --prefix=/path/to/ruby
     # shellcheck disable=SC2086,SC2153

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1173,7 +1173,11 @@ homebrew_openssl_versions() {
 # Example: 3.1.23 -> 30123
 # See also osx_version, require_java
 normalize_semver() {
-  awk -F. '{print $1 * 10000 + $2 * 100 + $3}' <<<"$1"
+  if [ "$1" = "dev" ]; then
+    echo 99999999
+  else
+    awk -F. '{print $1 * 10000 + $2 * 100 + $3}' <<<"$1"
+  fi
 }
 
 # Checks if system OpenSSL does NOT satisfy the version requirement


### PR DESCRIPTION
Fixes https://github.com/rbenv/ruby-build/issues/2637